### PR TITLE
Don't return unpublished file sets

### DIFF
--- a/src/api/opensearch.js
+++ b/src/api/opensearch.js
@@ -44,10 +44,7 @@ function isVisible(doc, { allowPrivate, allowUnpublished }) {
   if (!doc?.found) return false;
   const isAllowedVisibility =
     allowPrivate || doc?._source.visibility !== "Private";
-  const isAllowedPublished =
-    allowUnpublished ||
-    doc?._source.published ||
-    doc?._source.api_model == "FileSet";
+  const isAllowedPublished = allowUnpublished || doc?._source.published;
   return isAllowedVisibility && isAllowedPublished;
 }
 

--- a/test/fixtures/mocks/fileset-1234.json
+++ b/test/fixtures/mocks/fileset-1234.json
@@ -6,6 +6,8 @@
   "found": true,
   "_source": {
     "id": "1234",
-    "api_model": "FileSet"
+    "api_model": "FileSet",
+    "visibility": "Public",
+    "published": true
   }
 }


### PR DESCRIPTION
### Summary

We had been returning unpublished file sets in searches as we didn't have published indexed on file sets. Now we do.

### How to test

- In dev, make an API request to `/search/file-sets`.
- It should not contain unpublished file sets
