### PR TITLE
Ensure event object has expected members

### DIFF
--- a/docs/docs/spec/openapi.yaml
+++ b/docs/docs/spec/openapi.yaml
@@ -26,13 +26,8 @@ paths:
       tags:
       - Collection
       parameters:
-      - name: page
-        in: query
-        required: false
-        description: Page number of results to retrieve
-        schema:
-          type: integer
-          minimum: 1
+      - $ref: "./types.yaml#/components/parameters/page"
+      - $ref: "./types.yaml#/components/parameters/size"
       responses:
         200:
           $ref: "./types.yaml#/components/responses/SearchResponse"
@@ -43,6 +38,7 @@ paths:
       operationId: getCollectionById
       parameters:
       - $ref: "./types.yaml#/components/parameters/id"
+      - $ref: "./types.yaml#/components/parameters/as"
       responses:
         200:
           $ref: "./types.yaml#/components/responses/DocumentResponse"
@@ -53,23 +49,9 @@ paths:
       - Collection
       parameters: 
       - $ref: "./types.yaml#/components/parameters/id"
-      - name: aspect
-        in: query
-        required: false
-        description: Desired aspect ratio
-        schema:
-          type: string
-          enum: 
-            - full
-            - square
-      - name: size
-        in: query
-        required: false
-        description: Size of largest dimension
-        schema:
-          type: integer
-          minimum: 1
-          maximum: 300
+      - $ref: "./types.yaml#/components/parameters/id"
+      - $ref: "./types.yaml#/components/parameters/thumbnailAspect"
+      - $ref: "./types.yaml#/components/parameters/thumbnailSize"
       responses:
         200:
           description: A thumbnail image for the given collection
@@ -98,6 +80,16 @@ paths:
       responses:
         200:
           $ref: "./types.yaml#/components/responses/DocumentResponse"
+  /works/{id}/similar:
+    get:
+      operationId: getSimilarWorks
+      tags:
+      - Work
+      parameters:
+      - $ref: "./types.yaml#/components/parameters/id"
+      - $ref: "./types.yaml#/components/parameters/page"
+      - $ref: "./types.yaml#/components/parameters/size"
+      - $ref: "./types.yaml#/components/parameters/as"
   /works/{id}/thumbnail:
     get:
       operationId: getWorkThumbnail
@@ -105,23 +97,8 @@ paths:
       - Work
       parameters: 
       - $ref: "./types.yaml#/components/parameters/id"
-      - name: aspect
-        in: query
-        required: false
-        description: Desired aspect ratio
-        schema:
-          type: string
-          enum: 
-            - full
-            - square
-      - name: size
-        in: query
-        required: false
-        description: Size of largest dimension
-        schema:
-          type: integer
-          minimum: 1
-          maximum: 300
+      - $ref: "./types.yaml#/components/parameters/thumbnailAspect"
+      - $ref: "./types.yaml#/components/parameters/thumbnailSize"
       responses:
         200:
           description: A thumbnail image for the given work
@@ -136,34 +113,11 @@ paths:
       tags:
       - Search
       parameters:
-      - name: query
-        in: query
-        required: false
-        description: Keyword query
-        schema:
-          type: string
-      - name: searchToken
-        in: query
-        required: false
-        description: Search token from previous search response
-        schema:
-          type: string
-      - name: page
-        in: query
-        required: false
-        description: Page number of results to retrieve
-        schema:
-          type: integer
-          minimum: 1
-      - name: as
-        in: query
-        required: false
-        description: Desired output format
-        schema:
-          type: string
-          enum:
-            - iiif
-            - opensearch
+        - $ref: "./types.yaml#/components/parameters/query"
+        - $ref: "./types.yaml#/components/parameters/searchToken"
+        - $ref: "./types.yaml#/components/parameters/page"
+        - $ref: "./types.yaml#/components/parameters/size"
+        - $ref: "./types.yaml#/components/parameters/as"
       responses:
         200:
           $ref: "./types.yaml#/components/responses/SearchResponse"
@@ -181,6 +135,19 @@ paths:
         200:
           $ref: "./types.yaml#/components/responses/SearchResponse"
   /search/{models}:
+    get:
+      operationId: getSearch
+      tags:
+      - Search
+      parameters:
+        - $ref: "./types.yaml#/components/parameters/query"
+        - $ref: "./types.yaml#/components/parameters/searchToken"
+        - $ref: "./types.yaml#/components/parameters/page"
+        - $ref: "./types.yaml#/components/parameters/size"
+        - $ref: "./types.yaml#/components/parameters/as"
+      responses:
+        200:
+          $ref: "./types.yaml#/components/responses/SearchResponse"
     post:
       operationId: postSearchWithModels
       tags:

