### PR TITLE
IIIF Collection search handler

### DIFF
--- a/dev/env.json
+++ b/dev/env.json
@@ -2,6 +2,7 @@
   "Parameters": {
     "API_TOKEN_SECRET": "DEVELOPMENT_SECRET",
     "ELASTICSEARCH_ENDPOINT": "",
-    "ENV_PREFIX": ""
+    "ENV_PREFIX": "",
+    "DC_URL": ""
   }
 }

--- a/src/api/pagination.js
+++ b/src/api/pagination.js
@@ -9,8 +9,8 @@ async function decodeSearchToken(token) {
   return JSON.parse(await decompress(token));
 }
 
-async function encodeSearchToken(models, body) {
-  let token = { body: { size: 10 }, models };
+async function encodeSearchToken(models, body, format, options) {
+  let token = { body: { size: 10 }, models, format, options };
   for (const field in body) {
     if (encodeFields.includes(field)) {
       token.body[field] = body[field];
@@ -44,18 +44,20 @@ function thisPage(body) {
 }
 
 class Paginator {
-  constructor(baseUrl, route, models, body) {
+  constructor(baseUrl, route, models, body, format, options) {
     this.baseUrl = baseUrl;
     this.route = route;
     this.models = models;
     this.body = { ...body };
+    this.format = format;
+    this.options = options;
   }
 
   async pageInfo(count) {
     let url = new URL(this.route, this.baseUrl);
     url.searchParams.set(
       "searchToken",
-      await encodeSearchToken(this.models, this.body)
+      await encodeSearchToken(this.models, this.body, this.format, this.options)
     );
 
     const prev = prevPage(this.body, count);
@@ -68,6 +70,8 @@ class Paginator {
       offset: from(this.body),
       total_hits: count,
       total_pages: maxPage(this.body, count),
+      options: this.options,
+      format: this.format,
     };
     if (prev) {
       url.searchParams.set("page", prev);

--- a/src/api/request/models.js
+++ b/src/api/request/models.js
@@ -6,7 +6,14 @@ const mapTargets = {
   collections: "dc-v2-collection",
 };
 
-function validModels(models) {
+function extractRequestedModels(requestedModels) {
+  return requestedModels == null ? ["works"] : requestedModels.split(",");
+}
+
+function validModels(models, format) {
+  if (format === "iiif") {
+    return models.length == 1 && models.every((model) => model === "works");
+  }
   return models.every(isAllowed);
 }
 
@@ -18,4 +25,4 @@ function modelsToTargets(models) {
   return String(models.map((model) => prefix(mapTargets[model])));
 }
 
-module.exports = { modelsToTargets, validModels };
+module.exports = { extractRequestedModels, modelsToTargets, validModels };

--- a/src/api/response/iiif/collection.js
+++ b/src/api/response/iiif/collection.js
@@ -1,0 +1,121 @@
+const dcUrl = process.env.DC_URL || "http://placeholder-for-dc-url";
+
+async function transform(response, pager) {
+  if (response.statusCode === 200) {
+    const responseBody = JSON.parse(response.body);
+    const pageInfo = await pager.pageInfo(responseBody.hits.total.value);
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(await buildCollection(responseBody, pageInfo)),
+    };
+  }
+  return transformError(response);
+}
+
+async function buildCollection(responseBody, pageInfo) {
+  const collectionLabel = pageInfo.options.collectionLabel;
+  const collectionSummary = pageInfo.options.collectionSummary;
+
+  return {
+    "@context": ["http://iiif.io/api/presentation/3/context.json"],
+    id: collectionId(pageInfo),
+    type: "Collection",
+    label: {
+      none: [`${collectionLabel}`],
+    },
+    summary: {
+      none: [`${collectionSummary}`],
+    },
+    homepage: [
+      {
+        id: homepageUrl(pageInfo),
+        type: "Text",
+        format: "text/html",
+        label: {
+          none: [`Results for ${collectionLabel} of ${collectionSummary}`],
+        },
+      },
+    ],
+    items: getItems(responseBody?.hits?.hits, pageInfo),
+  };
+}
+
+function getItems(hits, pageInfo) {
+  const items = hits.map((item) => loadItem(item["_source"]));
+
+  if (pageInfo?.next_url) {
+    items.push({
+      id: pageInfo.next_url,
+      type: "Collection",
+      label: {
+        none: ["Next page"],
+      },
+    });
+  }
+
+  return items;
+}
+
+function collectionId(pageInfo) {
+  let collectionId = new URL(pageInfo.query_url);
+  if (pageInfo.current_page > 1) {
+    collectionId.searchParams.set("page", pageInfo.current_page);
+  }
+  return collectionId;
+}
+
+function homepageUrl(pageInfo) {
+  const result = new URL("/search", dcUrl);
+  result.searchParams.set("q", pageInfo.options.queryString);
+  return result;
+}
+
+function loadItem(item) {
+  return {
+    id: item.iiif_manifest,
+    type: "Manifest",
+    homepage: [
+      {
+        id: `${dcUrl}/items/${item.id}`,
+        type: "Text",
+        format: "text/html",
+        label: {
+          none: [`${item.title}`],
+        },
+      },
+    ],
+    label: {
+      none: [`${item.title}`],
+    },
+    summary: {
+      none: [`${item.work_type}`],
+    },
+    thumbnail: [
+      {
+        id: [`${item.representative_file_set.url}/full/400,/0/default.jpg`],
+        service: [
+          {
+            profile: "http://iiif.io/api/image/2/level2.json",
+            "@context": "http://iiif.io/api/image/2/context.json",
+            "@id": `${item.representative_file_set.url}`,
+          },
+        ],
+        type: "Image",
+        width: 400,
+        height: 400,
+      },
+    ],
+  };
+}
+
+function transformError(response) {
+  const responseBody = { status: response.statusCode, error: "TODO" };
+
+  return {
+    statusCode: response.statusCode,
+    body: JSON.stringify(responseBody),
+  };
+}
+
+module.exports = { transform };

--- a/src/api/response/opensearch/index.js
+++ b/src/api/response/opensearch/index.js
@@ -20,11 +20,19 @@ async function transformMany(responseBody, pager) {
     statusCode: 200,
     body: JSON.stringify({
       data: extractSource(responseBody.hits.hits),
-      pagination: await pager.pageInfo(responseBody.hits.total.value),
+      pagination: await paginationInfo(responseBody, pager),
       info: {},
       aggregations: responseBody.aggregations,
     }),
   };
+}
+
+async function paginationInfo(responseBody, pager) {
+  let { format, options, ...pageInfo } = await pager.pageInfo(
+    responseBody.hits.total.value
+  );
+
+  return pageInfo;
 }
 
 function transformError(response) {

--- a/src/api/response/transformer.js
+++ b/src/api/response/transformer.js
@@ -1,0 +1,30 @@
+const iiifCollectionResponse = require("./iiif/collection.js");
+const opensearchResponse = require("./opensearch");
+
+async function transformSearchResult(response, pager) {
+  if (response.statusCode === 200) {
+    const responseBody = JSON.parse(response.body);
+    const pageInfo = await pager.pageInfo(responseBody.hits.total.value);
+
+    if (pageInfo.format === "iiif") {
+      return await iiifCollectionResponse.transform(response, pager);
+    }
+
+    return await opensearchResponse.transform(response, pager);
+  }
+  return transformError(response);
+}
+
+function transformError(response) {
+  const responseBody = {
+    status: response.statusCode,
+    error: "TODO",
+  };
+
+  return {
+    statusCode: response.statusCode,
+    body: JSON.stringify(responseBody),
+  };
+}
+
+module.exports = { transformSearchResult };

--- a/src/handlers/search.js
+++ b/src/handlers/search.js
@@ -1,59 +1,80 @@
 const middleware = require("./middleware");
 const { baseUrl } = require("../helpers");
-const { modelsToTargets, validModels } = require("../api/request/models");
+const {
+  extractRequestedModels,
+  modelsToTargets,
+  validModels,
+} = require("../api/request/models");
 const { search } = require("../api/opensearch");
-const opensearchResponse = require("../api/response/opensearch");
+const responseTransformer = require("../api/response/transformer");
 const { decodeSearchToken, Paginator } = require("../api/pagination");
 const RequestPipeline = require("../api/request/pipeline");
 
 const getSearch = async (event) => {
   event = middleware(event);
-  let token = event.queryStringParameters.searchToken;
-  if (token === undefined || token === "") {
-    return invalidRequest("searchToken parameter is required");
-  }
 
-  let request;
+  const models = extractRequestedModels(event.pathParameters?.models);
+  const format = await responseFormat(event);
+
+  console.log("format", format);
+
+  let searchContext;
+
   try {
-    request = await decodeSearchToken(token);
-  } catch (err) {
-    return invalidRequest("searchToken is invalid");
+    searchContext = await constructSearchContext(event);
+  } catch (error) {
+    return invalidRequest(error.message);
   }
 
-  const page = Number(event.queryStringParameters.page || 1);
-  request.body.from = request.body.size * (page - 1);
-
-  return await executeSearch(event, request.models, request.body);
+  return await executeSearch(
+    event,
+    models,
+    searchContext,
+    format,
+    getOptions(event.queryStringParameters, format)
+  );
 };
 
 const postSearch = async (event) => {
   event = middleware(event);
-  const eventBody = JSON.parse(event.body);
 
-  const requestedModels =
-    event.pathParameters?.models == null
-      ? ["works"]
-      : event.pathParameters.models.split(",");
+  const searchContext = JSON.parse(event.body);
+  const models = extractRequestedModels(event.pathParameters?.models);
 
-  return await executeSearch(event, requestedModels, eventBody);
+  return await executeSearch(event, models, searchContext);
 };
 
 /**
  * Function to wrap search requests and transform responses
  */
-const executeSearch = async (event, models, body) => {
-  if (!validModels(models)) {
+const executeSearch = async (
+  event,
+  models,
+  searchContext,
+  format = "default",
+  options = {}
+) => {
+  if (!validModels(models, format)) {
     return invalidRequest(`Invalid models requested: ${models}`);
   }
 
-  const pager = new Paginator(baseUrl(event), "search", models, body);
-  const filteredBody = new RequestPipeline(body).authFilter().toJson();
-  let esResponse = await search(modelsToTargets(models), filteredBody);
-  let transformedResponse = await opensearchResponse.transform(
-    esResponse,
-    pager
+  const pager = new Paginator(
+    baseUrl(event),
+    "search",
+    models,
+    searchContext,
+    format,
+    options
   );
-  return transformedResponse;
+  const filteredSearchContext = new RequestPipeline(searchContext)
+    .authFilter()
+    .toJson();
+  const esResponse = await search(
+    modelsToTargets(models),
+    filteredSearchContext
+  );
+
+  return await responseTransformer.transformSearchResult(esResponse, pager);
 };
 
 const invalidRequest = (message) => {
@@ -61,6 +82,86 @@ const invalidRequest = (message) => {
     statusCode: 400,
     body: JSON.stringify({ message: message }),
   };
+};
+
+const constructSearchContext = async (event) => {
+  const token = event.queryStringParameters?.searchToken;
+
+  return token === undefined || token === ""
+    ? fromQueryString(event.queryStringParameters)
+    : await fromBody(event);
+};
+
+const fromQueryString = (queryStringParameters) => {
+  let searchContext = {
+    query: {
+      query_string: {
+        query: queryStringParameters?.query || "*",
+      },
+    },
+  };
+
+  if (queryStringParameters?.size) {
+    searchContext.size = queryStringParameters.size;
+  }
+
+  if (queryStringParameters?.from) {
+    searchContext.from = queryStringParameters.from;
+  }
+
+  if (queryStringParameters?.sort) {
+    //TODO
+  }
+  return searchContext;
+};
+
+const responseFormat = async (event) => {
+  if (event.queryStringParameters?.as) {
+    return event.queryStringParameters?.as;
+  } else {
+    if (event.queryStringParameters?.searchToken === undefined)
+      return "default";
+    const token = event.queryStringParameters.searchToken;
+
+    try {
+      request = await decodeSearchToken(token);
+    } catch (err) {
+      return invalidRequest("searchToken is invalid");
+    }
+    return request.format;
+  }
+};
+
+const fromBody = async (event) => {
+  const token = event.queryStringParameters.searchToken;
+
+  let request;
+
+  try {
+    request = await decodeSearchToken(token);
+  } catch (err) {
+    throw new Error("searchToken is invalid");
+  }
+
+  const page = Number(event.queryStringParameters.page || 1);
+  request.body.from = request.body.size * (page - 1);
+
+  return request.body;
+};
+
+const getOptions = (queryStringParameters, format) => {
+  if (format === "iiif") {
+    const collectionLabel =
+      queryStringParameters?.collectionLabel || "IIIF Collection";
+    const collectionSummary = queryStringParameters?.collectionSummary || "";
+    const queryString = queryStringParameters.query || "*";
+    return {
+      collectionLabel: collectionLabel,
+      collectionSummary: collectionSummary,
+      queryString: queryString,
+    };
+  }
+  return {};
 };
 
 module.exports = { postSearch, getSearch };

--- a/template.yaml
+++ b/template.yaml
@@ -23,6 +23,9 @@ Parameters:
   CustomDomainHost:
     Type: String
     Description: Hostname within ApiDomainName for Custom Domain
+  DcUrl:
+    Type: String
+    Description: URL of Digital Collections website
   ElasticsearchEndpoint:
     Type: String
     Description: Elasticsearch url
@@ -59,6 +62,7 @@ Resources:
             Resource: "*"
       Environment:
         Variables:
+          DC_URL: !Ref DcUrl
           ENV_PREFIX: !Ref EnvironmentPrefix
           ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
@@ -88,6 +92,7 @@ Resources:
             Resource: "*"
       Environment:
         Variables:
+          DC_URL: !Ref DcUrl
           ENV_PREFIX: !Ref EnvironmentPrefix
           ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
@@ -117,6 +122,7 @@ Resources:
             Resource: "*"
       Environment:
         Variables:
+          DC_URL: !Ref DcUrl
           ENV_PREFIX: !Ref EnvironmentPrefix
           ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
@@ -146,6 +152,7 @@ Resources:
             Resource: "*"
       Environment:
         Variables:
+          DC_URL: !Ref DcUrl
           ENV_PREFIX: !Ref EnvironmentPrefix
           ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
@@ -240,6 +247,7 @@ Resources:
             Resource: "*"
       Environment:
         Variables:
+          DC_URL: !Ref DcUrl
           ENV_PREFIX: !Ref EnvironmentPrefix
           ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:

--- a/test/unit/api/response/iiif/collection.test.js
+++ b/test/unit/api/response/iiif/collection.test.js
@@ -1,0 +1,51 @@
+"use strict";
+
+const transformer = require("../../../../../src/api/response/iiif/collection");
+const { Paginator } = require("../../../../../src/api/pagination");
+const chai = require("chai");
+const expect = chai.expect;
+
+describe("IIIF Collection response transformer", () => {
+  let pager;
+  beforeEach(() => {
+    pager = new Paginator(
+      "http://dcapi.library.northwestern.edu/v2/",
+      "search",
+      ["works"],
+      { query: { query_string: { query: "genre.label:architecture" } } },
+      "iiif",
+      {
+        collectionLabel: "The collection label",
+        collectionSummary: "The collection Summary",
+        queryString: "genre.label:architecture",
+      }
+    );
+  });
+
+  it("transforms a search response", async () => {
+    const response = {
+      statusCode: 200,
+      body: helpers.testFixture("mocks/search.json"),
+    };
+    const result = await transformer.transform(response, pager);
+    expect(result.statusCode).to.eq(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.type).to.eq("Collection");
+    expect(body.label.none[0]).to.eq("The collection label");
+  });
+
+  it("transforms an error response", async () => {
+    const response = {
+      statusCode: 404,
+      body: helpers.testFixture("mocks/missing-index.json"),
+    };
+
+    const result = await transformer.transform(response, pager);
+    expect(result.statusCode).to.eq(404);
+
+    const body = JSON.parse(result.body);
+    expect(body.status).to.eq(404);
+    expect(body.error).to.be.a("string");
+  });
+});


### PR DESCRIPTION
NOTE: Grab new tfvars

Configures `GET /search` route:
- handle query string requests returning our API format (deafult) or a IIIF collection if the `as=iiif` parameter is present
- accepts:
  - `query`
  - `size`
  - `from`
  - `collectionLabel`
  - `collectionSummary`

The last item in the collection would be a link to the next "page" of results in the collection. Ex: 

```
{
      "id": "http://127.0.0.1:3000/search?searchToken=N4IgRg9gJgniBcoDOBLAXgUwSAzCANCAI4CuGATnIsWZQPpIAu5KAdgOYKikVUjsZW5DADoANgEMwGMfAA6ICeQDGACxSMMyxiWEACABRQUSZSgAOYthgCUCkAF8nhALbQZSBAG0QAdwjkANaeALqEAGYBLhKM2Cjx4QQgEOaMKBCsntTKEGJiWmkZADJSMthKahoFuhiGxqYWVqy2STl5BemsAMokLtGU2ADigsKehDyUXcxsnPD8I6KS0rIKFeqa2jV1JmaW1nYgjg5AA&page=2",
      "type": "Collection",
      "label": {
        "none": [
          "Next page"
        ]
      }
    }
```


converts the query to a POST to send as a `query_string` to ES. Elasticsearch query string syntax: https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-query-string-query.html#query-string-syntax


Examples of things that should work (data supporting):
- `http://127.0.0.1:3000/search`
- `http://127.0.0.1:3000/search?as=iiif`
- `http://127.0.0.1:3000/search?query=genre.label:%22architecture%20(discipline)%22&collectionLabel=architecture%20(discipline)&collectionSummary=Genres&size=3&as=iiif`
- `http://127.0.0.1:3000/search?query=genre.label:%22architecture%20(discipline)%22`

TODO: not supported: `sort` parameter