### PR TITLE
Prefer the search context's size over the default

### DIFF
--- a/src/handlers/search-runner.js
+++ b/src/handlers/search-runner.js
@@ -92,8 +92,7 @@ const constructSearchContext = async (event) => {
 
   if (queryStringParameters.page) {
     const page = Number(queryStringParameters.page || 1);
-    const size = Number(queryStringParameters.size || 10);
-    searchContext.from = (page - 1) * size;
+    searchContext.from = (page - 1) * searchContext.size;
   }
 
   return searchContext;


### PR DESCRIPTION
To test:

First, your dev index must have at least 2 pages of works in it for whatever page size you choose to test with.

`POST` a query that includes a size attribute in the JSON, e.g.:
```
curl --data '{"size":50, "query":{"bool":{"must":[{"match":{"api_model":"Work"}}, {"query_string":{"query":"collection.id:18ec4c6b-192a-4ab8-9903-ea0f393c35f7"}}]}}}' http://localhost:3000/search
```

Watch the pagination blocks as you page through results.