### PR TITLE
Add pagination to search

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "@aws-sdk/node-http-handler": "^3.127.0",
         "@aws-sdk/protocol-http": "^3.127.0",
         "@aws-sdk/signature-v4": "^3.130.0",
-        "axios": ">=0.21.1"
+        "axios": ">=0.21.1",
+        "lz-string": "^1.4.4"
       },
       "devDependencies": {
         "chai": "^4.2.0",
@@ -2256,6 +2257,14 @@
       "license": "MIT",
       "dependencies": {
         "get-func-name": "^2.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/make-dir": {
@@ -4658,6 +4667,11 @@
       "requires": {
         "get-func-name": "^2.0.0"
       }
+    },
+    "lz-string": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz",
+      "integrity": "sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ=="
     },
     "make-dir": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "@aws-sdk/node-http-handler": "^3.127.0",
     "@aws-sdk/protocol-http": "^3.127.0",
     "@aws-sdk/signature-v4": "^3.130.0",
-    "axios": ">=0.21.1"
+    "axios": ">=0.21.1",
+    "lz-string": "^1.4.4"
   },
   "scripts": {
     "prettier": "prettier -c src tests",

--- a/src/api/pagination.js
+++ b/src/api/pagination.js
@@ -1,0 +1,84 @@
+const {
+  decompressFromEncodedURIComponent: decompress,
+  compressToEncodedURIComponent: compress,
+} = require("lz-string");
+
+const encodeFields = ["query", "size", "sort", "fields", "_source"];
+
+async function decodeSearchToken(token) {
+  return JSON.parse(await decompress(token));
+}
+
+async function encodeSearchToken(models, body) {
+  let token = { body: { size: 10 }, models };
+  for (const field in body) {
+    if (encodeFields.includes(field)) {
+      token.body[field] = body[field];
+    }
+  }
+  return await compress(JSON.stringify(token));
+}
+
+function from(body) {
+  return body?.from || 0;
+}
+function size(body) {
+  return body?.size || 10;
+}
+
+function maxPage(body, count) {
+  return Math.ceil(count / size(body));
+}
+
+function nextPage(body, count) {
+  const current = thisPage(body);
+  return maxPage(body, count) > current ? current + 1 : null;
+}
+
+function prevPage(body, _count) {
+  return body.from > 0 ? thisPage(body) - 1 : null;
+}
+
+function thisPage(body) {
+  return Math.floor(from(body) / size(body) + 1);
+}
+
+class Paginator {
+  constructor(baseUrl, models, body) {
+    this.baseUrl = baseUrl;
+    this.models = models;
+    this.body = { ...body };
+  }
+
+  async pageInfo(count) {
+    let url = new URL("search", this.baseUrl);
+    url.searchParams.set(
+      "searchToken",
+      await encodeSearchToken(this.models, this.body)
+    );
+
+    const prev = prevPage(this.body, count);
+    const next = nextPage(this.body, count);
+
+    let result = {
+      query_url: url.toString(),
+      current_page: thisPage(this.body),
+      limit: size(this.body),
+      offset: from(this.body),
+      total_hits: count,
+      total_pages: maxPage(this.body, count),
+    };
+    if (prev) {
+      url.searchParams.set("page", prev);
+      result.prev_url = url.toString();
+    }
+    if (next) {
+      url.searchParams.set("page", next);
+      result.next_url = url.toString();
+    }
+
+    return result;
+  }
+}
+
+module.exports = { decodeSearchToken, encodeSearchToken, Paginator };

--- a/src/handlers/search.js
+++ b/src/handlers/search.js
@@ -1,49 +1,63 @@
+const { baseUrl } = require("../helpers");
 const { modelsToTargets, validModels } = require("../api/request/models");
 const { search } = require("../api/opensearch");
 const opensearchResponse = require("../api/response/opensearch");
-const RequestPipeline = require("../api/request/pipeline.js");
+const { decodeSearchToken, Paginator } = require("../api/pagination");
+const RequestPipeline = require("../api/request/pipeline");
 
-/**
- * Function to wrap search requests and transform responses
- */
-exports.handler = async (event) => {
-  const eventBody = event.body;
+const getSearch = async (event) => {
+  let token = event.queryStringParameters.searchToken;
+  if (token === undefined || token === "") {
+    return invalidRequest("searchToken parameter is required");
+  }
+
+  let request;
+  try {
+    request = await decodeSearchToken(token);
+  } catch (err) {
+    return invalidRequest("searchToken is invalid");
+  }
+
+  const page = Number(event.queryStringParameters.page || 1);
+  request.body.from = request.body.size * (page - 1);
+
+  return await executeSearch(event, request.models, request.body);
+};
+
+const postSearch = async (event) => {
+  const eventBody = JSON.parse(event.body);
 
   const requestedModels =
     event.pathParameters?.models == null
       ? ["works"]
       : event.pathParameters.models.split(",");
 
-  if (!validModels(requestedModels)) {
-    return {
-      statusCode: 400,
-      body: JSON.stringify({
-        message: `Invalid models requested: ${requestedModels}`,
-      }),
-    };
+  return await executeSearch(event, requestedModels, eventBody);
+};
+
+/**
+ * Function to wrap search requests and transform responses
+ */
+const executeSearch = async (event, models, body) => {
+  if (!validModels(models)) {
+    return invalidRequest(`Invalid models requested: ${models}`);
   }
 
-  const filteredBody = new RequestPipeline(eventBody).authFilter().toJson();
-  let esResponse = await search(modelsToTargets(requestedModels), filteredBody);
-  let transformedResponse = opensearchResponse.transform(esResponse);
+  const pager = new Paginator(baseUrl(event), models, body);
+  const filteredBody = new RequestPipeline(body).authFilter().toJson();
+  let esResponse = await search(modelsToTargets(models), filteredBody);
+  let transformedResponse = await opensearchResponse.transform(
+    esResponse,
+    pager
+  );
   return transformedResponse;
 };
 
-function validModels(models) {
-  const validModels = models.filter((model) => isAllowed(model));
-  return validModels.length > 0;
-}
-
-function isAllowed(model) {
-  allowedModels = ["works", "file-sets", "collections"];
-  return allowedModels.includes(model);
-}
-
-function modelsToTargets(models) {
-  const mapTargets = {
-    works: "dc-v2-work",
-    "file-sets": "dc-v2-file-set",
-    collections: "dc-v2-collection",
+const invalidRequest = (message) => {
+  return {
+    statusCode: 400,
+    body: JSON.stringify({ message: message }),
   };
-  return String(models.map((model) => prefix(mapTargets[model])));
-}
+};
+
+module.exports = { postSearch, getSearch };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,0 +1,23 @@
+const gatewayRe = /execute-api.[a-z]+-[a-z]+-\d+.amazonaws.com/;
+
+function baseUrl(event) {
+  const scheme = event.headers["X-Forwarded-Proto"];
+
+  // The localhost check only matters in dev mode, but it's
+  // really inconvenient not to have it
+  const host =
+    event.requestContext.domainName === "localhost"
+      ? event.headers["Host"].split(/:/)[0]
+      : event.requestContext.domainName;
+  const port = event.headers["X-Forwarded-Port"];
+
+  let result = new URL(`${scheme}://${host}:${port}`);
+  const stage = event.requestContext?.stage;
+
+  if (gatewayRe.test(result.host) && stage !== "$default") {
+    result = new URL(`${stage}/`, result);
+  }
+  return result.toString();
+}
+
+module.exports = { baseUrl };

--- a/template.yaml
+++ b/template.yaml
@@ -106,10 +106,10 @@ Resources:
             ApiId: !Ref dcApi
             Path: /works/{id}
             Method: GET
-  searchFunction:
+  searchPostFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Handler: src/handlers/search.handler
+      Handler: src/handlers/search.postSearch
       Runtime: nodejs16.x
       Architectures:
         - x86_64
@@ -141,6 +141,35 @@ Resources:
             ApiId: !Ref dcApi
             Path: /search/{models}
             Method: POST
+  searchGetFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: src/handlers/search.getSearch
+      Runtime: nodejs16.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 100
+      Description: Handles paging requests
+      Policies:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ESHTTPPolicy
+            Effect: Allow
+            Action:
+              - es:ESHttp*
+            Resource: "*"
+      Environment:
+        Variables:
+          ENV_PREFIX: !Ref EnvironmentPrefix
+          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
+      Events:
+        SearchApi:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /search
+            Method: GET
   dcApi:
     Type: AWS::Serverless::HttpApi
     Properties:

--- a/tests/unit/api/helpers.test.js
+++ b/tests/unit/api/helpers.test.js
@@ -1,0 +1,100 @@
+"use strict";
+
+const { baseUrl } = require("../../../src/helpers");
+const chai = require("chai");
+const expect = chai.expect;
+
+describe("helpers", () => {
+  describe("baseUrl()", () => {
+    it("extracts the base URL from a local event", () => {
+      const event = {
+        headers: {
+          Host: "localhost",
+          "X-Forwarded-Proto": "http",
+          "X-Forwarded-Port": "3000",
+        },
+        requestContext: {
+          domainName: "localhost",
+          domainPrefix: "localhost",
+          stage: "v2",
+        },
+      };
+
+      expect(baseUrl(event)).to.eq("http://localhost:3000/");
+    });
+
+    it("extracts the base URL from an API Gateway event", () => {
+      const event = {
+        headers: {
+          Host: "abcdefghijz.execute-api.us-east-1.amazonaws.com",
+          "X-Forwarded-Proto": "https",
+          "X-Forwarded-Port": "443",
+        },
+        requestContext: {
+          domainName: "abcdefghijz.execute-api.us-east-1.amazonaws.com",
+          domainPrefix: "abcdefghijz",
+          stage: "v2",
+        },
+      };
+
+      expect(baseUrl(event)).to.eq(
+        "https://abcdefghijz.execute-api.us-east-1.amazonaws.com/v2/"
+      );
+    });
+
+    it("extracts the base URL from a CloudWatch event", () => {
+      const event = {
+        headers: {
+          Host: "abcdefghijz.cloudfront.net",
+          "X-Forwarded-Proto": "https",
+          "X-Forwarded-Port": "443",
+        },
+        requestContext: {
+          domainName: "abcdefghijz.cloudfront.net",
+          domainPrefix: "abcdefghijz",
+          stage: "v2",
+        },
+      };
+
+      expect(baseUrl(event)).to.eq("https://abcdefghijz.cloudfront.net/");
+    });
+
+    it("extracts the base URL from an event with a custom domain", () => {
+      const event = {
+        headers: {
+          Host: "api.test.library.northwestern.edu",
+          "X-Forwarded-Proto": "https",
+          "X-Forwarded-Port": "443",
+        },
+        requestContext: {
+          domainName: "api.test.library.northwestern.edu",
+          domainPrefix: "api",
+          stage: "v2",
+        },
+      };
+
+      expect(baseUrl(event)).to.eq(
+        "https://api.test.library.northwestern.edu/"
+      );
+    });
+
+    it("prefers a custom domain over localhost", () => {
+      const event = {
+        headers: {
+          Host: "localhost",
+          "X-Forwarded-Proto": "http",
+          "X-Forwarded-Port": "3000",
+        },
+        requestContext: {
+          domainName: "api.test.library.northwestern.edu",
+          domainPrefix: "api",
+          stage: "v2",
+        },
+      };
+
+      expect(baseUrl(event)).to.eq(
+        "http://api.test.library.northwestern.edu:3000/"
+      );
+    });
+  });
+});

--- a/tests/unit/api/pagination.test.js
+++ b/tests/unit/api/pagination.test.js
@@ -1,0 +1,74 @@
+"use strict";
+
+const { decodeSearchToken, Paginator } = require("../../../src/api/pagination");
+const chai = require("chai");
+const expect = chai.expect;
+
+describe("Paginator", function () {
+  const requestBody = {
+    query: { match_all: {} },
+    size: 50,
+    sort: [{ create_date: "asc" }],
+    _source: ["id", "title", "collection"],
+    aggs: { collection: { terms: { field: "contributor.label", size: 10 } } },
+  };
+
+  let pager;
+
+  this.beforeEach(() => {
+    pager = new Paginator(
+      "http://dcapi.library.northwestern.edu/v2/",
+      ["works"],
+      requestBody
+    );
+  });
+
+  it("produces page 1 pagination", async () => {
+    let result = await pager.pageInfo(1275);
+    expect(result.current_page).to.eq(1);
+    expect(result.offset).to.eq(0);
+    expect(result.limit).to.eq(50);
+    expect(result.total_hits).to.eq(1275);
+    expect(result.total_pages).to.eq(26);
+    expect(result.prev_url).to.be.undefined;
+
+    let url = new URL(result.next_url);
+    expect(url.host).to.eq("dcapi.library.northwestern.edu");
+    expect(url.pathname).to.eq("/v2/search");
+    expect(url.searchParams.get("page")).to.eq("2");
+  });
+
+  it("produces additional page pagination", async () => {
+    pager.body.from = 100;
+    let result = await pager.pageInfo(1275);
+    expect(result.current_page).to.eq(3);
+    expect(new URL(result.prev_url).searchParams.get("page")).to.eq("2");
+    expect(new URL(result.next_url).searchParams.get("page")).to.eq("4");
+    expect(requestBody.from).to.be.undefined;
+  });
+
+  it("produces last page pagination", async () => {
+    pager.body.from = 1270;
+    const result = await pager.pageInfo(1275);
+    expect(result.next_url).to.be.undefined;
+  });
+
+  it("produces a usable token", async () => {
+    pager.body.from = 100;
+    const result = await pager.pageInfo(1275);
+    const token = new URL(result.query_url).searchParams.get("searchToken");
+    const rehydrated = await decodeSearchToken(token);
+
+    expect(rehydrated.models).to.include.members(["works"]);
+    for (const field of ["query", "size", "sort", "_source"]) {
+      expect(rehydrated.body[field]).to.deep.equal(requestBody[field]);
+    }
+    expect(rehydrated.body).not.to.include.keys(["aggs", "from"]);
+  });
+
+  it("correctly sets the default size", async () => {
+    delete pager.body.size;
+    const result = await pager.pageInfo(1275);
+    expect(result.limit).to.eq(10);
+  });
+});

--- a/tests/unit/api/response/opensearch.test.js
+++ b/tests/unit/api/response/opensearch.test.js
@@ -1,20 +1,31 @@
 "use strict";
 
 const transformer = require("../../../../src/api/response/opensearch");
+const { Paginator } = require("../../../../src/api/pagination");
 const chai = require("chai");
 const expect = chai.expect;
 
 describe("OpenSearch response transformer", () => {
+  let pager;
+  beforeEach(() => {
+    pager = new Paginator(
+      "http://dcapi.library.northwestern.edu/v2/",
+      ["works"],
+      { query: { match_all: {} } }
+    );
+  });
+
   it("transforms a doc response", async () => {
     const response = {
       statusCode: 200,
       body: helpers.testFixture("mocks/work-1234.json"),
     };
-    const result = await transformer.transform(response);
+    const result = await transformer.transform(response, pager);
     expect(result.statusCode).to.eq(200);
 
     const body = JSON.parse(result.body);
     expect(body.data).to.be.an("object");
+    expect(body).not.to.include.key("pagination");
   });
 
   it("transforms a search response", async () => {
@@ -22,11 +33,21 @@ describe("OpenSearch response transformer", () => {
       statusCode: 200,
       body: helpers.testFixture("mocks/search.json"),
     };
-    const result = await transformer.transform(response);
+    const result = await transformer.transform(response, pager);
     expect(result.statusCode).to.eq(200);
 
     const body = JSON.parse(result.body);
     expect(body.data).to.be.an("array");
+    expect(body).to.include.key("pagination");
+    expect(body.pagination).to.include.keys([
+      "query_url",
+      "current_page",
+      "limit",
+      "next_url",
+      "offset",
+      "total_hits",
+      "total_pages",
+    ]);
   });
 
   it("transforms an error response", async () => {
@@ -35,7 +56,7 @@ describe("OpenSearch response transformer", () => {
       body: helpers.testFixture("mocks/missing-index.json"),
     };
 
-    const result = await transformer.transform(response);
+    const result = await transformer.transform(response, pager);
     expect(result.statusCode).to.eq(404);
 
     const body = JSON.parse(result.body);


### PR DESCRIPTION
There's some naming confusion here because (from previous commits) `test-helpers.js` injects a `helpers` object into the global context. But I've also just added `src/helpers.js`. Since the global `helpers` object doesn't exist at runtime, there's no concern about requiring it in any code under `src`, and so far I'm just using `const { baseUrl } = require("path/to/helpers")` in `helpers.test.js` to avoid a collision. But if the presence of both is awkward, I'm open to suggestions, e.g.,

- rename the global test-mode-only `helpers` object to `testHelpers` or `_helpers` or something else
- rename the new `helpers.js` file to something else (though we're already trying to avoid `utils`, but then again, is `helpers` any better?)
