### PR TITLE
Explicitly list acceptable request headers in CORS response

### DIFF
--- a/src/api/request/pipeline.js
+++ b/src/api/request/pipeline.js
@@ -1,5 +1,4 @@
 const sortJson = require("sort-json");
-const ApiToken = require("../api-token");
 
 function filterFor(query, event) {
   const matchTheQuery = query;

--- a/src/handlers/get-auth-login.js
+++ b/src/handlers/get-auth-login.js
@@ -1,14 +1,12 @@
 const { dcApiEndpoint, apiTokenSecret } = require("../environment");
 const axios = require("axios").default;
 const cookie = require("cookie");
-const { processRequest, processResponse } = require("./middleware");
+const { wrap } = require("./middleware");
 
 /**
  * Performs NUSSO login
  */
-exports.handler = async (event) => {
-  event = processRequest(event);
-
+exports.handler = wrap(async (event) => {
   const callbackUrl = `${dcApiEndpoint()}/auth/callback`;
   const url = `${process.env.NUSSO_BASE_URL}get-ldap-redirect-url`;
   const returnPath =
@@ -20,35 +18,30 @@ exports.handler = async (event) => {
     };
   }
 
-  let resp;
-
-  await axios
-    .get(url, {
+  try {
+    const response = await axios.get(url, {
       headers: {
         apikey: process.env.NUSSO_API_KEY,
         goto: callbackUrl,
       },
-    })
-    .then((response) => {
-      resp = {
-        statusCode: 302,
-        cookies: [
-          cookie.serialize(
-            "redirectUrl",
-            Buffer.from(returnPath, "utf8").toString("base64")
-          ),
-        ],
-        headers: {
-          location: response.data.redirecturl,
-        },
-      };
-    })
-    .catch((error) => {
-      console.error("NUSSO request error", error);
-      resp = {
-        statusCode: 401,
-      };
     });
 
-  return processResponse(event, resp);
-};
+    return {
+      statusCode: 302,
+      cookies: [
+        cookie.serialize(
+          "redirectUrl",
+          Buffer.from(returnPath, "utf8").toString("base64")
+        ),
+      ],
+      headers: {
+        location: response.data.redirecturl,
+      },
+    };
+  } catch (error) {
+    console.error("NUSSO request error", error);
+    return {
+      statusCode: 401,
+    };
+  }
+});

--- a/src/handlers/get-auth-logout.js
+++ b/src/handlers/get-auth-logout.js
@@ -1,33 +1,29 @@
 const axios = require("axios").default;
 const cookie = require("cookie");
-const { processRequest, processResponse } = require("./middleware");
+const { wrap } = require("./middleware");
 const ApiToken = require("../api/api-token");
 
 /**
  * Performs NUSSO logout
  */
-exports.handler = async (event) => {
-  event = processRequest(event);
+exports.handler = wrap(async (event) => {
   const url = `${process.env.NUSSO_BASE_URL}logout`;
-  let resp;
 
-  await axios
-    .get(url, { headers: { apikey: process.env.NUSSO_API_KEY } })
-    .then((response) => {
-      resp = {
-        statusCode: 302,
-        headers: {
-          location: response.data.url,
-        },
-      };
-      event.userToken = new ApiToken().expire();
-    })
-    .catch((error) => {
-      console.error("NUSSO request error", error);
-      resp = {
-        statusCode: 401,
-      };
+  try {
+    const response = await axios.get(url, {
+      headers: { apikey: process.env.NUSSO_API_KEY },
     });
-
-  return processResponse(event, resp);
-};
+    event.userToken = new ApiToken().expire();
+    return {
+      statusCode: 302,
+      headers: {
+        location: response.data.url,
+      },
+    };
+  } catch (error) {
+    console.error("NUSSO request error", error);
+    return {
+      statusCode: 401,
+    };
+  }
+});

--- a/src/handlers/get-auth-whoami.js
+++ b/src/handlers/get-auth-whoami.js
@@ -1,31 +1,21 @@
-const { processRequest, processResponse } = require("./middleware");
+const { wrap } = require("./middleware");
 
 /**
  * Whoami - validates JWT and returns user info, or issues an anonymous
  * token if none is present
  */
-exports.handler = async (event) => {
-  event = processRequest(event);
-
+exports.handler = wrap(async (event) => {
   try {
     const token = event.userToken;
 
-    const response = {
+    return {
       statusCode: 200,
-      headers: {
-        "Access-Control-Allow-Origin": event.headers.origin,
-        "Access-Control-Allow-Headers": "*",
-        "Access-Control-Allow-Methods": "POST, GET, OPTIONS",
-        "Access-Control-Allow-Credentials": "true",
-      },
       body: JSON.stringify(token.userInfo()),
     };
-
-    return processResponse(event, response);
   } catch (error) {
     return {
       statusCode: 401,
       body: "Error verifying API token: " + error.message,
     };
   }
-};
+});

--- a/src/handlers/get-collection-by-id.js
+++ b/src/handlers/get-collection-by-id.js
@@ -1,14 +1,12 @@
-const { processRequest, processResponse } = require("./middleware");
+const { wrap } = require("./middleware");
 const { getCollection } = require("../api/opensearch");
 const { doSearch } = require("./search-runner");
 const opensearchResponse = require("../api/response/opensearch");
 
 const getCollectionById = async (event) => {
-  event = processRequest(event);
   const id = event.pathParameters.id;
   const esResponse = await getCollection(id);
-  const response = await opensearchResponse.transform(esResponse);
-  return processResponse(event, response);
+  return await opensearchResponse.transform(esResponse);
 };
 
 const getIiifCollectionById = async (event) => {
@@ -30,8 +28,8 @@ const getIiifCollectionById = async (event) => {
 /**
  * Get a colletion by id
  */
-exports.handler = async (event) => {
+exports.handler = wrap(async (event) => {
   return event.queryStringParameters?.as === "iiif"
     ? getIiifCollectionById(event)
     : getCollectionById(event);
-};
+});

--- a/src/handlers/get-collections.js
+++ b/src/handlers/get-collections.js
@@ -1,12 +1,11 @@
 const { doSearch } = require("./search-runner");
-const { processRequest } = require("./middleware");
+const { wrap } = require("./middleware");
 
 /**
  * A simple function to get Collections
  */
-exports.handler = async (event) => {
-  event = processRequest(event);
+exports.handler = wrap(async (event) => {
   event.pathParameters.models = "collections";
   event.body = { query: { match_all: {} } };
   return doSearch(event, { includeToken: false });
-};
+});

--- a/src/handlers/get-file-set-auth.js
+++ b/src/handlers/get-file-set-auth.js
@@ -1,19 +1,17 @@
-const ApiToken = require("../api/api-token");
-const { processRequest, processResponse } = require("./middleware");
 const { getFileSet } = require("../api/opensearch");
+const { wrap } = require("./middleware");
 
 const OPEN_DOCUMENT_NAMESPACE = /^0{8}-0{4}-0{4}-0{4}-0{9}[0-9A-Fa-f]{3}/;
 
 /**
  * Authorizes a FileSet by id
  */
-exports.handler = async (event) => {
-  event = processRequest(event);
+exports.handler = wrap(async (event) => {
   const id = event.pathParameters.id;
 
   // Special namespace for entities that aren't actual entities
   // with indexed metadata (i.e., placeholder images)
-  if (OPEN_DOCUMENT_NAMESPACE.test(id)) return sendResponse(event, 204);
+  if (OPEN_DOCUMENT_NAMESPACE.test(id)) return sendResponse(204);
 
   const osResponse = await getFileSet(id, {
     allowPrivate: true,
@@ -21,7 +19,7 @@ exports.handler = async (event) => {
   });
 
   if (osResponse.statusCode != 200) {
-    return sendResponse(event, osResponse.statusCode, osResponse.statusCode);
+    return sendResponse(osResponse.statusCode);
   }
 
   const body = JSON.parse(osResponse.body);
@@ -35,20 +33,20 @@ exports.handler = async (event) => {
   const workId = fileSet.work_id;
 
   if (token.isSuperUser()) {
-    return sendResponse(event, 204);
+    return sendResponse(204);
   } else if (token.hasEntitlement(workId)) {
-    return sendResponse(event, 204);
+    return sendResponse(204);
   } else if (isAllowedVisibility(token, visibility, readingRoom) && published) {
-    return sendResponse(event, 204);
+    return sendResponse(204);
   } else {
-    return sendResponse(event, 403);
+    return sendResponse(403);
   }
-};
+});
 
-function sendResponse(event, statusCode) {
-  return processResponse(event, {
+function sendResponse(statusCode) {
+  return {
     statusCode: statusCode,
-  });
+  };
 }
 
 function isAllowedVisibility(token, visibility, readingRoom) {

--- a/src/handlers/get-file-set-by-id.js
+++ b/src/handlers/get-file-set-by-id.js
@@ -1,15 +1,13 @@
-const { processRequest, processResponse } = require("./middleware");
+const { wrap } = require("./middleware");
 const { getFileSet } = require("../api/opensearch");
 const opensearchResponse = require("../api/response/opensearch");
 
 /**
  * A simple function to get a FileSet by id
  */
-exports.handler = async (event) => {
-  event = processRequest(event);
+exports.handler = wrap(async (event) => {
   const id = event.pathParameters.id;
   const allowPrivate = event.userToken.isReadingRoom();
   const esResponse = await getFileSet(id, { allowPrivate });
-  const response = await opensearchResponse.transform(esResponse);
-  return processResponse(event, response);
-};
+  return await opensearchResponse.transform(esResponse);
+});

--- a/src/handlers/get-similar.js
+++ b/src/handlers/get-similar.js
@@ -1,10 +1,11 @@
 const { doSearch } = require("./search-runner");
+const { wrap } = require("./middleware");
 const { modelsToTargets } = require("../api/request/models");
 
 /**
  * Get similar works via 'More Like This' query
  */
-exports.handler = async (event) => {
+exports.handler = wrap(async (event) => {
   const id = event.pathParameters.id;
   const models = ["works"];
   const workIndex = modelsToTargets(models);
@@ -34,4 +35,4 @@ exports.handler = async (event) => {
   };
 
   return doSearch(event, { includeToken: false });
-};
+});

--- a/src/handlers/get-work-by-id.js
+++ b/src/handlers/get-work-by-id.js
@@ -1,14 +1,12 @@
-const { processRequest, processResponse } = require("./middleware");
 const { getWork } = require("../api/opensearch");
-
 const manifestResponse = require("../api/response/iiif/manifest");
+const { wrap } = require("./middleware");
 const opensearchResponse = require("../api/response/opensearch");
 
 /**
  * A simple function to get a Work by id
  */
-exports.handler = async (event) => {
-  event = processRequest(event);
+exports.handler = wrap(async (event) => {
   const id = event.pathParameters.id;
 
   const allowPrivate =
@@ -17,15 +15,12 @@ exports.handler = async (event) => {
 
   const esResponse = await getWork(id, { allowPrivate, allowUnpublished });
 
-  let response;
   const as = event.queryStringParameters.as;
 
   if (as && as === "iiif") {
     // Make it IIIFy
-    response = manifestResponse.transform(esResponse);
+    return manifestResponse.transform(esResponse);
   } else {
-    response = await opensearchResponse.transform(esResponse);
+    return await opensearchResponse.transform(esResponse);
   }
-
-  return processResponse(event, response);
-};
+});

--- a/src/handlers/middleware.js
+++ b/src/handlers/middleware.js
@@ -9,22 +9,37 @@ const {
   stubEventMembers,
 } = require("../helpers");
 
-const processRequest = function (event) {
-  if (event._processRequest) return event;
+const wrap = function (handler) {
+  try {
+    return async (event) => {
+      event = _processRequest(event);
+      const response = await handler(event);
+      return _processResponse(event, response);
+    };
+  } catch (error) {
+    console.error("error", error);
+    return {
+      statusCode: 400,
+    };
+  }
+};
+
+const _processRequest = function (event) {
+  if (event.__processRequest) return event;
   let result = stubEventMembers(event);
   result = normalizeHeaders(event);
   result = objectifyCookies(result);
   result = decodeEventBody(result);
   result = decodeToken(result);
-  result._processRequest = true;
+  result.__processRequest = true;
   return result;
 };
 
-const processResponse = function (event, response) {
+const _processResponse = function (event, response) {
   let result = addCorsHeaders(event, response);
   result = encodeToken(event, result);
   result = ensureCharacterEncoding(result, "UTF-8");
   return result;
 };
 
-module.exports = { processRequest, processResponse };
+module.exports = { wrap, _processRequest, _processResponse };

--- a/src/handlers/oai.js
+++ b/src/handlers/oai.js
@@ -1,4 +1,3 @@
-const { processRequest } = require("./middleware");
 const { baseUrl } = require("../helpers");
 const {
   getRecord,
@@ -8,6 +7,7 @@ const {
   listRecords,
 } = require("./oai/verbs");
 const { invalidOaiRequest } = require("./oai/xml-transformer");
+const { wrap } = require("./middleware");
 
 const allowedVerbs = [
   "GetRecord",
@@ -21,8 +21,7 @@ const allowedVerbs = [
 /**
  * A function to support the OAI-PMH harvesting specfication
  */
-exports.handler = async (event) => {
-  event = processRequest(event);
+exports.handler = wrap(async (event) => {
   const url = `${baseUrl(event)}oai`;
   let verb, identifier, metadataPrefix, resumptionToken;
   if (event.requestContext.http.method === "GET") {
@@ -60,4 +59,4 @@ exports.handler = async (event) => {
     default:
       return invalidOaiRequest("badVerb", "Illegal OAI verb");
   }
-};
+});

--- a/src/handlers/options-request.js
+++ b/src/handlers/options-request.js
@@ -1,6 +1,5 @@
-const { processRequest, processResponse } = require("./middleware");
+const { wrap } = require("./middleware");
 
-module.exports.handler = async (event) => {
-  event = processRequest(event);
-  return processResponse(event, { statusCode: 200 });
-};
+module.exports.handler = wrap(async () => {
+  return { statusCode: 200 };
+});

--- a/src/handlers/search-runner.js
+++ b/src/handlers/search-runner.js
@@ -1,5 +1,4 @@
 const { baseUrl, effectivePath } = require("../helpers");
-const { processRequest, processResponse } = require("./middleware");
 const {
   extractRequestedModels,
   modelsToTargets,
@@ -14,7 +13,6 @@ const RequestPipeline = require("../api/request/pipeline");
  * Function to wrap search requests and transform responses
  */
 const doSearch = async (event, searchParams = {}) => {
-  event = processRequest(event);
   const models = extractRequestedModels(event.pathParameters?.models);
   const format = await responseFormat(event);
 
@@ -52,11 +50,7 @@ const doSearch = async (event, searchParams = {}) => {
     filteredSearchContext
   );
 
-  const response = await responseTransformer.transformSearchResult(
-    esResponse,
-    pager
-  );
-  return processResponse(event, response);
+  return await responseTransformer.transformSearchResult(esResponse, pager);
 };
 
 const invalidRequest = (message) => {

--- a/src/handlers/search.js
+++ b/src/handlers/search.js
@@ -1,10 +1,11 @@
 const { doSearch } = require("./search-runner");
+const { wrap } = require("./middleware");
 
-const getSearch = async (event) => {
+const getSearch = wrap(async (event) => {
   const includeToken = !!event.queryStringParameters?.searchToken;
   return await doSearch(event, { includeToken });
-};
+});
 
-const postSearch = async (event) => await doSearch(event);
+const postSearch = wrap(async (event) => await doSearch(event));
 
 module.exports = { postSearch, getSearch };

--- a/test/integration/get-auth-whoami.test.js
+++ b/test/integration/get-auth-whoami.test.js
@@ -4,8 +4,6 @@ const chai = require("chai");
 const expect = chai.expect;
 const getAuthWhoamiHandler = require("../../src/handlers/get-auth-whoami");
 const jwt = require("jsonwebtoken");
-const ApiToken = require("../../src/api/api-token");
-const { processRequest } = require("../../src/handlers/middleware");
 
 describe("auth whoami", function () {
   helpers.saveEnvironment();

--- a/test/integration/get-collection-by-id.test.js
+++ b/test/integration/get-collection-by-id.test.js
@@ -3,7 +3,6 @@
 const chai = require("chai");
 const expect = chai.expect;
 const RequestPipeline = require("../../src/api/request/pipeline");
-const { processRequest } = require("../../src/handlers/middleware");
 chai.use(require("chai-http"));
 
 describe("Retrieve collection by id", () => {
@@ -51,7 +50,7 @@ describe("Retrieve collection by id", () => {
         query: { query_string: { query: "collection.id:1234" } },
       };
       const authQuery = new RequestPipeline(originalQuery)
-        .authFilter(processRequest({}))
+        .authFilter(helpers.preprocess({}))
         .toJson();
 
       mock

--- a/test/integration/get-collections.test.js
+++ b/test/integration/get-collections.test.js
@@ -4,7 +4,6 @@ const chai = require("chai");
 const expect = chai.expect;
 const getCollectionsHandler = require("../../src/handlers/get-collections");
 const RequestPipeline = require("../../src/api/request/pipeline");
-const { processRequest } = require("../../src/handlers/middleware");
 chai.use(require("chai-http"));
 
 describe("Collections route", () => {
@@ -17,7 +16,7 @@ describe("Collections route", () => {
     let event;
     const makeQuery = (params) =>
       new RequestPipeline({ query: { match_all: {} }, ...params })
-        .authFilter(processRequest(baseEvent))
+        .authFilter(helpers.preprocess(baseEvent))
         .toJson();
 
     it("paginates results using default size and page number", async () => {

--- a/test/integration/get-similar.test.js
+++ b/test/integration/get-similar.test.js
@@ -4,7 +4,6 @@ const chai = require("chai");
 const expect = chai.expect;
 const { handler } = require("../../src/handlers/get-similar");
 const RequestPipeline = require("../../src/api/request/pipeline");
-const { processRequest } = require("../../src/handlers/middleware");
 chai.use(require("chai-http"));
 
 describe("Similar routes", () => {
@@ -14,7 +13,9 @@ describe("Similar routes", () => {
     .mockEvent("GET", "/works/{id}/similar")
     .pathParams({ id: 1234 });
   const makeQuery = (params) =>
-    new RequestPipeline(params).authFilter(processRequest(baseEvent)).toJson();
+    new RequestPipeline(params)
+      .authFilter(helpers.preprocess(baseEvent))
+      .toJson();
 
   it("paginates results using default size and page number", async () => {
     mock

--- a/test/integration/get-work-by-id.test.js
+++ b/test/integration/get-work-by-id.test.js
@@ -47,13 +47,6 @@ describe("Retrieve work by id", () => {
     });
 
     it("returns a single work as a IIIF Manifest", async () => {
-      // const originalQuery = {
-      //   query: { query_string: { query: "collection.id:1234" } },
-      // };
-      // const authQuery = new RequestPipeline(originalQuery)
-      //   .authFilter()
-      //   .toJson();
-
       mock
         .get("/dc-v2-work/_doc/1234")
         .reply(200, helpers.testFixture("mocks/work-1234.json"));

--- a/test/integration/options-request.test.js
+++ b/test/integration/options-request.test.js
@@ -18,5 +18,9 @@ describe("OPTIONS handler", async () => {
       "Access-Control-Allow-Origin":
         "https://dc.library.northwestern.edu/origin-test-path",
     });
+
+    expect(
+      response.headers["Access-Control-Allow-Headers"].split(/, /)
+    ).to.include("Content-Type");
   });
 });

--- a/test/integration/search.test.js
+++ b/test/integration/search.test.js
@@ -4,7 +4,6 @@ const chai = require("chai");
 const expect = chai.expect;
 const searchHandlers = require("../../src/handlers/search");
 const RequestPipeline = require("../../src/api/request/pipeline");
-const { processRequest } = require("../../src/handlers/middleware");
 
 chai.use(require("chai-http"));
 
@@ -16,7 +15,7 @@ describe("Search routes", () => {
     const handler = searchHandlers.postSearch;
     const originalQuery = { query: { match_all: {} } };
     const authQuery = new RequestPipeline(originalQuery)
-      .authFilter(processRequest({}))
+      .authFilter(helpers.preprocess({}))
       .toJson();
 
     it("performs a works search by default", async () => {
@@ -82,7 +81,7 @@ describe("Search routes", () => {
     const handler = searchHandlers.getSearch;
     const originalQuery = { query: { match_all: {} } };
     const authQuery = new RequestPipeline(originalQuery)
-      .authFilter(processRequest({}))
+      .authFilter(helpers.preprocess({}))
       .toJson();
     const searchToken =
       "N4IgRg9gJgniBcoCOBXApgJzokBbAhgC4DGAFgPr4A2VCwAvvQDQgDOAlgF5oICMADMzzQ0VVggDaIAO4QMAa3EBdekA";
@@ -94,7 +93,7 @@ describe("Search routes", () => {
       const event = helpers.mockEvent("GET", "/search").queryParams().render();
 
       const authQuery = new RequestPipeline(originalQuery)
-        .authFilter(processRequest(event))
+        .authFilter(helpers.preprocess(event))
         .toJson();
 
       mock
@@ -165,7 +164,7 @@ describe("Search routes", () => {
         .queryParams({ as: "iiif" })
         .render();
       const authQuery = new RequestPipeline(originalQuery)
-        .authFilter(processRequest(event))
+        .authFilter(helpers.preprocess(event))
         .toJson();
 
       mock
@@ -192,7 +191,7 @@ describe("Search routes", () => {
         .queryParams({ sort: "create_date:asc,modified_date:desc" })
         .render();
       const authQuery = new RequestPipeline(originalQuery)
-        .authFilter(processRequest(event))
+        .authFilter(helpers.preprocess(event))
         .toJson();
 
       mock

--- a/test/test-helpers/index.js
+++ b/test/test-helpers/index.js
@@ -1,7 +1,7 @@
+const { _processRequest } = require("../../src/handlers/middleware");
 const fs = require("fs");
 const nock = require("nock");
 const path = require("path");
-const { isArray } = require("util");
 const EventBuilder = require("./event-builder.js");
 
 function saveEnvironment() {
@@ -77,4 +77,5 @@ global.helpers = {
   encodedFixture,
   testFixture,
   cookieValue,
+  preprocess: _processRequest,
 };

--- a/test/unit/api/request/pipeline.test.js
+++ b/test/unit/api/request/pipeline.test.js
@@ -3,7 +3,6 @@
 const RequestPipeline = require("../../../../src/api/request/pipeline");
 const chai = require("chai");
 const expect = chai.expect;
-const { processRequest } = require("../../../../src/handlers/middleware");
 const ApiToken = require("../../../../src/api/api-token");
 
 describe("RequestPipeline", () => {
@@ -28,7 +27,7 @@ describe("RequestPipeline", () => {
   it("adds an auth filter", () => {
     event.userToken = new ApiToken();
 
-    const result = pipeline.authFilter(event);
+    const result = pipeline.authFilter(helpers.preprocess(event));
     expect(result.searchContext.size).to.eq(50);
     expect(result.searchContext.query.bool.must).to.include(requestBody.query);
     expect(result.searchContext.query.bool.must_not).to.deep.include(
@@ -46,7 +45,7 @@ describe("RequestPipeline", () => {
       event.userToken = new ApiToken();
 
       // process.env.READING_ROOM_IPS = "192.168.0.1,172.16.10.2";
-      const result = pipeline.authFilter(event);
+      const result = pipeline.authFilter(helpers.preprocess(event));
       expect(result.searchContext.size).to.eq(50);
       expect(result.searchContext.query.bool.must).to.include(
         requestBody.query
@@ -60,7 +59,7 @@ describe("RequestPipeline", () => {
     it("includes private results if the user is in the reading room", () => {
       event.userToken = new ApiToken().readingRoom();
 
-      const result = pipeline.authFilter(event);
+      const result = pipeline.authFilter(helpers.preprocess(event));
       expect(result.searchContext.size).to.eq(50);
       expect(result.searchContext.query.bool.must).to.include(
         requestBody.query


### PR DESCRIPTION
- Refactor middleware into a single function wrapper to DRY up handlers
- Give test helper explicit access to `processRequest` for use in setup
- Remove some unused requires

It was my intention to wrap handlers like:
```JavaScript
module.exports.handler = wrap(
  async (event) => {
    // ... handler code
  }
);
```
because I thought it called more attention to the fact that the function was being wrapped. But `prettier` preferred
```JavaScript
module.exports.handler = wrap(async (event) => {
  // ... handler code
});
```