### PR TITLE
Allow certain IPs to receive private results

### DIFF
--- a/src/handlers/get-collections.js
+++ b/src/handlers/get-collections.js
@@ -37,7 +37,7 @@ exports.handler = async (event) => {
     null,
     { extraParams, includeToken: false }
   );
-  const filteredBody = new RequestPipeline(body).authFilter().toJson();
+  const filteredBody = new RequestPipeline(body).authFilter(event).toJson();
   let esResponse = await search(modelsToTargets(models), filteredBody);
   let transformedResponse = await opensearchResponse.transform(
     esResponse,

--- a/src/handlers/get-file-set-by-id.js
+++ b/src/handlers/get-file-set-by-id.js
@@ -1,5 +1,6 @@
 const { processRequest, processResponse } = require("./middleware");
 const { getFileSet } = require("../api/opensearch");
+const { isFromReadingRoom } = require("../helpers");
 const opensearchResponse = require("../api/response/opensearch");
 
 /**
@@ -8,7 +9,8 @@ const opensearchResponse = require("../api/response/opensearch");
 exports.handler = async (event) => {
   event = processRequest(event);
   const id = event.pathParameters.id;
-  const esResponse = await getFileSet(id);
+  const allowPrivate = isFromReadingRoom(event);
+  const esResponse = await getFileSet(id, { allowPrivate });
   const response = opensearchResponse.transform(esResponse);
   return processResponse(event, response);
 };

--- a/src/handlers/get-work-by-id.js
+++ b/src/handlers/get-work-by-id.js
@@ -1,5 +1,6 @@
 const { processRequest, processResponse } = require("./middleware");
 const { getWork } = require("../api/opensearch");
+const { isFromReadingRoom } = require("../helpers");
 const opensearchResponse = require("../api/response/opensearch");
 
 /**
@@ -8,7 +9,8 @@ const opensearchResponse = require("../api/response/opensearch");
 exports.handler = async (event) => {
   event = processRequest(event);
   const id = event.pathParameters.id;
-  const esResponse = await getWork(id);
+  const allowPrivate = isFromReadingRoom(event);
+  const esResponse = await getWork(id, { allowPrivate });
   const response = opensearchResponse.transform(esResponse);
   return processResponse(event, response);
 };

--- a/src/handlers/search.js
+++ b/src/handlers/search.js
@@ -12,7 +12,6 @@ const RequestPipeline = require("../api/request/pipeline");
 
 const getSearch = async (event) => {
   event = processRequest(event);
-
   const models = extractRequestedModels(event.pathParameters?.models);
   const format = await responseFormat(event);
 
@@ -67,7 +66,7 @@ const executeSearch = async (
     options
   );
   const filteredSearchContext = new RequestPipeline(searchContext)
-    .authFilter()
+    .authFilter(event)
     .toJson();
   const esResponse = await search(
     modelsToTargets(models),

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -96,10 +96,17 @@ function objectifyCookies(event) {
   return event;
 }
 
+function isFromReadingRoom(event) {
+  const AllowedIPs = (process.env.READING_ROOM_IPS || "").split(/\s*,\s*/);
+  const sourceIp = event?.requestContext?.http?.sourceIp;
+  return AllowedIPs.includes(sourceIp);
+}
+
 module.exports = {
   addCorsHeaders,
   baseUrl,
   decodeEventBody,
+  isFromReadingRoom,
   normalizeHeaders,
   objectifyCookies,
 };

--- a/template.yaml
+++ b/template.yaml
@@ -4,12 +4,22 @@ Description: >
   dc-api-v2
 
   Sample SAM Template for dc-api-v2
-
 # More info about Globals: https://github.com/awslabs/serverless-application-model/blob/master/docs/globals.rst
 Globals:
   Function:
+    CodeUri: ./src
+    Runtime: nodejs16.x
+    Architectures:
+    - x86_64
+    MemorySize: 128
     Timeout: 3
-
+    Environment:
+      Variables:
+        DC_API_ENDPOINT: !Ref DcApiEndpoint
+        DC_URL: !Ref DcUrl
+        ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
+        ENV_PREFIX: !Ref EnvironmentPrefix
+        READING_ROOM_IPS: !Ref ReadingRoomIPs
 Parameters:
   ApiSecret:
     Type: String