--- a/docs/docs/spec/types.yaml
+++ b/docs/docs/spec/types.yaml
@@ -9,6 +9,65 @@ components:
       schema:
         type: string
         format: uuid
+    query:
+      name: query
+      in: query
+      required: false
+      description: Keyword query
+      schema:
+        type: string
+    searchToken:
+      name: searchToken
+      in: query
+      required: false
+      description: Search token from previous search response
+      schema:
+        type: string
+    page:
+      name: page
+      in: query
+      required: false
+      description: Page number of results to retrieve
+      schema:
+        type: integer
+        minimum: 1
+    size:
+      name: size
+      in: query
+      required: false
+      description: Maximum number of results per page
+      schema:
+        type: integer
+        minimum: 0
+    as:
+      name: as
+      in: query
+      required: false
+      description: Desired output format
+      schema:
+        type: string
+        enum:
+          - iiif
+          - opensearch
+    thumbnailAspect:
+      name: aspect
+      in: query
+      required: false
+      description: Desired aspect ratio
+      schema:
+        type: string
+        enum: 
+          - full
+          - square
+    thumbnailSize: 
+      name: size
+      in: query
+      required: false
+      description: Size of largest dimension
+      schema:
+        type: integer
+        minimum: 1
+        maximum: 300
   responses:
     DocumentResponse:
       description: A single document response

--- a/src/handlers/middleware.js
+++ b/src/handlers/middleware.js
@@ -3,10 +3,12 @@ const {
   decodeEventBody,
   normalizeHeaders,
   objectifyCookies,
+  stubEventMembers,
 } = require("../helpers");
 
 const processRequest = function (event) {
-  let result = normalizeHeaders(event);
+  let result = stubEventMembers(event);
+  result = normalizeHeaders(event);
   result = objectifyCookies(result);
   result = decodeEventBody(result);
   return result;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -102,6 +102,15 @@ function isFromReadingRoom(event) {
   return AllowedIPs.includes(sourceIp);
 }
 
+function stubEventMembers(event) {
+  event.headers ||= {};
+  event.pathParameters ||= {};
+  event.queryStringParameters ||= {};
+  event.stageVariables ||= {};
+  event.cookies ||= [];
+  return event;
+}
+
 module.exports = {
   addCorsHeaders,
   baseUrl,
@@ -109,4 +118,5 @@ module.exports = {
   isFromReadingRoom,
   normalizeHeaders,
   objectifyCookies,
+  stubEventMembers,
 };

--- a/test/test-helpers/event-builder.js
+++ b/test/test-helpers/event-builder.js
@@ -15,7 +15,6 @@ module.exports = class {
         "X-Forwarded-Port": "443",
         "X-Forwarded-Proto": "https",
       },
-      queryStringParameters: {},
       requestContext: {
         accountId: "123456789012",
         apiId: "pewpew",
@@ -35,9 +34,7 @@ module.exports = class {
         timeEpoch: Number(now),
       },
       body: "",
-      pathParameters: {},
       isBase64Encoded: false,
-      stageVariables: {},
     };
   }
 

--- a/test/unit/api/helpers.test.js
+++ b/test/unit/api/helpers.test.js
@@ -6,6 +6,7 @@ const {
   isFromReadingRoom,
   normalizeHeaders,
   objectifyCookies,
+  stubEventMembers,
 } = require("../../../src/helpers");
 const chai = require("chai");
 const expect = chai.expect;
@@ -198,6 +199,15 @@ describe("helpers", () => {
         testName: "works%20when%20there%20are%20cookies",
         cookieType: "snickerdoodle",
       });
+    });
+  });
+
+  describe("stubEventMembers", () => {
+    it("makes sure the event has all expected members", () => {
+      const result = stubEventMembers({});
+      expect(result.cookies).to.eql([]);
+      expect(result.pathParameters).to.eql({});
+      expect(result.queryStringParameters).to.eql({});
     });
   });
 });


### PR DESCRIPTION
`sam local` and API Gateway apparently differ in how the event object is built. `sam` makes sure _some_ (but not all) event properties like `cookies`, `pathParameters`, etc. exist even if they're empty. API Gateway leaves them undefined if they're not part of the request. This PR adds logic to the event-prep middleware to add them if they're missing.

Additional changes:
- Update swagger docs to include correct query parameters
- Add swagger entry for /works/{id}/similar