### PR TITLE
Create API custom domain and mappings

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,5 +1,17 @@
 const gatewayRe = /execute-api.[a-z]+-[a-z]+-\d+.amazonaws.com/;
 
+function isApiGateway(event) {
+  return gatewayRe.test(event.requestContext.domainName);
+}
+
+function isDefaultRoute(event) {
+  return event.routeKey.match(/\$default$/);
+}
+
+function isLocal(event) {
+  return event.requestContext.domainName === "localhost";
+}
+
 function getHeader(event, name) {
   return event.headers[name] || event.headers[name.toLowerCase()];
 }
@@ -9,18 +21,27 @@ function baseUrl(event) {
 
   // The localhost check only matters in dev mode, but it's
   // really inconvenient not to have it
-  const host =
-    event.requestContext.domainName === "localhost"
-      ? getHeader(event, "Host").split(/:/)[0]
-      : event.requestContext.domainName;
+  const host = isLocal(event)
+    ? getHeader(event, "Host").split(/:/)[0]
+    : event.requestContext.domainName;
   const port = getHeader(event, "X-Forwarded-Port");
 
   let result = new URL(`${scheme}://${host}:${port}`);
-  const stage = event.requestContext?.stage;
 
-  if (gatewayRe.test(result.host) && stage !== "$default") {
-    result = new URL(`${stage}/`, result);
+  let stem;
+  if (isApiGateway(event) && !isDefaultRoute(event)) {
+    const routeKey = event.routeKey.split(" ")[1];
+    const routeRe = new RegExp(
+      "^(.*)" + routeKey.replace(/\{.+?\}/g, ".+?") + "$"
+    );
+    stem = routeRe.exec(event.rawPath)[1];
+  } else if (!isLocal(event) && event?.stageVariables?.basePath) {
+    stem = event.stageVariables.basePath;
+  } else {
+    stem = "";
   }
+
+  result = new URL(`${stem}/`, result);
   return result.toString();
 }
 

--- a/template.yaml
+++ b/template.yaml
@@ -11,6 +11,15 @@ Globals:
     Timeout: 3
 
 Parameters:
+  CustomDomainCertificateArn:
+    Type: String
+    Description: SSL Certificate for the Custom Domain Name
+  CustomDomainZone:
+    Type: String
+    Description: Hosted Zone Name for Custom Domain
+  CustomDomainHost:
+    Type: String
+    Description: Hostname within ApiDomainName for Custom Domain
   ElasticsearchEndpoint:
     Type: String
     Description: Elasticsearch url
@@ -18,6 +27,13 @@ Parameters:
     Type: String
     Description: Index Prefix
     Default: ""
+  V1ApiId:
+    Type: String
+    Description: ID of the v1 API to mount on /api/v1
+  V1ApiStage:
+    Type: String
+    Description: Stage name of the v1 API to mount on /api/v1
+    Default: latest
 Resources:
   getCollectionByIdFunction:
     Type: AWS::Serverless::Function
@@ -184,3 +200,29 @@ Resources:
           - OPTIONS
         MaxAge: 600
       StageName: v2
+      StageVariables:
+        basePath: api/v2
+      Domain:
+        DomainName: !Sub "${CustomDomainHost}.${CustomDomainZone}"
+        BasePath: api/v2
+        CertificateArn: !Ref CustomDomainCertificateArn
+        Route53:
+          HostedZoneName: !Sub "${CustomDomainZone}."
+  v1Mapping:
+    Type: AWS::ApiGatewayV2::ApiMapping
+    Properties:
+      ApiMappingKey: api/v1
+      DomainName: !Sub "${CustomDomainHost}.${CustomDomainZone}"
+      ApiId: !Ref V1ApiId
+      Stage: !Ref V1ApiStage
+#  v1Mapping:
+#    Type: AWS::ApiGateway::BasePathMapping
+#    Properties: 
+#      BasePath: api/v1
+#      DomainName: !Sub "${CustomDomainHost}.${CustomDomainZone}"
+#      RestApiId: !Ref V1ApiId
+#      Stage: !Ref V1ApiStage
+# Outputs:
+#   V2ApiEndpoint:
+#     Description: URL to access the v2 API
+#     Value: !GetAtt dcApiapiv2ApiMapping

--- a/test/integration/get-doc.test.js
+++ b/test/integration/get-doc.test.js
@@ -15,9 +15,11 @@ describe("Doc retrieval routes", () => {
         .get("/dc-v2-work/_doc/1234")
         .reply(200, helpers.testFixture("mocks/work-1234.json"));
 
-      const { event } = helpers
+      const event = helpers
         .mockEvent("GET", "/works/{id}")
-        .pathParams({ id: 1234 });
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
 
@@ -31,9 +33,11 @@ describe("Doc retrieval routes", () => {
         .get("/dc-v2-work/_doc/1234")
         .reply(200, helpers.testFixture("mocks/missing-work-1234.json"));
 
-      const { event } = helpers
+      const event = helpers
         .mockEvent("GET", "/works/{id}")
-        .pathParams({ id: 1234 });
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(404);
     });
@@ -43,9 +47,11 @@ describe("Doc retrieval routes", () => {
         .get("/dc-v2-work/_doc/1234")
         .reply(200, helpers.testFixture("mocks/unpublished-work-1234.json"));
 
-      const { event } = helpers
+      const event = helpers
         .mockEvent("GET", "/works/{id}")
-        .pathParams({ id: 1234 });
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(404);
     });
@@ -59,9 +65,11 @@ describe("Doc retrieval routes", () => {
         .get("/dc-v2-collection/_doc/1234")
         .reply(200, helpers.testFixture("mocks/collection-1234.json"));
 
-      const { event } = helpers
+      const event = helpers
         .mockEvent("GET", "/collections/{id}")
-        .pathParams({ id: 1234 });
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
 
@@ -79,9 +87,11 @@ describe("Doc retrieval routes", () => {
         .get("/dc-v2-file-set/_doc/1234")
         .reply(200, helpers.testFixture("mocks/fileset-1234.json"));
 
-      const { event } = helpers
+      const event = helpers
         .mockEvent("GET", "/file-sets/{id}")
-        .pathParams({ id: 1234 });
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
 

--- a/test/integration/search.test.js
+++ b/test/integration/search.test.js
@@ -18,9 +18,11 @@ describe("Search routes", () => {
       mock
         .post("/dc-v2-work/_search", authQuery)
         .reply(200, helpers.testFixture("mocks/search.json"));
-      const { event } = helpers
+      const event = helpers
         .mockEvent("POST", "/search")
-        .body(originalQuery);
+        .pathPrefix("/api/v2")
+        .body(originalQuery)
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
 
@@ -33,11 +35,13 @@ describe("Search routes", () => {
       mock
         .post("/dc-v2-work,dc-v2-collection/_search", authQuery)
         .reply(200, helpers.testFixture("mocks/search-multiple-targets.json"));
-      const { event } = helpers
+      const event = helpers
         .mockEvent("POST", "/search/{models}")
+        .pathPrefix("/api/v2")
         .pathParams({ models: "works,collections" })
         .body(originalQuery)
-        .base64Encode();
+        .base64Encode()
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
 
@@ -47,10 +51,12 @@ describe("Search routes", () => {
     });
 
     it("errors if invalid models specified", async () => {
-      const { event } = helpers
+      const event = helpers
         .mockEvent("POST", "/search/{models}")
+        .pathPrefix("/api/v2")
         .pathParams({ models: "works,collections,blargh" })
-        .body(originalQuery);
+        .body(originalQuery)
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(400);
 
@@ -69,7 +75,11 @@ describe("Search routes", () => {
       "N4IgRg9gJgniBcoCOBXApgJzokBbAhgC4DGAFgPr4A2VCwAvvQDQgDOAlgF5oICMADMzzQ0VVggDaIAO4QMAa3EBdekA";
 
     it("requires a searchToken", async () => {
-      const { event } = helpers.mockEvent("GET", "/search");
+      const event = helpers
+        .mockEvent("GET", "/search")
+        .pathPrefix("/api/v2")
+        .render();
+
       const result = await handler(event);
       expect(result.statusCode).to.eq(400);
       const resultBody = JSON.parse(result.body);
@@ -77,9 +87,11 @@ describe("Search routes", () => {
     });
 
     it("requires a valid searchToken", async () => {
-      const { event } = helpers
+      const event = helpers
         .mockEvent("GET", "/search")
-        .queryParams({ searchToken: "Ceci n'est pas une searchToken" });
+        .pathPrefix("/api/v2")
+        .queryParams({ searchToken: "Ceci n'est pas une searchToken" })
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(400);
       const resultBody = JSON.parse(result.body);
@@ -91,9 +103,11 @@ describe("Search routes", () => {
         .post("/dc-v2-work/_search", authQuery)
         .reply(200, helpers.testFixture("mocks/search.json"));
 
-      const { event } = helpers
+      const event = helpers
         .mockEvent("GET", "/search")
-        .queryParams({ searchToken, page: 1 });
+        .pathPrefix("/api/v2")
+        .queryParams({ searchToken, page: 1 })
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
     });
@@ -103,9 +117,11 @@ describe("Search routes", () => {
         .post("/dc-v2-work/_search", authQuery)
         .reply(200, helpers.testFixture("mocks/search.json"));
 
-      const { event } = helpers
+      const event = helpers
         .mockEvent("GET", "/search")
-        .queryParams({ searchToken });
+        .pathPrefix("/api/v2")
+        .queryParams({ searchToken })
+        .render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
     });

--- a/test/unit/api/helpers.test.js
+++ b/test/unit/api/helpers.test.js
@@ -8,6 +8,8 @@ describe("helpers", () => {
   describe("baseUrl()", () => {
     it("extracts the base URL from a local event", () => {
       const event = {
+        routeKey: "GET /route/{param}",
+        rawPath: "/route/value",
         headers: {
           Host: "localhost",
           "X-Forwarded-Proto": "http",
@@ -25,6 +27,8 @@ describe("helpers", () => {
 
     it("extracts the base URL from an API Gateway event", () => {
       const event = {
+        routeKey: "GET /route/{param}",
+        rawPath: "/v2/route/value",
         headers: {
           Host: "abcdefghijz.execute-api.us-east-1.amazonaws.com",
           "X-Forwarded-Proto": "https",
@@ -44,6 +48,8 @@ describe("helpers", () => {
 
     it("extracts the base URL from a CloudWatch event", () => {
       const event = {
+        routeKey: "GET /route/{param}",
+        rawPath: "/route/value",
         headers: {
           Host: "abcdefghijz.cloudfront.net",
           "X-Forwarded-Proto": "https",
@@ -61,6 +67,8 @@ describe("helpers", () => {
 
     it("extracts the base URL from an event with a custom domain", () => {
       const event = {
+        routeKey: "GET /route/{param}",
+        rawPath: "/route/value",
         headers: {
           Host: "api.test.library.northwestern.edu",
           "X-Forwarded-Proto": "https",
@@ -80,6 +88,8 @@ describe("helpers", () => {
 
     it("prefers a custom domain over localhost", () => {
       const event = {
+        routeKey: "GET /route/{param}",
+        rawPath: "/route/value",
         headers: {
           Host: "localhost",
           "X-Forwarded-Proto": "http",
@@ -96,11 +106,26 @@ describe("helpers", () => {
         "http://api.test.library.northwestern.edu:3000/"
       );
     });
+
+    it("properly handles a base path mapping", () => {
+      const event = helpers
+        .mockEvent("GET", "/works/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .stageVariables({ basePath: "api/v2" })
+        .render();
+
+      expect(baseUrl(event)).to.eq(
+        "https://api.test.library.northwestern.edu/api/v2/"
+      );
+    });
   });
 
   describe("getHeader()", () => {
     it("extracts event headers regardless of case", () => {
       const event = {
+        routeKey: "GET /route/{param}",
+        rawPath: "/route/value",
         headers: {
           Host: "abcdefghijz.execute-api.us-east-1.amazonaws.com",
           "X-Forwarded-Proto": "https",


### PR DESCRIPTION
## Description

- Add custom domain and base mappings to `template.yml`
  - dc-api-v2 on `/api/v2`
  - elastic-proxy on `/api/v1`
- Fix `baseUrl` helper to account for differences between:
  - Access via `localhost` (when running `sam local`)
  - Access via dev hostname (`USER.dev.rdc.library.northwestern.edu`) (when running `sam.local`)
  - Access via the API Gateway (`API_ID.execute-api.us-east-1.amazonaws.com`) URL
  - Access via the custom domain with a base path mapping
- Update tests to cover the above change

This has been deployed to staging (as there was no other way to test), and the new parameters to support it added to [`samconfig.toml`](https://github.com/nulib/tfvars/blob/main/dc-api/samconfig.toml) in the `tfvars` repo.

## Testing

- Dev Environment
  - Run `sam local start-api --host 0.0.0.0`
  - If testing from a remote client, make sure port 3000 is open (`sg open all 3000`)
  - Try some requests using `http://localhost:3000/` as the base
  - Try some requests using `http://USER.dev.rdc.library.northwestern.edu:3000/` as the base
- Staging
  - Try some requests using `https://pylxu5f2l2.execute-api.us-east-1.amazonaws.com/v2/` as the base
  - Try some requests using `https://dcapi.rdc-staging.library.northwestern.edu/api/v2/` as the base

In all of the above cases, try to access some of the URLs in the pagination block to make sure they have the right host, port, and path.