### PR TITLE
Shared links API implementation

### DIFF
--- a/src/api/opensearch.js
+++ b/src/api/opensearch.js
@@ -14,12 +14,16 @@ async function getWork(id) {
   return getDocument("dc-v2-work", id);
 }
 
+async function getSharedLink(id) {
+  return getDocument("shared_links", id);
+}
+
 async function getDocument(index, id) {
   const request = initRequest(`/${prefix(index)}/_doc/${id}`);
   let response = await awsFetch(request);
   if (response.statusCode === 200) {
     const body = JSON.parse(response.body);
-    if (!isVisible(body)) {
+    if (index != "shared_links" && !isVisible(body)) {
       let responseBody = {
         _index: prefix(index),
         _type: "_doc",
@@ -78,4 +82,4 @@ async function search(targets, body) {
   return await awsFetch(request);
 }
 
-module.exports = { getCollection, getFileSet, getWork, search };
+module.exports = { getCollection, getFileSet, getSharedLink, getWork, search };

--- a/src/handlers/get-shared-link-by-id.js
+++ b/src/handlers/get-shared-link-by-id.js
@@ -1,0 +1,29 @@
+const { processRequest, processResponse } = require("./middleware");
+const { getSharedLink } = require("../api/opensearch");
+const opensearchResponse = require("../api/response/opensearch");
+
+/**
+ * Get a shared link document by id
+ */
+exports.handler = async (event) => {
+  event = processRequest(event);
+  const id = event.pathParameters.id;
+  const esResponse = await getSharedLink(id);
+  if (linkExpired(esResponse)) {
+    return {
+      statusCode: 404,
+      headers: { "content-type": "text/plain" },
+      body: "Not Found",
+    };
+  } else {
+    const response = opensearchResponse.transform(esResponse);
+    return processResponse(event, response);
+  }
+};
+
+const linkExpired = (response) => {
+  const body = JSON.parse(response.body);
+  const expires = new Date(body?._source?.expires);
+
+  return expires <= new Date();
+};

--- a/template.yaml
+++ b/template.yaml
@@ -371,6 +371,36 @@ Resources:
             ApiId: !Ref dcApi
             Path: /{proxy+}
             Method: OPTIONS
+  getSharedLinkByIdFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: ./src
+      Handler: handlers/get-shared-link-by-id.handler
+      Runtime: nodejs16.x
+      Architectures:
+        - x86_64
+      MemorySize: 128
+      Timeout: 100
+      Description: Gets a shared link document by id.
+      Policies:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ESHTTPPolicy
+            Effect: Allow
+            Action:
+              - es:ESHttp*
+            Resource: "*"
+      Environment:
+        Variables:
+          ENV_PREFIX: !Ref EnvironmentPrefix
+          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /resolve/{id}
+            Method: GET
   dcApi:
     Type: AWS::Serverless::HttpApi
     Properties:

--- a/test/fixtures/mocks/expired-shared-link-9101112.json
+++ b/test/fixtures/mocks/expired-shared-link-9101112.json
@@ -1,0 +1,13 @@
+{
+  "_index": "dev-shared_links",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "target_index": "meadow",
+    "target_id": "23255308-53f4-4c96-a268-aefa596d9d21",
+    "shared_link_id": "b47a0a1c-ca52-424f-877f-a2ab9f1c0735",
+    "expires": "2021-10-26T16:47:06Z"
+  }
+}

--- a/test/fixtures/mocks/missing-shared-link-5678.json
+++ b/test/fixtures/mocks/missing-shared-link-5678.json
@@ -1,0 +1,6 @@
+{
+  "_index": "dev-shared_links",
+  "_type": "_doc",
+  "_id": "1234",
+  "found": false
+}

--- a/test/fixtures/mocks/shared-link-1234.json
+++ b/test/fixtures/mocks/shared-link-1234.json
@@ -1,0 +1,13 @@
+{
+  "_index": "dev-shared_links",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "target_index": "meadow",
+    "target_id": "23255308-53f4-4c96-a268-aefa596d9d21",
+    "shared_link_id": "b47a0a1c-ca52-424f-877f-a2ab9f1c0735",
+    "expires": "2028-10-26T16:47:06Z"
+  }
+}

--- a/test/integration/get-shared-link-by-id.test.js
+++ b/test/integration/get-shared-link-by-id.test.js
@@ -1,0 +1,64 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+
+describe("Retrieve shared link by id", () => {
+  helpers.saveEnvironment();
+  const mock = helpers.mockIndex();
+
+  describe("GET /resolve/{id}", () => {
+    const { handler } = require("../../src/handlers/get-shared-link-by-id");
+
+    it("retrieves a single shared link document", async () => {
+      mock
+        .get("/shared_links/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/shared-link-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/resolve/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+      expect(result.headers).to.include({ "content-type": "application/json" });
+
+      const resultBody = JSON.parse(result.body);
+      expect(resultBody.data.target_id).to.eq(
+        "23255308-53f4-4c96-a268-aefa596d9d21"
+      );
+    });
+
+    it("404s a missing shared link", async () => {
+      mock
+        .get("/shared_links/_doc/5678")
+        .reply(404, helpers.testFixture("mocks/missing-shared-link-5678.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/shared_links/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 5678 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(404);
+    });
+
+    it("404s an expired shared link", async () => {
+      mock
+        .get("/shared_links/_doc/9101112")
+        .reply(
+          200,
+          helpers.testFixture("mocks/expired-shared-link-9101112.json")
+        );
+
+      const event = helpers
+        .mockEvent("GET", "/shared_links/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 9101112 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(404);
+    });
+  });
+});


### PR DESCRIPTION
- Implements `/resolve/{id}` route
- Straight port of current shared link functionality from https://github.com/nulib/elastic-proxy