@@ -42,6 +52,9 @@ Parameters:
   NussoBaseUrl:
     Type: String
     Description: Auth server URL
+  ReadingRoomIPs:
+    Type: String
+    Description: Comma-delimited list of IP addresses to serve private resources to
   V1ApiId:
     Type: String
     Description: ID of the v1 API to mount on /api/v1
@@ -54,19 +67,11 @@ Resources:
   getAuthCallbackFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-auth-callback.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: NUSSO callback function.
       Environment:
         Variables:
           API_TOKEN_SECRET: !Ref ApiSecret
-          DC_API_ENDPOINT: !Ref DcApiEndpoint
-          DC_URL: !Ref DcUrl
           NUSSO_API_KEY: !Ref NussoApiKey
           NUSSO_BASE_URL: !Ref NussoBaseUrl
       Events:
@@ -79,18 +84,10 @@ Resources:
   getAuthLoginFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-auth-login.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Performs NUSSO login.
       Environment:
         Variables:
-          DC_API_ENDPOINT: !Ref DcApiEndpoint
-          DC_URL: !Ref DcUrl
           NUSSO_API_KEY: !Ref NussoApiKey
           NUSSO_BASE_URL: !Ref NussoBaseUrl
       Events:
@@ -103,19 +100,11 @@ Resources:
   getAuthWhoAmIFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-auth-whoami.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Exchanges valid JWT token for user information.
       Environment:
         Variables:
           API_TOKEN_SECRET: !Ref ApiSecret
-          DC_API_ENDPOINT: !Ref DcApiEndpoint
-          DC_URL: !Ref DcUrl
           NUSSO_API_KEY: !Ref NussoApiKey
           NUSSO_BASE_URL: !Ref NussoBaseUrl
       Events:
@@ -128,13 +117,7 @@ Resources:
   getCollectionsFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-collections.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Gets Collections.
       Policies:
         Version: 2012-10-17
@@ -144,11 +127,6 @@ Resources:
             Action:
               - es:ESHttp*
             Resource: "*"
-      Environment:
-        Variables:
-          DC_URL: !Ref DcUrl
-          ENV_PREFIX: !Ref EnvironmentPrefix
-          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
         Api:
           Type: HttpApi
@@ -159,13 +137,7 @@ Resources:
   getCollectionByIdFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-collection-by-id.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Gets a Collection by id.
       Policies:
         Version: 2012-10-17
@@ -175,11 +147,6 @@ Resources:
             Action:
               - es:ESHttp*
             Resource: "*"
-      Environment:
-        Variables:
-          DC_URL: !Ref DcUrl
-          ENV_PREFIX: !Ref EnvironmentPrefix
-          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
         Api:
           Type: HttpApi
@@ -190,13 +157,7 @@ Resources:
   getFileSetByIdFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-file-set-by-id.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Gets a FileSet by id.
       Policies:
         Version: 2012-10-17
@@ -206,11 +167,6 @@ Resources:
             Action:
               - es:ESHttp*
             Resource: "*"
-      Environment:
-        Variables:
-          DC_URL: !Ref DcUrl
-          ENV_PREFIX: !Ref EnvironmentPrefix
-          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
         Api:
           Type: HttpApi
@@ -221,13 +177,7 @@ Resources:
   getWorkByIdFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-work-by-id.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Gets a Work by id.
       Policies:
         Version: 2012-10-17
@@ -237,11 +187,6 @@ Resources:
             Action:
               - es:ESHttp*
             Resource: "*"
-      Environment:
-        Variables:
-          DC_URL: !Ref DcUrl
-          ENV_PREFIX: !Ref EnvironmentPrefix
-          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
         Api:
           Type: HttpApi
@@ -252,13 +197,7 @@ Resources:
   getThumbnailFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-thumbnail.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Gets a Work's representative thumbnail.
       Policies:
         Version: 2012-10-17
@@ -271,8 +210,6 @@ Resources:
       Environment:
         Variables:
           API_TOKEN_SECRET: !Ref ApiSecret
-          ENV_PREFIX: !Ref EnvironmentPrefix
-          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
         CollectionApi:
           Type: HttpApi
@@ -289,13 +226,7 @@ Resources:
   searchPostFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/search.postSearch
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Handles OpenSearch search requests, Works only by default.
       Policies:
         Version: 2012-10-17
