### PR TITLE
Add support for the 'sort' query string parameter in GET searches

### DIFF
--- a/docs/docs/spec/openapi.yaml
+++ b/docs/docs/spec/openapi.yaml
@@ -11,7 +11,7 @@ info:
     name: NUL Repository Team
     email: repository@northwestern.edu
 servers:
-- url: https://dcapi.rdc.library.northwestern.edu/api/v2
+  - url: https://dcapi.rdc.library.northwestern.edu/api/v2
 tags:
   - name: Models
     description: >
@@ -24,21 +24,22 @@ paths:
     get:
       operationId: getCollections
       tags:
-      - Collection
+        - Collection
       parameters:
-      - $ref: "./types.yaml#/components/parameters/page"
-      - $ref: "./types.yaml#/components/parameters/size"
+        - $ref: "./types.yaml#/components/parameters/page"
+        - $ref: "./types.yaml#/components/parameters/size"
+        - $ref: "./types.yaml#/components/parameters/sort"
       responses:
         200:
           $ref: "./types.yaml#/components/responses/SearchResponse"
   /collections/{id}:
     get:
       tags:
-      - Collection
+        - Collection
       operationId: getCollectionById
       parameters:
-      - $ref: "./types.yaml#/components/parameters/id"
-      - $ref: "./types.yaml#/components/parameters/as"
+        - $ref: "./types.yaml#/components/parameters/id"
+        - $ref: "./types.yaml#/components/parameters/as"
       responses:
         200:
           $ref: "./types.yaml#/components/responses/DocumentResponse"
@@ -46,12 +47,12 @@ paths:
     get:
       operationId: getCollectionThumbnail
       tags:
-      - Collection
-      parameters: 
-      - $ref: "./types.yaml#/components/parameters/id"
-      - $ref: "./types.yaml#/components/parameters/id"
-      - $ref: "./types.yaml#/components/parameters/thumbnailAspect"
-      - $ref: "./types.yaml#/components/parameters/thumbnailSize"
+        - Collection
+      parameters:
+        - $ref: "./types.yaml#/components/parameters/id"
+        - $ref: "./types.yaml#/components/parameters/id"
+        - $ref: "./types.yaml#/components/parameters/thumbnailAspect"
+        - $ref: "./types.yaml#/components/parameters/thumbnailSize"
       responses:
         200:
           description: A thumbnail image for the given collection
@@ -64,9 +65,9 @@ paths:
     get:
       operationId: getFileSetById
       tags:
-      - FileSet
+        - FileSet
       parameters:
-      - $ref: "./types.yaml#/components/parameters/id"
+        - $ref: "./types.yaml#/components/parameters/id"
       responses:
         200:
           $ref: "./types.yaml#/components/responses/DocumentResponse"
@@ -74,9 +75,9 @@ paths:
     get:
       operationId: getWorkById
       tags:
-      - Work
+        - Work
       parameters:
-      - $ref: "./types.yaml#/components/parameters/id"
+        - $ref: "./types.yaml#/components/parameters/id"
       responses:
         200:
           $ref: "./types.yaml#/components/responses/DocumentResponse"
@@ -84,12 +85,13 @@ paths:
     get:
       operationId: getSimilarWorks
       tags:
-      - Work
+        - Work
       parameters:
-      - $ref: "./types.yaml#/components/parameters/id"
-      - $ref: "./types.yaml#/components/parameters/page"
-      - $ref: "./types.yaml#/components/parameters/size"
-      - $ref: "./types.yaml#/components/parameters/as"
+        - $ref: "./types.yaml#/components/parameters/id"
+        - $ref: "./types.yaml#/components/parameters/page"
+        - $ref: "./types.yaml#/components/parameters/size"
+        - $ref: "./types.yaml#/components/parameters/sort"
+        - $ref: "./types.yaml#/components/parameters/as"
       responses:
         200:
           $ref: "./types.yaml#/components/responses/SearchResponse"
@@ -97,11 +99,11 @@ paths:
     get:
       operationId: getWorkThumbnail
       tags:
-      - Work
-      parameters: 
-      - $ref: "./types.yaml#/components/parameters/id"
-      - $ref: "./types.yaml#/components/parameters/thumbnailAspect"
-      - $ref: "./types.yaml#/components/parameters/thumbnailSize"
+        - Work
+      parameters:
+        - $ref: "./types.yaml#/components/parameters/id"
+        - $ref: "./types.yaml#/components/parameters/thumbnailAspect"
+        - $ref: "./types.yaml#/components/parameters/thumbnailSize"
       responses:
         200:
           description: A thumbnail image for the given work
@@ -114,12 +116,13 @@ paths:
     get:
       operationId: getSearch
       tags:
-      - Search
+        - Search
       parameters:
         - $ref: "./types.yaml#/components/parameters/query"
         - $ref: "./types.yaml#/components/parameters/searchToken"
         - $ref: "./types.yaml#/components/parameters/page"
         - $ref: "./types.yaml#/components/parameters/size"
