### PR TITLE
Refactor JWT auth for reading room, shared links, thumbnails and new data shape

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2585,7 +2585,6 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.flattendeep": {
@@ -2612,11 +2611,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
-    "node_modules/lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -3888,7 +3882,7 @@
         "cookie": "^0.5.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
-        "lodash.isobject": "^3.0.2",
+        "lodash": "^4.17.21",
         "lz-string": "^1.4.4",
         "parse-http-header": "^1.0.1",
         "sort-json": "^2.0.1",
@@ -5118,7 +5112,7 @@
         "cookie": "^0.5.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
-        "lodash.isobject": "^3.0.2",
+        "lodash": "^4.17.21",
         "lz-string": "^1.4.4",
         "parse-http-header": "^1.0.1",
         "sort-json": "^2.0.1",
@@ -5640,8 +5634,7 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "dev": true
+      "version": "4.17.21"
     },
     "lodash.flattendeep": {
       "version": "4.4.0",
@@ -5666,11 +5659,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
-    "lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/src/api/api-token.js
+++ b/src/api/api-token.js
@@ -1,0 +1,100 @@
+const { apiTokenSecret, dcApiEndpoint } = require("../environment");
+const jwt = require("jsonwebtoken");
+
+class ApiToken {
+  constructor(signedToken) {
+    if (signedToken) {
+      this.token = jwt.verify(signedToken, apiTokenSecret());
+      this.token.entitlements = new Set(this.token.entitlements || []);
+    } else {
+      this.token = {
+        iss: dcApiEndpoint(),
+        exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60, // 12 hours
+        iat: Math.floor(Number(new Date()) / 1000),
+        entitlements: new Set(),
+        isLoggedIn: false,
+      };
+    }
+  }
+
+  // manipulation – always return `this` for chaining
+
+  user(user) {
+    this.token = {
+      ...this.token,
+      sub: user?.uid,
+      name: user?.displayName?.[0],
+      email: user?.mail,
+      isLoggedIn: !!user,
+    };
+
+    return this;
+  }
+
+  readingRoom() {
+    this.token.isReadingRoom = true;
+    return this;
+  }
+
+  superUser() {
+    this.token.isSuperUser = true;
+    return this;
+  }
+
+  // add, remove, and replace entitlements
+
+  addEntitlement(entitlement) {
+    this.token.entitlements.add(entitlement);
+
+    return this;
+  }
+
+  entitlements(entitlements) {
+    this.token = {
+      ...this.token,
+      entitlements: new Set(entitlements),
+    };
+    return this;
+  }
+
+  removeEntitlement(entitlement) {
+    this.token.entitlements.delete(entitlement);
+    return this;
+  }
+
+  // serialization methods
+
+  userInfo() {
+    const result = { ...this.token };
+    delete result.entitlements;
+    return result;
+  }
+
+  sign() {
+    const result = {
+      ...this.token,
+      entitlements: [...this.token.entitlements],
+    };
+    return jwt.sign(result, apiTokenSecret());
+  }
+
+  // boolean checks
+
+  hasEntitlement(entitlement) {
+    return this.token.entitlements.has(entitlement);
+  }
+
+  isLoggedIn() {
+    return this.token.isLoggedIn;
+  }
+
+  isReadingRoom() {
+    return this.token.isReadingRoom;
+  }
+
+  isSuperUser() {
+    return this.token.isSuperUser;
+  }
+}
+
+module.exports = ApiToken;

--- a/src/api/opensearch.js
+++ b/src/api/opensearch.js
@@ -1,6 +1,6 @@
 const { HttpRequest } = require("@aws-sdk/protocol-http");
 const { awsFetch } = require("../aws/fetch");
-const { elasticsearchEndpoint, prefix } = require("../aws/environment");
+const { elasticsearchEndpoint, prefix } = require("../environment");
 
 async function getCollection(id, opts) {
   return getDocument("dc-v2-collection", id, opts);
@@ -23,6 +23,7 @@ async function getDocument(index, id, opts = {}) {
   let response = await awsFetch(request);
   if (response.statusCode === 200) {
     const body = JSON.parse(response.body);
+
     if (index != "shared_links" && !isVisible(body, opts)) {
       let responseBody = {
         _index: prefix(index),
@@ -37,6 +38,7 @@ async function getDocument(index, id, opts = {}) {
       };
     }
   }
+
   return response;
 }
 
@@ -45,6 +47,7 @@ function isVisible(doc, { allowPrivate, allowUnpublished }) {
   const isAllowedVisibility =
     allowPrivate || doc?._source.visibility !== "Private";
   const isAllowedPublished = allowUnpublished || doc?._source.published;
+
   return isAllowedVisibility && isAllowedPublished;
 }
 

--- a/src/api/request/models.js
+++ b/src/api/request/models.js
@@ -1,4 +1,4 @@
-const { prefix } = require("../../aws/environment");
+const { prefix } = require("../../environment");
 
 const mapTargets = {
   works: "dc-v2-work",

--- a/src/api/request/pipeline.js
+++ b/src/api/request/pipeline.js
@@ -1,12 +1,12 @@
-const { isFromReadingRoom } = require("../../helpers");
 const sortJson = require("sort-json");
+const ApiToken = require("../api-token");
 
 function filterFor(query, event) {
   const matchTheQuery = query;
   const beUnpublished = { term: { published: false } };
   const beRestricted = { term: { visibility: "Private" } };
 
-  const filter = isFromReadingRoom(event)
+  const filter = event.userToken.isReadingRoom()
     ? { must: [matchTheQuery], must_not: [beUnpublished] }
     : { must: [matchTheQuery], must_not: [beUnpublished, beRestricted] };
 

--- a/src/api/response/iiif/collection.js
+++ b/src/api/response/iiif/collection.js
@@ -1,4 +1,4 @@
-const { dcApiEndpoint, dcUrl } = require("../../../aws/environment");
+const { dcApiEndpoint, dcUrl } = require("../../../environment");
 
 async function transform(response, pager) {
   if (response.statusCode === 200) {

--- a/src/api/response/iiif/manifest.js
+++ b/src/api/response/iiif/manifest.js
@@ -1,5 +1,5 @@
 const { IIIFBuilder } = require("iiif-builder");
-const { dcApiEndpoint, dcUrl } = require("../../../aws/environment");
+const { dcApiEndpoint, dcUrl } = require("../../../environment");
 const {
   buildAnnotationBody,
   buildImageResourceId,

--- a/src/aws/fetch.js
+++ b/src/aws/fetch.js
@@ -2,7 +2,7 @@ const { defaultProvider } = require("@aws-sdk/credential-provider-node");
 const { SignatureV4 } = require("@aws-sdk/signature-v4");
 const { NodeHttpHandler } = require("@aws-sdk/node-http-handler");
 const { Sha256 } = require("@aws-crypto/sha256-browser");
-const region = require("./environment").region();
+const region = require("../environment").region();
 
 async function awsFetch(request) {
   const signer = new SignatureV4({

--- a/src/environment.js
+++ b/src/environment.js
@@ -9,6 +9,14 @@ function apiToken() {
   return jwt.sign(token, process.env.API_TOKEN_SECRET);
 }
 
+function apiTokenName() {
+  return process.env.API_TOKEN_NAME;
+}
+
+function apiTokenSecret() {
+  return process.env.API_TOKEN_SECRET;
+}
+
 function dcApiEndpoint() {
   return process.env.DC_API_ENDPOINT;
 }
@@ -33,6 +41,8 @@ function region() {
 
 module.exports = {
   apiToken,
+  apiTokenName,
+  apiTokenSecret,
   dcApiEndpoint,
   dcUrl,
   elasticsearchEndpoint,

--- a/src/handlers/get-auth-callback.js
+++ b/src/handlers/get-auth-callback.js
@@ -1,7 +1,7 @@
 const axios = require("axios").default;
 const cookie = require("cookie");
-const jwt = require("jsonwebtoken");
 const { processRequest, processResponse } = require("./middleware");
+const ApiToken = require("../api/api-token");
 
 const BAD_DIRECTORY_SEARCH_FAULT =
   /Reason: ResponseCode 404 is treated as error/;
@@ -20,15 +20,11 @@ exports.handler = async (event) => {
   const user = await redeemSsoToken(event);
   let response;
   if (user) {
-    const token = jwt.sign(user, process.env.API_TOKEN_SECRET);
+    event.userToken = new ApiToken().user(user);
+    event._userTokenUpdated = true;
     response = {
       statusCode: 302,
       cookies: [
-        cookie.serialize("dcApiV2Token", token, {
-          domain: "library.northwestern.edu",
-          path: "/",
-          secure: true,
-        }),
         cookie.serialize("redirectUrl", null, {
           expires: new Date(1),
         }),

--- a/src/handlers/get-auth-login.js
+++ b/src/handlers/get-auth-login.js
@@ -1,4 +1,4 @@
-const { dcApiEndpoint } = require("../aws/environment");
+const { dcApiEndpoint, apiTokenSecret } = require("../environment");
 const axios = require("axios").default;
 const cookie = require("cookie");
 const { processRequest, processResponse } = require("./middleware");

--- a/src/handlers/get-auth-logout.js
+++ b/src/handlers/get-auth-logout.js
@@ -1,6 +1,7 @@
 const axios = require("axios").default;
 const cookie = require("cookie");
 const { processRequest, processResponse } = require("./middleware");
+const ApiToken = require("../api/api-token");
 
 /**
  * Performs NUSSO logout
@@ -15,18 +16,12 @@ exports.handler = async (event) => {
     .then((response) => {
       resp = {
         statusCode: 302,
-        cookies: [
-          cookie.serialize("dcApiV2Token", null, {
-            expires: new Date(1),
-            domain: "library.northwestern.edu",
-            path: "/",
-            secure: true,
-          }),
-        ],
         headers: {
           location: response.data.url,
         },
       };
+      event.userToken = new ApiToken();
+      event._userTokenUpdated = true;
     })
     .catch((error) => {
       console.error("NUSSO request error", error);

--- a/src/handlers/get-auth-whoami.js
+++ b/src/handlers/get-auth-whoami.js
@@ -1,15 +1,14 @@
-const jwt = require("jsonwebtoken");
 const { processRequest, processResponse } = require("./middleware");
 
 /**
- * NUSSO whoami - validates JWT and returns user info
+ * Whoami - validates JWT and returns user info, or issues an anonymous
+ * token if none is present
  */
 exports.handler = async (event) => {
   event = processRequest(event);
 
   try {
-    const token = event.cookieObject.dcApiV2Token;
-    const user = jwt.verify(token, process.env.API_TOKEN_SECRET);
+    const token = event.userToken;
 
     const response = {
       statusCode: 200,
@@ -19,8 +18,9 @@ exports.handler = async (event) => {
         "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
         "Access-Control-Allow-Credentials": "true",
       },
-      body: JSON.stringify(user),
+      body: JSON.stringify(token.userInfo()),
     };
+
     return processResponse(event, response);
   } catch (error) {
     return {

--- a/src/handlers/get-file-set-by-id.js
+++ b/src/handlers/get-file-set-by-id.js
@@ -1,6 +1,5 @@
 const { processRequest, processResponse } = require("./middleware");
 const { getFileSet } = require("../api/opensearch");
-const { isFromReadingRoom } = require("../helpers");
 const opensearchResponse = require("../api/response/opensearch");
 
 /**
@@ -9,7 +8,7 @@ const opensearchResponse = require("../api/response/opensearch");
 exports.handler = async (event) => {
   event = processRequest(event);
   const id = event.pathParameters.id;
-  const allowPrivate = isFromReadingRoom(event);
+  const allowPrivate = event.userToken.isReadingRoom();
   const esResponse = await getFileSet(id, { allowPrivate });
   const response = await opensearchResponse.transform(esResponse);
   return processResponse(event, response);

--- a/src/handlers/get-shared-link-by-id.js
+++ b/src/handlers/get-shared-link-by-id.js
@@ -1,6 +1,9 @@
 const { processRequest, processResponse } = require("./middleware");
 const { getSharedLink, getWork } = require("../api/opensearch");
 const opensearchResponse = require("../api/response/opensearch");
+const { apiTokenName } = require("../environment");
+const ApiToken = require("../api/api-token");
+const cookie = require("cookie");
 
 /**
  * Get a shared link document by id
@@ -21,7 +24,13 @@ exports.handler = async (event) => {
     allowUnpublished: true,
   });
   if (workResponse.statusCode !== 200) return invalidRequest("Not Found");
-  const response = opensearchResponse.transform(workResponse);
+  const response = await opensearchResponse.transform(workResponse);
+
+  // add entitlement for the work id
+  // TODO make part of request/response processing
+  event.userToken.addEntitlement(workId);
+  event._userTokenUpdated = true;
+
   return processResponse(event, response);
 };
 

--- a/src/handlers/get-work-by-id.js
+++ b/src/handlers/get-work-by-id.js
@@ -1,6 +1,5 @@
 const { processRequest, processResponse } = require("./middleware");
 const { getWork } = require("../api/opensearch");
-const { isFromReadingRoom } = require("../helpers");
 
 const manifestResponse = require("../api/response/iiif/manifest");
 const opensearchResponse = require("../api/response/opensearch");
@@ -11,8 +10,12 @@ const opensearchResponse = require("../api/response/opensearch");
 exports.handler = async (event) => {
   event = processRequest(event);
   const id = event.pathParameters.id;
-  const allowPrivate = isFromReadingRoom(event);
-  const esResponse = await getWork(id, { allowPrivate });
+
+  const allowPrivate =
+    event.userToken.isReadingRoom() || event.userToken.hasEntitlement(id);
+  const allowUnpublished = event.userToken.hasEntitlement(id);
+
+  const esResponse = await getWork(id, { allowPrivate, allowUnpublished });
 
   let response;
   const as = event.queryStringParameters.as;

--- a/src/handlers/middleware.js
+++ b/src/handlers/middleware.js
@@ -1,6 +1,8 @@
 const {
   addCorsHeaders,
   decodeEventBody,
+  decodeToken,
+  encodeToken,
   ensureCharacterEncoding,
   normalizeHeaders,
   objectifyCookies,
@@ -13,12 +15,14 @@ const processRequest = function (event) {
   result = normalizeHeaders(event);
   result = objectifyCookies(result);
   result = decodeEventBody(result);
+  result = decodeToken(result);
   result._processRequest = true;
   return result;
 };
 
 const processResponse = function (event, response) {
   let result = addCorsHeaders(event, response);
+  result = encodeToken(event, result);
   result = ensureCharacterEncoding(result, "UTF-8");
   return result;
 };

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -18,7 +18,7 @@
         "cookie": "^0.5.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
-        "lodash.isobject": "^3.0.2",
+        "lodash": "^4.17.21",
         "lz-string": "^1.4.4",
         "parse-http-header": "^1.0.1",
         "sort-json": "^2.0.1",
@@ -1261,6 +1261,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -1280,11 +1285,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
-    "node_modules/lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA=="
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
@@ -2630,6 +2630,11 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
     "lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -2649,11 +2654,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw=="
-    },
-    "lodash.isobject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
-      "integrity": "sha512-3/Qptq2vr7WeJbB4KHUSKlq8Pl7ASXi3UG6CMbBm8WRtXi8+GHm7mKaU3urfpSEzWe2wCIChs6/sdocUsTKJiA=="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",

--- a/src/package.json
+++ b/src/package.json
@@ -15,7 +15,7 @@
     "cookie": "^0.5.0",
     "iiif-builder": "^1.0.6",
     "jsonwebtoken": "^8.5.1",
-    "lodash.isobject": "^3.0.2",
+    "lodash": "^4.17.21",
     "lz-string": "^1.4.4",
     "parse-http-header": "^1.0.1",
     "sort-json": "^2.0.1",

--- a/template.yaml
+++ b/template.yaml
@@ -15,12 +15,20 @@ Globals:
     Timeout: 3
     Environment:
       Variables:
+        API_TOKEN_NAME: !Ref ApiTokenName
+        API_TOKEN_SECRET: !Ref ApiTokenSecret
         DC_API_ENDPOINT: !Ref DcApiEndpoint
         DC_URL: !Ref DcUrl
         ELASTICSEARCH_ENDPOINT: !Ref ElasticsearchEndpoint
         ENV_PREFIX: !Ref EnvironmentPrefix
         READING_ROOM_IPS: !Ref ReadingRoomIPs
 Parameters:
+  ApiTokenName:
+    Type: String
+    Description: Name of the jwt that DC API issues
+  ApiTokenSecret:
+    Type: String
+    Description: Name of the jwt that DC API issues
   ApiSecret:
     Type: String
     Description: Secret Key for Encrypting JWTs (must match IIIF server)

--- a/test/fixtures/mocks/fileset-restricted-unpublished-1234.json
+++ b/test/fixtures/mocks/fileset-restricted-unpublished-1234.json
@@ -8,6 +8,7 @@
     "id": "1234",
     "api_model": "FileSet",
     "visibility": "Private",
-    "published": false
+    "published": false,
+    "work_id": "756ea5b9-8ca1-4bd7-a70e-4b2082dd0440"
   }
 }

--- a/test/fixtures/mocks/private-unpublished-work-1234.json
+++ b/test/fixtures/mocks/private-unpublished-work-1234.json
@@ -8,6 +8,10 @@
     "id": "1234",
     "api_model": "Work",
     "published": false,
-    "visibility": "Private"
+    "visibility": "Private",
+    "representative_file_set": {
+      "fileSetId": "5678",
+      "url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/5678"
+    }
   }
 }

--- a/test/integration/get-auth-callback.test.js
+++ b/test/integration/get-auth-callback.test.js
@@ -1,21 +1,16 @@
 "use strict";
 
 const chai = require("chai");
-const cookie = require("cookie");
 const expect = chai.expect;
-const jwt = require("jsonwebtoken");
 const nock = require("nock");
 const getAuthCallbackHandler = require("../../src/handlers/get-auth-callback");
+const ApiToken = require("../../src/api/api-token");
 
 describe("auth callback", function () {
   helpers.saveEnvironment();
 
   let event;
   beforeEach(() => {
-    process.env.NUSSO_BASE_URL = "https://nusso-base.com/";
-    process.env.NUSSO_API_KEY = "abc123";
-    process.env.API_TOKEN_SECRET = "abc123";
-
     event = helpers
       .mockEvent("GET", "/auth/callback")
       .headers({
@@ -32,7 +27,7 @@ describe("auth callback", function () {
     nock(process.env.NUSSO_BASE_URL)
       .get("/validate-with-directory-search-response")
       .reply(200, {
-        results: [{ displayName: ["Some User"] }],
+        results: [{ uid: "uid123", displayName: ["Some User"] }],
       });
 
     const result = await getAuthCallbackHandler.handler(event);
@@ -40,12 +35,16 @@ describe("auth callback", function () {
     expect(result.statusCode).to.eq(302);
     expect(result.headers.location).to.eq("https://example.com");
 
-    const { dcApiV2Token } = cookie.parse(result.cookies[0]);
-    const token = jwt.verify(dcApiV2Token, process.env.API_TOKEN_SECRET);
-    expect(token).to.deep.include({
-      displayName: ["Some User"],
-      uid: "uid123",
-    });
+    const dcApiCookie = helpers.cookieValue(
+      result.cookies,
+      process.env.API_TOKEN_NAME
+    );
+
+    const apiToken = new ApiToken(dcApiCookie);
+
+    expect(apiToken.token.sub).to.eq("uid123");
+    expect(apiToken.token.name).to.eq("Some User");
+    expect(apiToken.isLoggedIn()).to.be.true;
   });
 
   it("assembles a user object from the netID if directory search fails", async () => {
@@ -68,12 +67,16 @@ describe("auth callback", function () {
       "redirectUrl=null; Expires=Thu, 01 Jan 1970 00:00:00 GMT"
     );
 
-    const { dcApiV2Token } = cookie.parse(result.cookies[0]);
-    const token = jwt.verify(dcApiV2Token, process.env.API_TOKEN_SECRET);
-    expect(token).to.deep.include({
-      displayName: ["uid123"],
-      mail: "uid123@e.northwestern.edu",
-      uid: "uid123",
-    });
+    const dcApiCookie = helpers.cookieValue(
+      result.cookies,
+      process.env.API_TOKEN_NAME
+    );
+
+    const apiToken = new ApiToken(dcApiCookie);
+
+    expect(apiToken.token.sub).to.eq("uid123");
+    expect(apiToken.token.name).to.eq("uid123");
+    expect(apiToken.token.email).to.eq("uid123@e.northwestern.edu");
+    expect(apiToken.isLoggedIn()).to.be.true;
   });
 });

--- a/test/integration/get-auth-logout.test.js
+++ b/test/integration/get-auth-logout.test.js
@@ -4,26 +4,33 @@ const chai = require("chai");
 const expect = chai.expect;
 const nock = require("nock");
 const getAuthLogoutHandler = require("../../src/handlers/get-auth-logout");
+const ApiToken = require("../../src/api/api-token");
 
 describe("auth logout", function () {
   helpers.saveEnvironment();
 
-  it("logs a user out of NU WebSSO and expires the dcApiV2Token", async () => {
+  it("logs a user out of NU WebSSO and expires the DC API Token", async () => {
     process.env.NUSSO_BASE_URL = "https://nusso-base.com/";
     process.env.NUSSO_API_KEY = "abc123";
 
     const url = "https://test.com/northwestern#logout";
-    const _scope = nock(process.env.NUSSO_BASE_URL).get("/logout").reply(200, {
+    nock(process.env.NUSSO_BASE_URL).get("/logout").reply(200, {
       url: url,
     });
 
     const event = helpers.mockEvent("GET", "/auth/logout").render();
 
     const result = await getAuthLogoutHandler.handler(event);
+
+    const dcApiCookie = helpers.cookieValue(
+      result.cookies,
+      process.env.API_TOKEN_NAME
+    );
+
+    const apiToken = new ApiToken(dcApiCookie);
     expect(result.statusCode).to.eq(302);
     expect(result.headers.location).to.eq(url);
-    expect(result.cookies[0]).to.contain(
-      "Expires=Thu, 01 Jan 1970 00:00:00 GMT;"
-    );
+    expect(apiToken.token.sub).to.not.exist;
+    expect(apiToken.token.isLoggedIn).to.be.false;
   });
 });

--- a/test/integration/get-auth-whoami.test.js
+++ b/test/integration/get-auth-whoami.test.js
@@ -3,35 +3,80 @@
 const chai = require("chai");
 const expect = chai.expect;
 const getAuthWhoamiHandler = require("../../src/handlers/get-auth-whoami");
+const jwt = require("jsonwebtoken");
+const ApiToken = require("../../src/api/api-token");
+const { processRequest } = require("../../src/handlers/middleware");
 
 describe("auth whoami", function () {
   helpers.saveEnvironment();
 
-  it("redeems a valid NUSSO token", async () => {
-    process.env.API_TOKEN_SECRET = "abc123";
+  it("redeems a valid NUSSO token for user info", async () => {
+    const payload = {
+      iss: "https://example.com",
+      sub: "user123",
+      name: "Some One",
+      exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
+      iat: Math.floor(Number(new Date()) / 1000),
+      email: "user@example.com",
+    };
+    const token = jwt.sign(payload, process.env.API_TOKEN_SECRET);
 
     const event = helpers
       .mockEvent("GET", "/auth/whoami")
       .headers({
-        Cookie:
-          "dcApiV2Token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJkaXNwbGF5TmFtZSI6IlNvbWUgT25lIiwiaWF0IjoxNjY1NDE3NzYzfQ.Nwi8dJnc7w201ZtO5de5zYmU-F5gEalkmHZ5pR1VXms;",
+        Cookie: `${process.env.API_TOKEN_NAME}=${token};`,
       })
       .render();
 
     const result = await getAuthWhoamiHandler.handler(event);
     expect(result.statusCode).to.eq(200);
-    expect(JSON.parse(result.body)).to.contain({ displayName: "Some One" });
+    expect(JSON.parse(result.body)).to.contain({ name: "Some One" });
   });
 
-  it("rejects an invalid or missing NUSSO token", async () => {
-    process.env.API_TOKEN_SECRET = "abc123";
+  it("Replaces an expired token with an anonymous token", async () => {
+    const payload = {
+      iss: "https://example.com",
+      sub: "user123",
+      name: "Some One",
+      exp: Math.floor(Number(new Date()) / 1000),
+      iat: Math.floor(Number(new Date()) / 1000),
+      email: "user@example.com",
+    };
+    const token = jwt.sign(payload, process.env.API_TOKEN_SECRET);
 
+    const event = helpers
+      .mockEvent("GET", "/auth/whoami")
+      .headers({
+        Cookie: `${process.env.API_TOKEN_NAME}=${token};`,
+      })
+      .render();
+
+    const result = await getAuthWhoamiHandler.handler(event);
+    expect(result.statusCode).to.eq(200);
+    expect(JSON.parse(result.body)).not.to.contain({
+      sub: "user123",
+    });
+  });
+
+  it("Issues an anonymous API token if no token is present", async () => {
     const event = helpers.mockEvent("GET", "/auth/whoami").render();
 
     const result = await getAuthWhoamiHandler.handler(event);
-    expect(result.statusCode).to.eq(401);
-    expect(result.body).to.eq(
-      "Error verifying API token: jwt must be provided"
+    const dcApiCookie = helpers.cookieValue(
+      result.cookies,
+      process.env.API_TOKEN_NAME
     );
+
+    const apiToken = new ApiToken(dcApiCookie);
+    expect(apiToken.token.iss).to.eq(process.env.DC_API_ENDPOINT);
+    expect(apiToken.token.sub).to.not.exist;
+
+    expect(result.statusCode).to.eq(200);
+    expect(JSON.parse(result.body)).to.contain({
+      iss: process.env.DC_API_ENDPOINT,
+    });
+    expect(JSON.parse(result.body)).not.to.contain({
+      sub: "user123",
+    });
   });
 });

--- a/test/integration/get-collection-by-id.test.js
+++ b/test/integration/get-collection-by-id.test.js
@@ -3,6 +3,7 @@
 const chai = require("chai");
 const expect = chai.expect;
 const RequestPipeline = require("../../src/api/request/pipeline");
+const { processRequest } = require("../../src/handlers/middleware");
 chai.use(require("chai-http"));
 
 describe("Retrieve collection by id", () => {
@@ -50,7 +51,7 @@ describe("Retrieve collection by id", () => {
         query: { query_string: { query: "collection.id:1234" } },
       };
       const authQuery = new RequestPipeline(originalQuery)
-        .authFilter()
+        .authFilter(processRequest({}))
         .toJson();
 
       mock

--- a/test/integration/get-collections.test.js
+++ b/test/integration/get-collections.test.js
@@ -4,6 +4,7 @@ const chai = require("chai");
 const expect = chai.expect;
 const getCollectionsHandler = require("../../src/handlers/get-collections");
 const RequestPipeline = require("../../src/api/request/pipeline");
+const { processRequest } = require("../../src/handlers/middleware");
 chai.use(require("chai-http"));
 
 describe("Collections route", () => {
@@ -16,7 +17,7 @@ describe("Collections route", () => {
     let event;
     const makeQuery = (params) =>
       new RequestPipeline({ query: { match_all: {} }, ...params })
-        .authFilter()
+        .authFilter(processRequest(baseEvent))
         .toJson();
 
     it("paginates results using default size and page number", async () => {

--- a/test/integration/get-shared-link-by-id.test.js
+++ b/test/integration/get-shared-link-by-id.test.js
@@ -3,6 +3,7 @@
 const chai = require("chai");
 const expect = chai.expect;
 chai.use(require("chai-http"));
+const ApiToken = require("../../src/api/api-token");
 
 describe("Retrieve shared link by id", () => {
   helpers.saveEnvironment();
@@ -12,6 +13,8 @@ describe("Retrieve shared link by id", () => {
     const { handler } = require("../../src/handlers/get-shared-link-by-id");
 
     it("retrieves a single shared link document", async () => {
+      process.env.API_TOKEN_SECRET = "abc123";
+      process.env.API_TOKEN_NAME = "dcapiTEST";
       mock
         .get("/shared_links/_doc/1234")
         .reply(200, helpers.testFixture("mocks/shared-link-1234.json"));
@@ -29,6 +32,13 @@ describe("Retrieve shared link by id", () => {
       const resultBody = JSON.parse(result.body);
       expect(resultBody.data.api_model).to.eq("Work");
       expect(resultBody.data.visibility).to.eq("Private");
+
+      const dcApiCookie = helpers.cookieValue(
+        result.cookies,
+        process.env.API_TOKEN_NAME
+      );
+      const token = new ApiToken(dcApiCookie);
+      expect(token.hasEntitlement("1234")).to.be.true;
     });
 
     it("404s a missing shared link", async () => {

--- a/test/integration/get-similar.test.js
+++ b/test/integration/get-similar.test.js
@@ -4,6 +4,7 @@ const chai = require("chai");
 const expect = chai.expect;
 const { handler } = require("../../src/handlers/get-similar");
 const RequestPipeline = require("../../src/api/request/pipeline");
+const { processRequest } = require("../../src/handlers/middleware");
 chai.use(require("chai-http"));
 
 describe("Similar routes", () => {
@@ -13,7 +14,7 @@ describe("Similar routes", () => {
     .mockEvent("GET", "/works/{id}/similar")
     .pathParams({ id: 1234 });
   const makeQuery = (params) =>
-    new RequestPipeline(params).authFilter().toJson();
+    new RequestPipeline(params).authFilter(processRequest(baseEvent)).toJson();
 
   it("paginates results using default size and page number", async () => {
     mock

--- a/test/integration/get-work-by-id.test.js
+++ b/test/integration/get-work-by-id.test.js
@@ -4,6 +4,7 @@ const chai = require("chai");
 const expect = chai.expect;
 const RequestPipeline = require("../../src/api/request/pipeline");
 chai.use(require("chai-http"));
+const ApiToken = require("../../src/api/api-token");
 
 describe("Retrieve work by id", () => {
   helpers.saveEnvironment();
@@ -74,6 +75,34 @@ describe("Retrieve work by id", () => {
         "http://iiif.io/api/presentation/3/context.json"
       );
       expect(resultBody.label.none[0]).to.eq("Canary Record TEST 1");
+    });
+
+    it("will retrieve a private, unpublished work document with an entitlement", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/private-unpublished-work-1234.json")
+        );
+
+      const token = new ApiToken().addEntitlement("1234").sign();
+
+      const event = helpers
+        .mockEvent("GET", "/work/{id}")
+        .pathParams({ id: "1234" })
+        .headers({
+          Cookie: `${process.env.API_TOKEN_NAME}=${token};`,
+        })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+      expect(result).to.have.header(
+        "content-type",
+        /application\/json;.*charset=UTF-8/
+      );
+
+      const resultBody = JSON.parse(result.body);
+      expect(resultBody.data.id).to.eq("1234");
     });
   });
 });

--- a/test/test-helpers/index.js
+++ b/test/test-helpers/index.js
@@ -7,8 +7,12 @@ function saveEnvironment() {
   const env = Object.assign({}, process.env);
 
   beforeEach(function () {
+    process.env.API_TOKEN_SECRET = "abc123";
+    process.env.API_TOKEN_NAME = "dcapiTEST";
     process.env.DC_URL = "https://thisisafakedcurl";
     process.env.DC_API_ENDPOINT = "https://thisisafakeapiurl";
+    process.env.NUSSO_BASE_URL = "https://nusso-base.com/";
+    process.env.NUSSO_API_KEY = "abc123";
   });
 
   afterEach(function () {
@@ -44,10 +48,24 @@ function testFixture(file) {
   return fs.readFileSync(fixtureFile);
 }
 
+function cookieValue(cookies, cookieName) {
+  let cookieValue = "";
+  const regex = new RegExp(`(^| )${cookieName}=(?<value>([^;]+))`);
+  for (const c of cookies) {
+    const match = regex.exec(c);
+    if (match) {
+      const { value } = match.groups;
+      cookieValue = value;
+    }
+  }
+  return cookieValue;
+}
+
 global.helpers = {
   saveEnvironment,
   mockEvent,
   mockIndex,
   encodedFixture,
   testFixture,
+  cookieValue,
 };

--- a/test/unit/api/api-token.test.js
+++ b/test/unit/api/api-token.test.js
@@ -1,0 +1,144 @@
+"use strict";
+
+const ApiToken = require("../../../src/api/api-token");
+const chai = require("chai");
+const expect = chai.expect;
+const jwt = require("jsonwebtoken");
+
+describe("ApiToken", function () {
+  this.beforeEach(() => {});
+  describe("constructor", function () {
+    it("constructs an anonymous token by default", async () => {
+      const token = new ApiToken();
+      expect(token.token.sub).to.not.exist;
+      expect(token.token.isReadingRoom).to.not.exist;
+      expect(token.token.isSuperUser).to.not.exist;
+      expect(token.token.isLoggedIn).to.be.false;
+      expect(token.token.entitlements).to.be.empty;
+    });
+
+    it("verifies an existing token", async () => {
+      const payload = {
+        iss: "https://example.com",
+        sub: "user123",
+        name: "Some One",
+        exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
+        iat: Math.floor(Number(new Date()) / 1000),
+        email: "user@example.com",
+        isLoggedIn: true,
+        entitlements: ["1234", "5678"],
+        isReadingRoom: true,
+      };
+      const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+      const token = new ApiToken(existingToken);
+
+      expect(token.token.sub).to.eq("user123");
+      expect(token.token.isReadingRoom).to.be.true;
+      expect(token.token.isLoggedIn).to.be.true;
+      expect(token.hasEntitlement("1234")).to.be.true;
+    });
+  });
+  describe("user()", function () {
+    it("updates the user properties", async () => {});
+
+    const user = {
+      uid: "user123",
+      displayName: ["Some One"],
+      mail: "user@example.com",
+    };
+
+    const token = new ApiToken();
+    expect(token.token.sub).to.not.exist;
+
+    token.user(user);
+    expect(token.token.sub).to.eq("user123");
+    expect(token.token.name).to.eq("Some One");
+    expect(token.token.email).to.eq("user@example.com");
+    expect(token.isLoggedIn()).to.be.true;
+  });
+
+  describe("readingRoom()", function () {
+    it("sets the isReadingRoom flag to true", async () => {});
+
+    const token = new ApiToken().readingRoom();
+    expect(token.isReadingRoom()).to.be.true;
+  });
+
+  describe("superUser()", function () {
+    it("sets the isSuperUser flag to true", async () => {});
+
+    const token = new ApiToken().superUser();
+    expect(token.isSuperUser()).to.be.true;
+  });
+
+  describe("entitlements", function () {
+    it("addEntitlement() adds an entitlement to the token", async () => {});
+
+    const payload = {
+      iss: "https://example.com",
+      sub: "user123",
+      name: "Some One",
+      exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
+      iat: Math.floor(Number(new Date()) / 1000),
+      email: "user@example.com",
+      isLoggedIn: true,
+      entitlements: ["1234"],
+    };
+    const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+
+    const token = new ApiToken(existingToken);
+    expect(token.hasEntitlement("1234")).to.be.true;
+    expect(token.hasEntitlement("5678")).to.be.false;
+
+    token.addEntitlement("5678");
+
+    expect(token.hasEntitlement("1234")).to.be.true;
+    expect(token.hasEntitlement("5678")).to.be.true;
+  });
+
+  it("entitlements() replaces entitlements", async () => {
+    const payload = {
+      iss: "https://example.com",
+      sub: "user123",
+      name: "Some One",
+      exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
+      iat: Math.floor(Number(new Date()) / 1000),
+      email: "user@example.com",
+      isLoggedIn: true,
+      entitlements: ["1234"],
+    };
+    const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+
+    const token = new ApiToken(existingToken);
+    expect(token.hasEntitlement("1234")).to.be.true;
+    expect(token.hasEntitlement("5678")).to.be.false;
+
+    token.entitlements(["5678", "9101112"]);
+
+    expect(token.hasEntitlement("1234")).to.be.false;
+    expect(token.hasEntitlement("5678")).to.be.true;
+  });
+
+  it("removeEntitlement() removes an entitlement", async () => {
+    const payload = {
+      iss: "https://example.com",
+      sub: "user123",
+      name: "Some One",
+      exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
+      iat: Math.floor(Number(new Date()) / 1000),
+      email: "user@example.com",
+      isLoggedIn: true,
+      entitlements: ["1234", "5678"],
+    };
+    const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+
+    const token = new ApiToken(existingToken);
+    expect(token.hasEntitlement("1234")).to.be.true;
+    expect(token.hasEntitlement("5678")).to.be.true;
+
+    token.removeEntitlement("5678");
+
+    expect(token.hasEntitlement("1234")).to.be.true;
+    expect(token.hasEntitlement("5678")).to.be.false;
+  });
+});

--- a/test/unit/api/request/pipeline.test.js
+++ b/test/unit/api/request/pipeline.test.js
@@ -3,11 +3,13 @@
 const RequestPipeline = require("../../../../src/api/request/pipeline");
 const chai = require("chai");
 const expect = chai.expect;
+const { processRequest } = require("../../../../src/handlers/middleware");
+const ApiToken = require("../../../../src/api/api-token");
 
 describe("RequestPipeline", () => {
   helpers.saveEnvironment();
 
-  const event = helpers.mockEvent("GET", "/search").render();
+  let event = helpers.mockEvent("GET", "/search").render();
 
   const requestBody = {
     query: { match: { term: { title: "The Title" } } },
@@ -24,6 +26,8 @@ describe("RequestPipeline", () => {
   });
 
   it("adds an auth filter", () => {
+    event.userToken = new ApiToken();
+
     const result = pipeline.authFilter(event);
     expect(result.searchContext.size).to.eq(50);
     expect(result.searchContext.query.bool.must).to.include(requestBody.query);
@@ -37,9 +41,11 @@ describe("RequestPipeline", () => {
     expect(JSON.parse(pipeline.toJson())).to.deep.equal(requestBody);
   });
 
-  describe("reading room IPs", () => {
+  describe("reading room user", () => {
     it("filters out private results by default", () => {
-      process.env.READING_ROOM_IPS = "192.168.0.1,172.16.10.2";
+      event.userToken = new ApiToken();
+
+      // process.env.READING_ROOM_IPS = "192.168.0.1,172.16.10.2";
       const result = pipeline.authFilter(event);
       expect(result.searchContext.size).to.eq(50);
       expect(result.searchContext.query.bool.must).to.include(
@@ -51,8 +57,9 @@ describe("RequestPipeline", () => {
       );
     });
 
-    it("includes private results from allowed IP addresses", () => {
-      process.env.READING_ROOM_IPS = "10.9.8.7,192.168.0.1";
+    it("includes private results if the user is in the reading room", () => {
+      event.userToken = new ApiToken().readingRoom();
+
       const result = pipeline.authFilter(event);
       expect(result.searchContext.size).to.eq(50);
       expect(result.searchContext.query.bool.must).to.include(

--- a/test/unit/api/response/iiif/manifest.test.js
+++ b/test/unit/api/response/iiif/manifest.test.js
@@ -3,7 +3,7 @@
 const transformer = require("../../../../../src/api/response/iiif/manifest");
 const chai = require("chai");
 const expect = chai.expect;
-const { dcApiEndpoint, dcUrl } = require("../../../../../src/aws/environment");
+const { dcApiEndpoint, dcUrl } = require("../../../../../src/environment");
 
 describe("Image Work as IIIF Manifest response transformer", () => {
   function getMetadataValueByLabel(metadataArray, targetLabel) {

--- a/test/unit/aws/environment.test.js
+++ b/test/unit/aws/environment.test.js
@@ -1,6 +1,6 @@
 "use strict";
 
-const environment = require("../../../src/aws/environment");
+const environment = require("../../../src/environment");
 
 const chai = require("chai");
 const expect = chai.expect;


### PR DESCRIPTION
### Changes

Updates shape of JWT: 
```
token {
  sub
  name
  email
  iss
  iat
  exp
  isLoggedIn
  isReadingRoom
  entitlements
}
```
- issues anonymous JWT for non-logged in users
- handles reading room access rules
  - Reading room can access private materials (but not unpublished ones)
- handles shared links access rules (including authorizing `/works/{id}` if shared-links route has been hit first) by storing work id's in `entitlements`
  - Shared links can access private and unpublished materials
- handles file set auth rules for above cases
  - including different handling of images and metadata for netid works
- handles thumbnail route auth with `superUser` token