@@ -305,10 +236,6 @@ Resources:
             Action:
               - es:ESHttp*
             Resource: "*"
-      Environment:
-        Variables:
-          ENV_PREFIX: !Ref EnvironmentPrefix
-          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
         SearchApi:
           Type: HttpApi
@@ -325,13 +252,7 @@ Resources:
   searchGetFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/search.getSearch
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Handles paging requests
       Policies:
         Version: 2012-10-17
@@ -341,11 +262,6 @@ Resources:
             Action:
               - es:ESHttp*
             Resource: "*"
-      Environment:
-        Variables:
-          DC_URL: !Ref DcUrl
-          ENV_PREFIX: !Ref EnvironmentPrefix
-          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
         SearchApi:
           Type: HttpApi
@@ -356,12 +272,7 @@ Resources:
   optionsFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/options-request.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
       Timeout: 3
       Description: Handles all OPTIONS requests
       Events:
@@ -374,13 +285,7 @@ Resources:
   getSharedLinkByIdFunction:
     Type: AWS::Serverless::Function
     Properties:
-      CodeUri: ./src
       Handler: handlers/get-shared-link-by-id.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
-      Timeout: 100
       Description: Gets a shared link document by id.
       Policies:
         Version: 2012-10-17
@@ -390,10 +295,6 @@ Resources:
             Action:
               - es:ESHttp*
             Resource: "*"
-      Environment:
-        Variables:
-          ENV_PREFIX: !Ref EnvironmentPrefix
-          ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
       Events:
         Api:
           Type: HttpApi
@@ -433,10 +334,6 @@ Resources:
     Properties:
       CodeUri: ./redirect
       Handler: index.handler
-      Runtime: nodejs16.x
-      Architectures:
-        - x86_64
-      MemorySize: 128
       Timeout: 1
       Description: Redirects to latest version of docs
       Environment:

--- a/test/fixtures/mocks/private-work-1234.json
+++ b/test/fixtures/mocks/private-work-1234.json
@@ -1,0 +1,13 @@
+{
+  "_index": "dev-dc-v2-work",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "1234",
+    "api_model": "Work",
+    "published": true,
+    "visibility": "Private"
+  }
+}