+        - $ref: "./types.yaml#/components/parameters/sort"
         - $ref: "./types.yaml#/components/parameters/as"
       responses:
         200:
@@ -127,13 +130,13 @@ paths:
     post:
       operationId: postSearch
       tags:
-      - Search
+        - Search
       requestBody:
         content:
           application/json:
             schema:
               type: object
-              
+
       responses:
         200:
           $ref: "./types.yaml#/components/responses/SearchResponse"
@@ -141,13 +144,14 @@ paths:
     get:
       operationId: getSearchWithModels
       tags:
-      - Search
+        - Search
       parameters:
         - $ref: "./types.yaml#/components/parameters/models"
         - $ref: "./types.yaml#/components/parameters/query"
         - $ref: "./types.yaml#/components/parameters/searchToken"
         - $ref: "./types.yaml#/components/parameters/page"
         - $ref: "./types.yaml#/components/parameters/size"
+        - $ref: "./types.yaml#/components/parameters/sort"
         - $ref: "./types.yaml#/components/parameters/as"
       responses:
         200:
@@ -155,11 +159,12 @@ paths:
     post:
       operationId: postSearchWithModels
       tags:
-      - Search
+        - Search
       parameters:
         - $ref: "./types.yaml#/components/parameters/models"
         - $ref: "./types.yaml#/components/parameters/page"
         - $ref: "./types.yaml#/components/parameters/size"
+        - $ref: "./types.yaml#/components/parameters/sort"
         - $ref: "./types.yaml#/components/parameters/as"
       responses:
         200:

--- a/docs/docs/spec/types.yaml
+++ b/docs/docs/spec/types.yaml
@@ -53,6 +53,13 @@ components:
       schema:
         type: integer
         minimum: 0
+    sort:
+      name: sort
+      in: query
+      required: false
+      description: Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc")
+      schema:
+        type: string
     as:
       name: as
       in: query
@@ -70,10 +77,10 @@ components:
       description: Desired aspect ratio
       schema:
         type: string
-        enum: 
+        enum:
           - full
           - square
-    thumbnailSize: 
+    thumbnailSize:
       name: size
       in: query
       required: false
@@ -100,8 +107,8 @@ components:
         application/json:
           schema:
             oneOf:
-            - $ref: "#/components/schemas/OpenSearchResponse"
-            - $ref: "#/components/schemas/IiifPresentationManifest"
+              - $ref: "#/components/schemas/OpenSearchResponse"
+              - $ref: "#/components/schemas/IiifPresentationManifest"
   schemas:
     IiifPresentationManifest:
       type: object

--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,6 +1802,22 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/diff": {
       "version": "5.0.0",
       "dev": true,
@@ -2706,6 +2722,14 @@
         "node": ">=10"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
@@ -3426,6 +3450,19 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sort-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.1.tgz",
+      "integrity": "sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==",
+      "dependencies": {
+        "detect-indent": "^5.0.0",
+        "detect-newline": "^2.1.0",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "sort-json": "app/cmd.js"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
@@ -3831,7 +3868,8 @@
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
         "lz-string": "^1.4.4",
-        "parse-http-header": "^1.0.1"
+        "parse-http-header": "^1.0.1",
+        "sort-json": "^2.0.1"
       }
     }
   },
@@ -5058,7 +5096,8 @@
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
         "lz-string": "^1.4.4",
-        "parse-http-header": "^1.0.1"
+        "parse-http-header": "^1.0.1",
+        "sort-json": "^2.0.1"
       }
     },
     "debug": {
@@ -5094,6 +5133,16 @@
     },
     "delayed-stream": {
       "version": "1.0.0"
+    },
+    "detect-indent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g=="
+    },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg=="
     },
     "diff": {
       "version": "5.0.0",
@@ -5663,6 +5712,11 @@
         "brace-expansion": "^1.1.7"
       }
     },
+    "minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+    },
     "mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
