### PR TITLE
Fix 500 error in GET /collections

### DIFF
--- a/src/handlers/get-collections.js
+++ b/src/handlers/get-collections.js
@@ -1,9 +1,11 @@
 const { doSearch } = require("./search-runner");
+const { processRequest } = require("./middleware");
 
 /**
  * A simple function to get Collections
  */
 exports.handler = async (event) => {
+  event = processRequest(event);
   event.pathParameters.models = "collections";
   event.body = { query: { match_all: {} } };
   return doSearch(event, { includeToken: false });

--- a/src/handlers/middleware.js
+++ b/src/handlers/middleware.js
@@ -7,10 +7,12 @@ const {
 } = require("../helpers");
 
 const processRequest = function (event) {
+  if (event._processRequest) return event;
   let result = stubEventMembers(event);
   result = normalizeHeaders(event);
   result = objectifyCookies(result);
   result = decodeEventBody(result);
+  result._processRequest = true;
   return result;
 };
 

--- a/test/test-helpers/event-builder.js
+++ b/test/test-helpers/event-builder.js
@@ -102,20 +102,25 @@ module.exports = class {
       result.cookies = cookies.split(/;\s*/);
     }
 
-    result.pathParameters = { ...this._pathParams };
     result.rawPath = this._pathPrefix + this._route;
-    for (const param in result.pathParameters) {
-      result.rawPath = result.rawPath.replace(
-        `{${param}}`,
-        result.pathParameters[param]
-      );
-    }
     result.requestContext.http.path = result.rawPath;
 
-    result.queryStringParameters = { ...this._queryParams };
-    result.rawQueryString = new URLSearchParams(
-      result.queryStringParameters
-    ).toString();
+    if (this._pathParams) {
+      result.pathParameters = { ...this._pathParams };
+      for (const param in result.pathParameters) {
+        result.rawPath = result.rawPath.replace(
+          `{${param}}`,
+          result.pathParameters[param]
+        );
+      }
+    }
+
+    if (this._queryParams) {
+      result.queryStringParameters = { ...this._queryParams };
+      result.rawQueryString = new URLSearchParams(
+        result.queryStringParameters
+      ).toString();
+    }
 
     return result;
   }


### PR DESCRIPTION
- Leave optional members undefined in test event:
  - queryStringParameters, pathParameters, stageVariables, and cookies
- Make middleware.processRequest idempotent