--- a/test/integration/get-collections.test.js
+++ b/test/integration/get-collections.test.js
@@ -14,12 +14,13 @@ describe("Collections route", () => {
     const baseEvent = helpers
       .mockEvent("GET", "/collections")
       .pathPrefix("/api/v2");
+    let event;
     const makeQuery = (params) =>
       new RequestPipeline(params).authFilter().toJson();
 
     describe("validates parameters", () => {
       it("page", async () => {
-        const event = baseEvent.queryParams({ page: 0 }).render();
+        event = baseEvent.queryParams({ page: 0 }).render();
         const result = await handler(event);
         expect(result.statusCode).to.eq(400);
         const resultBody = JSON.parse(result.body);
@@ -27,7 +28,7 @@ describe("Collections route", () => {
       });
 
       it("size", async () => {
-        const event = baseEvent.queryParams({ size: 0 }).render();
+        event = baseEvent.queryParams({ size: 0 }).render();
         const result = await handler(event);
         expect(result.statusCode).to.eq(400);
         const resultBody = JSON.parse(result.body);
@@ -39,7 +40,7 @@ describe("Collections route", () => {
       mock
         .post("/dc-v2-collection/_search", makeQuery({ size: 10, from: 0 }))
         .reply(200, helpers.testFixture("mocks/collections.json"));
-      const event = baseEvent.render();
+      event = baseEvent.render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
       expect(result.headers).to.include({ "content-type": "application/json" });
@@ -55,7 +56,7 @@ describe("Collections route", () => {
       mock
         .post("/dc-v2-collection/_search", makeQuery({ size: 5, from: 10 }))
         .reply(200, helpers.testFixture("mocks/collections.json"));
-      const event = baseEvent.queryParams({ page: 3, size: 5 }).render();
+      event = baseEvent.queryParams({ page: 3, size: 5 }).render();
       const result = await handler(event);
       expect(result.statusCode).to.eq(200);
       expect(result.headers).to.include({ "content-type": "application/json" });

--- a/test/integration/get-doc.test.js
+++ b/test/integration/get-doc.test.js
@@ -56,6 +56,35 @@ describe("Doc retrieval routes", () => {
       const result = await handler(event);
       expect(result.statusCode).to.eq(404);
     });
+
+    it("404s a private work by default", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/private-work-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(404);
+    });
+
+    it("returns a private work to allowed IPs", async () => {
+      process.env.READING_ROOM_IPS = "127.0.0.1";
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/private-work-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}")
+        .pathPrefix("/api/v2")
+        .pathParams({ id: 1234 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+    });
   });
 
   describe("GET /collections/{id}", () => {

--- a/test/test-helpers/event-builder.js
+++ b/test/test-helpers/event-builder.js
@@ -9,7 +9,6 @@ module.exports = class {
       routeKey: `${method} ${route}`,
       rawPath: route,
       rawQueryString: "",
-      cookies: [],
       headers: {
         Host: "api.test.library.northwestern.edu",
         "X-Forwarded-For": "127.0.0.1, 127.0.0.2",
@@ -84,6 +83,12 @@ module.exports = class {
 
   base64Encode() {
     this._base64Encode = true;
+    return this;
+  }
+
+  cookie(name, value) {
+    if (!this._event.cookies) this._event.cookies = [];
+    this._event.cookies.push(`${name}=${encodeURIComponent(value)}`);
     return this;
   }
 

--- a/test/unit/api/request/pipeline.test.js
+++ b/test/unit/api/request/pipeline.test.js
@@ -5,6 +5,10 @@ const chai = require("chai");
 const expect = chai.expect;
 
 describe("RequestPipeline", () => {
+  helpers.saveEnvironment();
+
+  const event = helpers.mockEvent("GET", "/search").render();
+
   const requestBody = {
     query: { match: { term: { title: "The Title" } } },
     size: 50,
@@ -18,18 +22,8 @@ describe("RequestPipeline", () => {
     pipeline = new RequestPipeline(requestBody);
   });
 
-  it("adds an auth filter", () => {
-    const result = pipeline.authFilter();
-    expect(result.searchContext.size).to.eq(50);
-    expect(result.searchContext.query.bool.must).to.include(requestBody.query);
-    expect(result.searchContext.query.bool.must_not).to.deep.include(
-      { term: { visibility: "Private" } },
-      { term: { published: false } }
-    );
-  });
-
   it("sets a default query", () => {
-    const result = new RequestPipeline({ size: 20 }).authFilter();
+    const result = new RequestPipeline({ size: 20 }).authFilter(event);
     expect(result.searchContext.size).to.eq(20);
     expect(result.searchContext.query.bool.must).to.deep.include({
       match_all: {},
@@ -38,5 +32,35 @@ describe("RequestPipeline", () => {
 
   it("serializes JSON", () => {
     expect(JSON.parse(pipeline.toJson())).to.deep.equal(requestBody);
+  });
+
+  describe("reading room IPs", () => {
+    it("filters out private results by default", () => {
+      process.env.READING_ROOM_IPS = "192.168.0.1,172.16.10.2";
+      const result = pipeline.authFilter(event);
+      expect(result.searchContext.size).to.eq(50);
+      expect(result.searchContext.query.bool.must).to.include(
+        requestBody.query
+      );
+      expect(result.searchContext.query.bool.must_not).to.deep.include(
+        { term: { visibility: "Private" } },
+        { term: { published: false } }
+      );
+    });
+
+    it("includes private results from allowed IP addresses", () => {
+      process.env.READING_ROOM_IPS = "127.0.0.1,192.168.0.1";
+      const result = pipeline.authFilter(event);
+      expect(result.searchContext.size).to.eq(50);
+      expect(result.searchContext.query.bool.must).to.include(
+        requestBody.query
+      );
+      expect(result.searchContext.query.bool.must_not).to.deep.include({
+        term: { published: false },
+      });
+      expect(result.searchContext.query.bool.must_not).not.to.deep.include({
+        term: { visibility: "Private" },
+      });
+    });
   });
 });


### PR DESCRIPTION
- Add `READING_ROOM_IPS` environment variable / `ReadingRoomIPs` parameter
- Bring `helpers.js` up to 100% test coverage
- Eliminate redundancy in `template.yml` using a global function definition

To test, add `"READING_ROOM_IPS": "127.0.0.1"` to `env.json` and try to find/retrieve private works and file sets. Remove it and watch them disappear from search results and by-ID requests.