@@ -6128,6 +6182,16 @@
     "signal-exit": {
       "version": "3.0.7",
       "dev": true
+    },
+    "sort-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.1.tgz",
+      "integrity": "sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==",
+      "requires": {
+        "detect-indent": "^5.0.0",
+        "detect-newline": "^2.1.0",
+        "minimist": "^1.2.0"
+      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/src/api/request/pipeline.js
+++ b/src/api/request/pipeline.js
@@ -1,4 +1,5 @@
 const { isFromReadingRoom } = require("../../helpers");
+const sortJson = require("sort-json");
 
 function filterFor(query, event) {
   const matchTheQuery = query;
@@ -32,6 +33,6 @@ module.exports = class RequestPipeline {
   }
 
   toJson() {
-    return JSON.stringify(this.searchContext);
+    return JSON.stringify(sortJson(this.searchContext));
   }
 };

--- a/src/handlers/search-runner.js
+++ b/src/handlers/search-runner.js
@@ -86,37 +86,42 @@ const constructSearchContext = async (event) => {
   searchContext.size = queryStringParameters.size || searchContext.size || 10;
   searchContext.from = queryStringParameters.from || searchContext.from || 0;
 
+  if (queryStringParameters?.sort || searchContext.sort)
+    searchContext.sort =
+      parseSortParameter(queryStringParameters) || searchContext.sort;
+
   if (queryStringParameters.page) {
     const page = Number(queryStringParameters.page || 1);
     const size = Number(queryStringParameters.size || 10);
     searchContext.from = (page - 1) * size;
   }
 
-  // if (queryStringParameters.sort) {
-  //   //TODO
-  // }
-
   return searchContext;
 };
 
-const fromQueryString = ({ queryStringParameters, requestContext }) => {
-  if (queryStringParameters?.query) {
-    return {
-      query: {
-        query_string: {
-          query: queryStringParameters.query,
-        },
+const fromQueryString = ({ queryStringParameters, _requestContext }) => {
+  let request = {
+    query: {
+      query_string: {
+        query: queryStringParameters?.query || "*",
       },
-    };
-  } else {
-    return {
-      query: {
-        query_string: {
-          query: "*",
-        },
-      },
-    };
+    },
+  };
+  return request;
+};
+
+const parseSortParameter = ({ sort: sortString }) => {
+  if (sortString == undefined) return null;
+  let values = [];
+
+  for (const el of sortString.split(",")) {
+    let obj = {};
+    const [key, value] = el.split(":");
+    obj[key] = value;
+    values.push(obj);
   }
+
+  return values;
 };
 
 const responseFormat = async (event) => {

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -19,7 +19,8 @@
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
         "lz-string": "^1.4.4",
-        "parse-http-header": "^1.0.1"
+        "parse-http-header": "^1.0.1",
+        "sort-json": "^2.0.1"
       }
     },
     "node_modules/@aws-crypto/ie11-detection": {
@@ -1119,6 +1120,22 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-indent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -1304,6 +1321,14 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
@@ -1392,6 +1417,19 @@
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/sort-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.1.tgz",
+      "integrity": "sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==",
+      "dependencies": {
+        "detect-indent": "^5.0.0",
+        "detect-newline": "^2.1.0",
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "sort-json": "app/cmd.js"
       }
     },
     "node_modules/tiny-invariant": {
@@ -2473,6 +2511,16 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
+    "detect-indent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
+      "integrity": "sha512-rlpvsxUtM0PQvy9iZe640/IWwWYyBsTApREbA1pHOpmOUIl9MkP/U4z7vTtg4Oaojvqhxt7sdufnT0EzGaR31g=="
+    },
+    "detect-newline": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-2.1.0.tgz",
+      "integrity": "sha512-CwffZFvlJffUg9zZA0uqrjQayUTC8ob94pnr5sFwaVv3IOmkfUHcWH+jXaQK3askE51Cqe8/9Ql/0uXNwqZ8Zg=="
+    },
     "ecdsa-sig-formatter": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
@@ -2612,6 +2660,11 @@
         "mime-db": "1.52.0"
       }
     },
+    "minimist": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
+      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g=="
+    },
     "mitt": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.0.tgz",
@@ -2664,6 +2717,16 @@
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
       "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+    },
+    "sort-json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.1.tgz",
+      "integrity": "sha512-s8cs2bcsQCzo/P2T/uoU6Js4dS/jnX8+4xunziNoq9qmSpZNCrRIAIvp4avsz0ST18HycV4z/7myJ7jsHWB2XQ==",
+      "requires": {
+        "detect-indent": "^5.0.0",
+        "detect-newline": "^2.1.0",
+        "minimist": "^1.2.0"
+      }
     },
     "tiny-invariant": {
       "version": "1.3.1",

--- a/src/package.json
+++ b/src/package.json
@@ -16,6 +16,7 @@
     "iiif-builder": "^1.0.6",
     "jsonwebtoken": "^8.5.1",
     "lz-string": "^1.4.4",
-    "parse-http-header": "^1.0.1"
+    "parse-http-header": "^1.0.1",
+    "sort-json": "^2.0.1"
   }
 }

--- a/test/test-helpers/event-builder.js
+++ b/test/test-helpers/event-builder.js
@@ -1,3 +1,5 @@
+const sortJson = require("sort-json");
+
 module.exports = class {
   constructor(method, route) {
     const now = new Date();
@@ -116,6 +118,6 @@ module.exports = class {
       ).toString();
     }
 
-    return result;
+    return sortJson(result);
   }
 };


### PR DESCRIPTION
Steps to test:

- Index some works
- Perform a `GET` search with the `sort` query string parameter, e.g.
`https://[YOUR ENVIRONMENT]/search?sort=create_date:desc,accession_number:desc`
- Switch the sort direction to see the results change order
Note: ElasticSearch only supports sorting `keyword` fields so you'll get errors if you try to sort a `text` field such as `title`