### PR TITLE
Return a collection as IIIF collection

### DIFF
--- a/src/handlers/get-collection-by-id.js
+++ b/src/handlers/get-collection-by-id.js
@@ -1,14 +1,26 @@
 const { processRequest, processResponse } = require("./middleware");
 const { getCollection } = require("../api/opensearch");
+const { getSearch } = require("./search");
 const opensearchResponse = require("../api/response/opensearch");
 
 /**
- * A simple function to get a Collection by id
+ * Get a colletion by id
  */
 exports.handler = async (event) => {
   event = processRequest(event);
   const id = event.pathParameters.id;
   const esResponse = await getCollection(id);
+
+  const collection = JSON.parse(esResponse.body)?._source;
+
+  if (event.queryStringParameters?.as === "iiif" && collection) {
+    event.queryStringParameters.query = `collection.id:${id}`;
+    event.queryStringParameters.collectionLabel = collection?.title || "";
+    event.queryStringParameters.collectionSummary =
+      collection?.description || "";
+    return await getSearch(event);
+  }
+
   const response = opensearchResponse.transform(esResponse);
   return processResponse(event, response);
 };

--- a/test/fixtures/mocks/collection-1234.json
+++ b/test/fixtures/mocks/collection-1234.json
@@ -6,6 +6,7 @@
   "found": true,
   "_source": {
     "id": "1234",
+    "title": "Collection Title",
     "api_model": "Collection",
     "published": true,
     "representative_image": {

--- a/test/integration/get-collection-by-id.js
+++ b/test/integration/get-collection-by-id.js
@@ -1,0 +1,75 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+const RequestPipeline = require("../../src/api/request/pipeline");
+
+describe("Retrieve collection by id", () => {
+  helpers.saveEnvironment();
+  const mock = helpers.mockIndex();
+
+  describe("GET /collections/{id}", () => {
+    const { handler } = require("../../src/handlers/get-collection-by-id");
+
+    it("retrieves a single collection link document", async () => {
+      mock
+        .get("/dc-v2-collection/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/collection-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/collections/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+      expect(result.headers).to.include({ "content-type": "application/json" });
+
+      const resultBody = JSON.parse(result.body);
+      expect(resultBody.data.id).to.eq("1234");
+    });
+
+    it("404s a missing collection", async () => {
+      mock
+        .get("/dc-v2-collection/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/missing-collection-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/collections/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(404);
+    });
+
+    it("returns a single collection as a IIIF collection", async () => {
+      const originalQuery = {
+        query: { query_string: { query: "collection.id:1234" } },
+      };
+      const authQuery = new RequestPipeline(originalQuery)
+        .authFilter()
+        .toJson();
+
+      mock
+        .get("/dc-v2-collection/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/collection-1234.json"));
+      mock
+        .post("/dc-v2-work/_search", authQuery)
+        .reply(200, helpers.testFixture("mocks/search.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/collections/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .queryParams({ as: "iiif" })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+      expect(result.headers).to.include({ "content-type": "application/json" });
+      const resultBody = JSON.parse(result.body);
+      expect(resultBody.type).to.eq("Collection");
+      expect(resultBody.label.none[0]).to.eq("Collection Title");
+    });
+  });
+});


### PR DESCRIPTION
 Returns one of our Collections as a IIIF collection 

Examples: 
- `GET /collections/{id}?as=iiif`
- `GET /collections/{id}?as=iiif&size=2`