### PR TITLE
Adds /auth/logout handler

### DIFF
--- a/src/handlers/get-auth-logout.js
+++ b/src/handlers/get-auth-logout.js
@@ -1,0 +1,39 @@
+const axios = require("axios").default;
+const cookie = require("cookie");
+const { processRequest, processResponse } = require("./middleware");
+
+/**
+ * Performs NUSSO logout
+ */
+exports.handler = async (event) => {
+  event = processRequest(event);
+  const url = `${process.env.NUSSO_BASE_URL}logout`;
+  let resp;
+
+  await axios
+    .get(url, { headers: { apikey: process.env.NUSSO_API_KEY } })
+    .then((response) => {
+      resp = {
+        statusCode: 302,
+        cookies: [
+          cookie.serialize("dcApiV2Token", null, {
+            expires: new Date(1),
+            domain: "library.northwestern.edu",
+            path: "/",
+            secure: true,
+          }),
+        ],
+        headers: {
+          location: response.data.url,
+        },
+      };
+    })
+    .catch((error) => {
+      console.error("NUSSO request error", error);
+      resp = {
+        statusCode: 401,
+      };
+    });
+
+  return processResponse(event, resp);
+};

--- a/template.yaml
+++ b/template.yaml
@@ -97,6 +97,22 @@ Resources:
             ApiId: !Ref dcApi
             Path: /auth/login
             Method: GET
+  getAuthLogoutFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers/get-auth-logout.handler
+      Description: Performs NUSSO logout.
+      Environment:
+        Variables:
+          NUSSO_API_KEY: !Ref NussoApiKey
+          NUSSO_BASE_URL: !Ref NussoBaseUrl
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /auth/logout
+            Method: GET
   getAuthWhoAmIFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/test/integration/get-auth-logout.test.js
+++ b/test/integration/get-auth-logout.test.js
@@ -1,0 +1,29 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+const nock = require("nock");
+const getAuthLogoutHandler = require("../../src/handlers/get-auth-logout");
+
+describe("auth logout", function () {
+  helpers.saveEnvironment();
+
+  it("logs a user out of NU WebSSO and expires the dcApiV2Token", async () => {
+    process.env.NUSSO_BASE_URL = "https://nusso-base.com/";
+    process.env.NUSSO_API_KEY = "abc123";
+
+    const url = "https://test.com/northwestern#logout";
+    const _scope = nock(process.env.NUSSO_BASE_URL).get("/logout").reply(200, {
+      url: url,
+    });
+
+    const event = helpers.mockEvent("GET", "/auth/logout").render();
+
+    const result = await getAuthLogoutHandler.handler(event);
+    expect(result.statusCode).to.eq(302);
+    expect(result.headers.location).to.eq(url);
+    expect(result.cookies[0]).to.contain(
+      "Expires=Thu, 01 Jan 1970 00:00:00 GMT;"
+    );
+  });
+});


### PR DESCRIPTION
## Description

- Adds `/auth/logout` handler with tests
  - makes a `get` request to the NUSSO logout endpoint
  - expires the `dcApiV2Token` so that later to requests to `whoami` endpoint error out as expected
  
## Steps to test
- log in using `/auth/login` (I use `?goto=[dev env url]/auth/whoami`)
- log out using `/auth/logout` and make sure you land on the NU logout page
- double check the `auth/whoami` route to make sure the dcApiV2Token no longer returns your user data