### PR TITLE
Support multiple targets in search route

### DIFF
--- a/src/api/opensearch.js
+++ b/src/api/opensearch.js
@@ -54,13 +54,13 @@ function isVisible(doc) {
   }
 }
 
-async function search(body) {
+async function search(targets, body) {
   const endpoint = new AWS.Endpoint(elasticsearchEndpoint);
   const request = new AWS.HttpRequest(endpoint, region);
 
   request.method = "POST";
   request.body = body;
-  request.path += prefix("dc-v2-work") + `/_search`;
+  request.path += `${targets}/_search`;
   request.headers["host"] = elasticsearchEndpoint;
   request.headers["Content-Type"] = "application/json";
 

--- a/src/handlers/search.js
+++ b/src/handlers/search.js
@@ -1,3 +1,4 @@
+const { prefix } = require("../aws/environment");
 const { search } = require("../api/opensearch");
 const opensearchResponse = require("../api/response/opensearch");
 const RequestPipeline = require("../api/request/pipeline.js");
@@ -7,9 +8,42 @@ const RequestPipeline = require("../api/request/pipeline.js");
  */
 exports.handler = async (event) => {
   const eventBody = event.body;
-  console.log("RequestPipeline", RequestPipeline);
+
+  const requestedModels =
+    event.pathParameters?.models == null
+      ? ["works"]
+      : event.pathParameters.models.split(",");
+
+  if (!validModels(requestedModels)) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: `Invalid models requested: ${requestedModels}`,
+      }),
+    };
+  }
+
   const filteredBody = new RequestPipeline(eventBody).authFilter().toJson();
-  let esResponse = await search(filteredBody);
+  let esResponse = await search(modelsToTargets(requestedModels), filteredBody);
   let transformedResponse = opensearchResponse.transform(esResponse);
   return transformedResponse;
 };
+
+function validModels(models) {
+  const validModels = models.filter((model) => isAllowed(model));
+  return validModels.length > 0;
+}
+
+function isAllowed(model) {
+  allowedModels = ["works", "file-sets", "collections"];
+  return allowedModels.includes(model);
+}
+
+function modelsToTargets(models) {
+  const mapTargets = {
+    works: "dc-v2-work",
+    "file-sets": "dc-v2-file-set",
+    collections: "dc-v2-collection",
+  };
+  return String(models.map((model) => prefix(mapTargets[model])));
+}

--- a/template.yaml
+++ b/template.yaml
@@ -145,11 +145,17 @@ Resources:
           ENV_PREFIX: !Ref EnvironmentPrefix
           ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
-        Api:
+        SearchApi:
           Type: Api
           Properties:
             RestApiId: !Ref dcApi
             Path: /search
+            Method: POST
+        SearchWithModelsApi:
+          Type: Api
+          Properties:
+            RestApiId: !Ref dcApi
+            Path: /search/{models}
             Method: POST
   dcApi:
     Type: AWS::Serverless::Api


### PR DESCRIPTION
Example searches:

- `curl -X POST 'http://127.0.0.1:3000/search/works,collections,file-sets' --data-binary '{"query": {"match_all": {}}}' | jq`
- `curl -X POST 'http://127.0.0.1:3000/search/collections' --data-binary '{"query": {"match_all": {}}}' | jq`
-  `curl -X POST 'http://127.0.0.1:3000/search' --data-binary '{"query": {"match_all": {}}}' | jq`

Invalid Search
- `curl -X POST 'http://127.0.0.1:3000/search/nope' --data-binary '{"query": {"match_all": {}}}' | jq`