### PR TITLE
Don't serialize anonymous tokens

### DIFF
--- a/src/handlers/get-auth-callback.js
+++ b/src/handlers/get-auth-callback.js
@@ -21,7 +21,6 @@ exports.handler = async (event) => {
   let response;
   if (user) {
     event.userToken = new ApiToken().user(user);
-    event._userTokenUpdated = true;
     response = {
       statusCode: 302,
       cookies: [

--- a/src/handlers/get-auth-logout.js
+++ b/src/handlers/get-auth-logout.js
@@ -20,8 +20,7 @@ exports.handler = async (event) => {
           location: response.data.url,
         },
       };
-      event.userToken = new ApiToken();
-      event._userTokenUpdated = true;
+      event.userToken = new ApiToken().expire();
     })
     .catch((error) => {
       console.error("NUSSO request error", error);

--- a/src/handlers/get-shared-link-by-id.js
+++ b/src/handlers/get-shared-link-by-id.js
@@ -29,7 +29,6 @@ exports.handler = async (event) => {
   // add entitlement for the work id
   // TODO make part of request/response processing
   event.userToken.addEntitlement(workId);
-  event._userTokenUpdated = true;
 
   return processResponse(event, response);
 };

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -44,26 +44,29 @@ function decodeToken(event) {
 
   try {
     event.userToken = new ApiToken(existingToken);
-    event._userTokenUpdated = !existingToken;
   } catch (error) {
     event.userToken = new ApiToken();
-    event._userTokenUpdated = true;
   }
   if (isFromReadingRoom(event)) {
     event.userToken.readingRoom();
-    event._userTokenUpdated = true;
   }
 
   return event;
 }
 
 function encodeToken(event, response) {
-  if (event._userTokenUpdated) {
-    const newCookie = cookie.serialize(apiTokenName(), event.userToken.sign(), {
+  if (event.userToken.updated()) {
+    let cookieOptions = {
       domain: "library.northwestern.edu",
       path: "/",
       secure: true,
-    });
+    };
+    if (event.userToken.shouldExpire()) cookieOptions.expires = new Date(0);
+    const newCookie = cookie.serialize(
+      apiTokenName(),
+      event.userToken.sign(),
+      cookieOptions
+    );
 
     response.cookies =
       response.hasOwnProperty("cookies") && _.isArray(response.cookies)

--- a/test/integration/get-auth-callback.test.js
+++ b/test/integration/get-auth-callback.test.js
@@ -40,7 +40,7 @@ describe("auth callback", function () {
       process.env.API_TOKEN_NAME
     );
 
-    const apiToken = new ApiToken(dcApiCookie);
+    const apiToken = new ApiToken(dcApiCookie.value);
 
     expect(apiToken.token.sub).to.eq("uid123");
     expect(apiToken.token.name).to.eq("Some User");
@@ -72,7 +72,7 @@ describe("auth callback", function () {
       process.env.API_TOKEN_NAME
     );
 
-    const apiToken = new ApiToken(dcApiCookie);
+    const apiToken = new ApiToken(dcApiCookie.value);
 
     expect(apiToken.token.sub).to.eq("uid123");
     expect(apiToken.token.name).to.eq("uid123");

--- a/test/integration/get-auth-logout.test.js
+++ b/test/integration/get-auth-logout.test.js
@@ -22,15 +22,17 @@ describe("auth logout", function () {
 
     const result = await getAuthLogoutHandler.handler(event);
 
+    expect(result.statusCode).to.eq(302);
+    expect(result.headers.location).to.eq(url);
+
     const dcApiCookie = helpers.cookieValue(
       result.cookies,
       process.env.API_TOKEN_NAME
     );
 
-    const apiToken = new ApiToken(dcApiCookie);
-    expect(result.statusCode).to.eq(302);
-    expect(result.headers.location).to.eq(url);
+    const apiToken = new ApiToken(dcApiCookie.value);
     expect(apiToken.token.sub).to.not.exist;
     expect(apiToken.token.isLoggedIn).to.be.false;
+    expect(dcApiCookie.Expires).to.eq("Thu, 01 Jan 1970 00:00:00 GMT");
   });
 });

--- a/test/integration/get-shared-link-by-id.test.js
+++ b/test/integration/get-shared-link-by-id.test.js
@@ -37,7 +37,7 @@ describe("Retrieve shared link by id", () => {
         result.cookies,
         process.env.API_TOKEN_NAME
       );
-      const token = new ApiToken(dcApiCookie);
+      const token = new ApiToken(dcApiCookie.value);
       expect(token.hasEntitlement("1234")).to.be.true;
     });
 


### PR DESCRIPTION
- Immediately expire invalid/expired tokens
- Let ApiToken class decide when to update (i.e., move `event._userTokenUpdated` logic into the `ApiToken` class)