### PR TITLE
Allow paginator to take additional params for the base url

### DIFF
--- a/src/api/pagination.js
+++ b/src/api/pagination.js
@@ -69,6 +69,13 @@ class Paginator {
       );
     }
 
+    const extraParams = this?.options?.extraParams;
+    if (typeof extraParams === "object") {
+      for (const param in extraParams) {
+        url.searchParams.set(param, extraParams[param]);
+      }
+    }
+
     const prev = prevPage(this.body, count);
     const next = nextPage(this.body, count);
 

--- a/src/handlers/get-collections.js
+++ b/src/handlers/get-collections.js
@@ -6,9 +6,12 @@ const opensearchResponse = require("../api/response/opensearch");
 const { Paginator } = require("../api/pagination");
 const RequestPipeline = require("../api/request/pipeline");
 
+const DefaultSize = 10;
+
 const numberParam = (value, defaultValue) => {
-  if (value === undefined) return defaultValue;
-  return Number(value);
+  const result = Number(value);
+  if (isNaN(result)) return defaultValue;
+  return result;
 };
 
 /**
@@ -18,20 +21,21 @@ exports.handler = async (event) => {
   event = middleware(event);
 
   const page = numberParam(event.queryStringParameters?.page, 1);
-  if (isNaN(page) || page < 1) return invalidRequest("page must be >= 1");
-  const size = numberParam(event.queryStringParameters?.size, 10);
-  if (isNaN(size) || size < 1) return invalidRequest("size must be >= 1");
+  if (page < 1) return invalidRequest("page must be >= 1");
+  const size = numberParam(event.queryStringParameters?.size, DefaultSize);
+  if (size < 1) return invalidRequest("size must be >= 1");
 
   let body = { size: size, from: size * (page - 1) };
   let models = ["collections"];
 
+  const extraParams = size === DefaultSize ? {} : { size };
   const pager = new Paginator(
     baseUrl(event),
     "collections",
     models,
     body,
     null,
-    { includeToken: false }
+    { extraParams, includeToken: false }
   );
   const filteredBody = new RequestPipeline(body).authFilter().toJson();
   let esResponse = await search(modelsToTargets(models), filteredBody);

--- a/test/unit/api/pagination.test.js
+++ b/test/unit/api/pagination.test.js
@@ -72,4 +72,18 @@ describe("Paginator", function () {
     const result = await pager.pageInfo(1275);
     expect(result.limit).to.eq(10);
   });
+
+  it("excludes searchToken when required", async () => {
+    pager.options = { includeToken: false };
+    const result = await pager.pageInfo(1275);
+    const url = new URL(result.query_url);
+    expect(url.searchParams.has("searchToken")).to.be.false;
+  });
+
+  it("includes extra parameters", async () => {
+    pager.options = { extraParams: { size: 5 } };
+    const result = await pager.pageInfo(1275);
+    const url = new URL(result.query_url);
+    expect(url.searchParams.get("size")).to.eq("5");
+  });
 });


### PR DESCRIPTION
- Allow paginator to take additional params for the base url
- Include non-default size in `/collections` responses