### PR TITLE
Remove searchToken from /collections route

### DIFF
--- a/src/api/pagination.js
+++ b/src/api/pagination.js
@@ -22,6 +22,7 @@ async function encodeSearchToken(models, body, format, options) {
 function from(body) {
   return body?.from || 0;
 }
+
 function size(body) {
   return body?.size || 10;
 }
@@ -55,10 +56,18 @@ class Paginator {
 
   async pageInfo(count) {
     let url = new URL(this.route, this.baseUrl);
-    url.searchParams.set(
-      "searchToken",
-      await encodeSearchToken(this.models, this.body, this.format, this.options)
-    );
+
+    if (this.options?.includeToken != false) {
+      url.searchParams.set(
+        "searchToken",
+        await encodeSearchToken(
+          this.models,
+          this.body,
+          this.format,
+          this.options
+        )
+      );
+    }
 
     const prev = prevPage(this.body, count);
     const next = nextPage(this.body, count);

--- a/test/integration/get-collections.test.js
+++ b/test/integration/get-collections.test.js
@@ -13,32 +13,33 @@ describe("Collections route", () => {
     const handler = getCollectionsHandler.handler;
     const originalQuery = { size: 10, from: 0 };
     const authQuery = new RequestPipeline(originalQuery).authFilter().toJson();
-    const searchToken =
-      "N4IgRg9gJgniBcoDOBLAXgUwQRgAwF8AaEAW2gwBskEBtEAYwgoo3oBcUIA7agXXyA";
+    const baseEvent = helpers
+      .mockEvent("GET", "/collections")
+      .pathPrefix("/api/v2");
 
-    it("requires a valid searchToken", async () => {
-      const event = helpers
-        .mockEvent("GET", "/collections")
-        .pathPrefix("/api/v2")
-        .queryParams({ searchToken: "Ceci n'est pas une searchToken" })
-        .render();
+    describe("validates parameters", () => {
+      it("page", async () => {
+        const event = baseEvent.queryParams({ page: 0 }).render();
+        const result = await handler(event);
+        expect(result.statusCode).to.eq(400);
+        const resultBody = JSON.parse(result.body);
+        expect(resultBody.message).to.eq("page must be >= 1");
+      });
 
-      const result = await handler(event);
-      expect(result.statusCode).to.eq(400);
-      const resultBody = JSON.parse(result.body);
-      expect(resultBody.message).to.eq("searchToken is invalid");
+      it("size", async () => {
+        const event = baseEvent.queryParams({ size: 0 }).render();
+        const result = await handler(event);
+        expect(result.statusCode).to.eq(400);
+        const resultBody = JSON.parse(result.body);
+        expect(resultBody.message).to.eq("size must be >= 1");
+      });
     });
 
     it("paginates results using a searchToken and page number", async () => {
       mock
         .post("/dc-v2-collection/_search", authQuery)
         .reply(200, helpers.testFixture("mocks/collections.json"));
-      const event = helpers
-        .mockEvent("GET", "/collections")
-        .pathPrefix("/api/v2")
-        .queryParams({ searchToken, page: 1 })
-        .body(authQuery)
-        .render();
+      const event = baseEvent.queryParams({ page: 1 }).render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
       expect(result.headers).to.include({ "content-type": "application/json" });


### PR DESCRIPTION
- Remove `searchToken` from `/collections` route
- Add support for `size` parameter

### Testing

- Try `/collections` and make sure the pagination block has page info but no token
- Try `/collections?page=` with a page number and make sure there's page info but no token
- Try `/collections?size=` to change the number of results turned at a time
- Try invalid (0 and/or `NaN`) values for `page` and `limit` to make sure it returns a 400 error
- Try `/search` to make sure the search token is still present in the pagination block
