### PR TITLE
Adds thumbnail to IIIF collection if it's an RDC Collection

### DIFF
--- a/src/api/response/iiif/collection.js
+++ b/src/api/response/iiif/collection.js
@@ -1,4 +1,4 @@
-const dcUrl = process.env.DC_URL || "http://placeholder-for-dc-url";
+const { dcApiEndpoint, dcUrl } = require("../../../aws/environment");
 
 async function transform(response, pager) {
   if (response.statusCode === 200) {
@@ -26,7 +26,7 @@ async function buildCollection(responseBody, pageInfo) {
     },
   } = pageInfo;
 
-  return {
+  result = {
     "@context": ["http://iiif.io/api/presentation/3/context.json"],
     id: collectionId(pageInfo),
     type: "Collection",
@@ -42,8 +42,29 @@ async function buildCollection(responseBody, pageInfo) {
         },
       },
     ],
+
     items: getItems(responseBody?.hits?.hits, pageInfo),
   };
+
+  if (pageInfo.options?.parameterOverrides) {
+    const collectionId = new URL(pageInfo.query_url).pathname
+      .split("/")
+      .reverse()[0];
+    thumbnailId = new URL(
+      `${dcApiEndpoint()}/collections/${collectionId}/thumbnail`
+    );
+    result.thumbnail = [
+      {
+        id: thumbnailId,
+        type: "Image",
+        format: "image/jpeg",
+        width: 400,
+        height: 400,
+      },
+    ];
+  }
+
+  return result;
 }
 
 function getItems(hits, pageInfo) {
@@ -77,9 +98,9 @@ function homepageUrl(pageInfo) {
     const collectionId = new URL(pageInfo.query_url).pathname
       .split("/")
       .reverse()[0];
-    result = new URL(`/collections/${collectionId}`, dcUrl);
+    result = new URL(`/collections/${collectionId}`, dcUrl());
   } else {
-    result = new URL("/search", dcUrl);
+    result = new URL("/search", dcUrl());
     if (pageInfo.options?.queryStringParameters?.query)
       result.searchParams.set(
         "q",
@@ -96,7 +117,7 @@ function loadItem(item) {
     type: "Manifest",
     homepage: [
       {
-        id: `${dcUrl}/items/${item.id}`,
+        id: new URL(`/items/${item.id}`, dcUrl()),
         type: "Text",
         format: "text/html",
         label: {
@@ -112,12 +133,12 @@ function loadItem(item) {
     },
     thumbnail: [
       {
-        id: [`${item.representative_file_set.url}/full/400,/0/default.jpg`],
+        id: `${item.representative_file_set.url}/full/400,/0/default.jpg`,
         service: [
           {
             profile: "http://iiif.io/api/image/2/level2.json",
             "@context": "http://iiif.io/api/image/2/context.json",
-            "@id": `${item.representative_file_set.url}`,
+            "@id": item.representative_file_set.url,
           },
         ],
         type: "Image",

--- a/src/api/response/iiif/collection.js
+++ b/src/api/response/iiif/collection.js
@@ -50,9 +50,7 @@ async function buildCollection(responseBody, pageInfo) {
     const collectionId = new URL(pageInfo.query_url).pathname
       .split("/")
       .reverse()[0];
-    thumbnailId = new URL(
-      `${dcApiEndpoint()}/collections/${collectionId}/thumbnail`
-    );
+    const thumbnailId = `${dcApiEndpoint()}/collections/${collectionId}/thumbnail`;
     result.thumbnail = [
       {
         id: thumbnailId,
@@ -133,14 +131,8 @@ function loadItem(item) {
     },
     thumbnail: [
       {
-        id: `${item.representative_file_set.url}/full/400,/0/default.jpg`,
-        service: [
-          {
-            profile: "http://iiif.io/api/image/2/level2.json",
-            "@context": "http://iiif.io/api/image/2/context.json",
-            "@id": item.representative_file_set.url,
-          },
-        ],
+        id: item.thumbnail,
+        format: "image/jpeg",
         type: "Image",
         width: 400,
         height: 400,

--- a/test/test-helpers/index.js
+++ b/test/test-helpers/index.js
@@ -6,6 +6,11 @@ const EventBuilder = require("./event-builder.js");
 function saveEnvironment() {
   const env = Object.assign({}, process.env);
 
+  beforeEach(function () {
+    process.env.DC_URL = "https://thisisafakedcurl";
+    process.env.DC_API_ENDPOINT = "https://thisisafakeapiurl";
+  });
+
   afterEach(function () {
     process.env = env;
   });


### PR DESCRIPTION
### Summary

We want to add the `thumbnail` property containing the API thumbnail route for the collection  (`/collection/id/thumbnail`) to the IIIF collection response if the request was for a RDC collection. (the request was `/collections/id?as=iiif` rather than `/search?query=foo&as=iiif`)

### How to test

- Invoke `/collections/id?as=iiif` route and look for thumbnail property
- Invoke `/search?query=foo&as=iiif` and observe that there is no thumbnail property