### PR TITLE
Add support for 'for' and 'until' in OAI-PHM ListRecords and ListIdentifiers verbs

### DIFF
--- a/src/handlers/oai.js
+++ b/src/handlers/oai.js
@@ -21,7 +21,7 @@ const allowedVerbs = [
 function invalidDateParameters(verb, dates) {
   if (!["ListRecords", "ListIdentifiers"].includes(verb)) return [];
 
-  const regex = new RegExp(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/);
+  const regex = new RegExp(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}Z$/);
   let invalidDates = [];
 
   for (const [dateParameter, dateValue] of Object.entries(dates)) {
@@ -62,7 +62,7 @@ exports.handler = wrap(async (event) => {
   if (invalidDateParameters(verb, dates).length > 0)
     return invalidOaiRequest(
       "badArgument",
-      "Invalid date -- make sure that 'from' or 'until' parameters are formatted as: 'YYYY-MM-DDThh:mm:ss.ffffff'"
+      "Invalid date -- make sure that 'from' or 'until' parameters are formatted as: 'YYYY-MM-DDThh:mm:ss.ffffffZ'"
     );
   if (!verb) return invalidOaiRequest("badArgument", "Missing required verb");
 

--- a/src/handlers/oai.js
+++ b/src/handlers/oai.js
@@ -18,6 +18,23 @@ const allowedVerbs = [
   "ListSets",
 ];
 
+function invalidDateParameters(verb, dates) {
+  if (!["ListRecords", "ListIdentifiers"].includes(verb)) return [];
+
+  const regex = new RegExp(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{6}$/);
+  let invalidDates = [];
+
+  for (const [dateParameter, dateValue] of Object.entries(dates)) {
+    if (dateValue && !regex.test(dateValue)) {
+      invalidDates.push(dateParameter);
+    } else {
+      continue;
+    }
+  }
+
+  return invalidDates;
+}
+
 /**
  * A function to support the OAI-PMH harvesting specfication
  */
@@ -29,14 +46,24 @@ exports.handler = wrap(async (event) => {
     identifier = event.queryStringParameters?.identifier;
     metadataPrefix = event.queryStringParameters?.metadataPrefix;
     resumptionToken = event.queryStringParameters?.resumptionToken;
+    from = event.queryStringParameters?.from;
+    until = event.queryStringParameters?.until;
   } else {
     const body = new URLSearchParams(event.body);
     verb = body.get("verb");
     identifier = body.get("identifier");
     metadataPrefix = body.get("metadataPrefix");
     resumptionToken = body.get("resumptionToken");
+    from = body.get("from");
+    until = body.get("until");
   }
 
+  const dates = { from, until };
+  if (invalidDateParameters(verb, dates).length > 0)
+    return invalidOaiRequest(
+      "badArgument",
+      "Invalid date -- make sure that 'from' or 'until' parameters are formatted as: 'YYYY-MM-DDThh:mm:ss.ffffff'"
+    );
   if (!verb) return invalidOaiRequest("badArgument", "Missing required verb");
 
   switch (verb) {
@@ -45,11 +72,23 @@ exports.handler = wrap(async (event) => {
     case "Identify":
       return await identify(url);
     case "ListIdentifiers":
-      return await listIdentifiers(url, event, metadataPrefix, resumptionToken);
+      return await listIdentifiers(
+        url,
+        event,
+        metadataPrefix,
+        dates,
+        resumptionToken
+      );
     case "ListMetadataFormats":
       return await listMetadataFormats(url);
     case "ListRecords":
-      return await listRecords(url, event, metadataPrefix, resumptionToken);
+      return await listRecords(
+        url,
+        event,
+        metadataPrefix,
+        dates,
+        resumptionToken
+      );
     case "ListSets":
       return invalidOaiRequest(
         "noSetHierarchy",

--- a/src/handlers/oai/search.js
+++ b/src/handlers/oai/search.js
@@ -28,14 +28,14 @@ async function earliestRecord() {
 }
 
 async function oaiSearch(dates) {
-  let rangeQuery = { range: { create_date: {} } };
+  let rangeQuery = { range: { modified_date: {} } };
 
   if (dates.from) {
-    rangeQuery.range.create_date.gt = dates.from;
+    rangeQuery.range.modified_date.gt = dates.from;
   }
 
   if (dates.until) {
-    rangeQuery.range.create_date.lt = dates.until;
+    rangeQuery.range.modified_date.lt = dates.until;
   }
 
   const body = {
@@ -50,7 +50,7 @@ async function oaiSearch(dates) {
         ],
       },
     },
-    sort: [{ create_date: "asc" }],
+    sort: [{ modified_date: "asc" }],
   };
 
   const esResponse = await search(

--- a/src/handlers/oai/search.js
+++ b/src/handlers/oai/search.js
@@ -7,7 +7,7 @@ const {
 async function earliestRecord() {
   const body = {
     size: 1,
-    _source: "indexed_at",
+    _source: "create_date",
     query: {
       bool: {
         must: [
@@ -17,29 +17,29 @@ async function earliestRecord() {
         ],
       },
     },
-    sort: [{ indexed_at: "asc" }],
+    sort: [{ create_date: "asc" }],
   };
   const esResponse = await search(
     modelsToTargets(extractRequestedModels()),
     JSON.stringify(body)
   );
   const responseBody = JSON.parse(esResponse.body);
-  return responseBody?.hits?.hits[0]?._source?.indexed_at;
+  return responseBody?.hits?.hits[0]?._source?.create_date;
 }
 
 async function oaiSearch(dates) {
-  let rangeQuery = { range: { indexed_at: {} } };
+  let rangeQuery = { range: { create_date: {} } };
 
   if (dates.from) {
-    rangeQuery.range.indexed_at.gt = dates.from;
+    rangeQuery.range.create_date.gt = dates.from;
   }
 
   if (dates.until) {
-    rangeQuery.range.indexed_at.lt = dates.until;
+    rangeQuery.range.create_date.lt = dates.until;
   }
 
   const body = {
-    size: 5000,
+    size: 1000,
     query: {
       bool: {
         must: [
@@ -50,7 +50,7 @@ async function oaiSearch(dates) {
         ],
       },
     },
-    sort: [{ indexed_at: "asc" }],
+    sort: [{ create_date: "asc" }],
   };
 
   const esResponse = await search(

--- a/src/handlers/oai/verbs.js
+++ b/src/handlers/oai/verbs.js
@@ -138,8 +138,8 @@ const listIdentifiers = async (
 
   if (response.statusCode == 200) {
     const responseBody = JSON.parse(response.body);
-    let scrollId = responseBody._scroll_id;
     const hits = responseBody.hits.hits;
+    let scrollId = responseBody._scroll_id;
 
     if (hits.length === 0) {
       await deleteScroll(scrollId);

--- a/src/handlers/oai/verbs.js
+++ b/src/handlers/oai/verbs.js
@@ -109,7 +109,7 @@ const identify = async (url) => {
         protocolVersion: "2.0",
         earliestDatestamp: earliestDatestamp,
         deletedRecord: "no",
-        granularity: "YYYY-MM-DDThh:mm:ss.ffffff",
+        granularity: "YYYY-MM-DDThh:mm:ss.ffffffZ",
       },
     },
   };
@@ -184,7 +184,7 @@ const listIdentifiers = async (
   } else {
     return invalidOaiRequest(
       "badRequest",
-      "An error occurred processing the ListRecords request"
+      "An error occurred processing the ListIdentifiers request"
     );
   }
 };

--- a/src/handlers/oai/verbs.js
+++ b/src/handlers/oai/verbs.js
@@ -1,5 +1,5 @@
 const { invalidOaiRequest, output } = require("../oai/xml-transformer");
-const { earliestRecordCreateDate, oaiSearch } = require("../oai/search");
+const { earliestRecord, oaiSearch } = require("../oai/search");
 const { deleteScroll, getWork, scroll } = require("../../api/opensearch");
 
 const fieldMapper = {
@@ -92,7 +92,7 @@ const getRecord = async (url, id) => {
 };
 
 const identify = async (url) => {
-  let earliestDatestamp = await earliestRecordCreateDate();
+  let earliestDatestamp = await earliestRecord();
   const obj = {
     OAI_PMH: {
       _attributes: oaiAttributes,
@@ -109,14 +109,20 @@ const identify = async (url) => {
         protocolVersion: "2.0",
         earliestDatestamp: earliestDatestamp,
         deletedRecord: "no",
-        granularity: "YYYY-MM-DDThh:mm:ssZ",
+        granularity: "YYYY-MM-DDThh:mm:ss.ffffff",
       },
     },
   };
   return output(obj);
 };
 
-const listIdentifiers = async (url, event, metadataPrefix, resumptionToken) => {
+const listIdentifiers = async (
+  url,
+  event,
+  metadataPrefix,
+  dates,
+  resumptionToken
+) => {
   if (!metadataPrefix) {
     return invalidOaiRequest(
       "badArgument",
@@ -126,7 +132,7 @@ const listIdentifiers = async (url, event, metadataPrefix, resumptionToken) => {
   const response =
     typeof resumptionToken === "string" && resumptionToken.length !== 0
       ? await scroll(resumptionToken)
-      : await oaiSearch();
+      : await oaiSearch(dates);
   let headers = [];
   let resumptionTokenElement;
 
@@ -206,7 +212,13 @@ const listMetadataFormats = (url) => {
   return output(obj);
 };
 
-const listRecords = async (url, event, metadataPrefix, resumptionToken) => {
+const listRecords = async (
+  url,
+  event,
+  metadataPrefix,
+  dates,
+  resumptionToken
+) => {
   if (!metadataPrefix) {
     return invalidOaiRequest(
       "badArgument",
@@ -216,7 +228,7 @@ const listRecords = async (url, event, metadataPrefix, resumptionToken) => {
   const response =
     typeof resumptionToken === "string" && resumptionToken.length !== 0
       ? await scroll(resumptionToken)
-      : await oaiSearch();
+      : await oaiSearch(dates);
   let records = [];
   let resumptionTokenElement;
 

--- a/template.yaml
+++ b/template.yaml
@@ -370,6 +370,7 @@ Resources:
     Properties:
       Handler: handlers/oai.handler
       Description: Transforms works into OAI Records.
+      Timeout: 60
       Policies:
         Version: 2012-10-17
         Statement:

--- a/test/fixtures/mocks/search-earliest-indexed-at.json
+++ b/test/fixtures/mocks/search-earliest-indexed-at.json
@@ -20,7 +20,7 @@
         "_id": "559ca7fb-55d1-45dc-9d8d-bd2ae2de6ae5",
         "_score": null,
         "_source": {
-          "create_date": "2022-11-22T20:36:00.581418Z"
+          "indexed_at": "2022-11-22T20:36:00.581418"
         },
         "sort": [1669149360581]
       }

--- a/test/fixtures/mocks/search-earliest-record.json
+++ b/test/fixtures/mocks/search-earliest-record.json
@@ -20,7 +20,7 @@
         "_id": "559ca7fb-55d1-45dc-9d8d-bd2ae2de6ae5",
         "_score": null,
         "_source": {
-          "indexed_at": "2022-11-22T20:36:00.581418"
+          "create_date": "2022-11-22T20:36:00.581418Z"
         },
         "sort": [1669149360581]
       }

--- a/test/integration/oai.test.js
+++ b/test/integration/oai.test.js
@@ -107,13 +107,13 @@ describe("Oai routes", () => {
         "badArgument"
       );
       expect(resultBody.OAI_PMH.error["_text"]).to.eq(
-        "Invalid date -- make sure that 'from' or 'until' parameters are formatted as: 'YYYY-MM-DDThh:mm:ss.ffffff'"
+        "Invalid date -- make sure that 'from' or 'until' parameters are formatted as: 'YYYY-MM-DDThh:mm:ss.ffffffZ'"
       );
     });
 
     it("supports 'from' and 'until' parameters in ListRecords and ListIdentifiers verbs", async () => {
       const body =
-        "verb=ListRecords&metadataPrefix=oai_dc&from=2022-11-22T06:16:13.791570&until=2022-11-22T06:16:13.791572";
+        "verb=ListRecords&metadataPrefix=oai_dc&from=2022-11-22T06:16:13.791570Z&until=2022-11-22T06:16:13.791572Z";
       mock
         .post("/dc-v2-work/_search?scroll=2m")
         .reply(200, helpers.testFixture("mocks/scroll.json"));
@@ -249,7 +249,7 @@ describe("Oai routes", () => {
     it("supports the Identify verb", async () => {
       const query = {
         size: 1,
-        _source: "indexed_at",
+        _source: "create_date",
         query: {
           bool: {
             must: [
@@ -259,14 +259,11 @@ describe("Oai routes", () => {
             ],
           },
         },
-        sort: [{ indexed_at: "asc" }],
+        sort: [{ create_date: "asc" }],
       };
       mock
         .post("/dc-v2-work/_search", query)
-        .reply(
-          200,
-          helpers.testFixture("mocks/search-earliest-indexed-at.json")
-        );
+        .reply(200, helpers.testFixture("mocks/search-earliest-record.json"));
       const event = helpers
         .mockEvent("GET", "/oai")
         .queryParams({ verb: "Identify", metadataPrefix: "oai_dc" })
@@ -277,11 +274,11 @@ describe("Oai routes", () => {
       const resultBody = convert.xml2js(result.body, xmlOpts);
       const identifyElement = resultBody.OAI_PMH.Identify;
       expect(identifyElement.earliestDatestamp._text).to.eq(
-        "2022-11-22T20:36:00.581418"
+        "2022-11-22T20:36:00.581418Z"
       );
       expect(identifyElement.deletedRecord._text).to.eq("no");
       expect(identifyElement.granularity._text).to.eq(
-        "YYYY-MM-DDThh:mm:ss.ffffff"
+        "YYYY-MM-DDThh:mm:ss.ffffffZ"
       );
     });
 
@@ -433,7 +430,7 @@ describe("Oai routes", () => {
         "badRequest"
       );
       expect(resultBody.OAI_PMH.error["_text"]).to.eq(
-        "An error occurred processing the ListRecords request"
+        "An error occurred processing the ListIdentifiers request"
       );
     });
 


### PR DESCRIPTION
## Steps to test

1. Index some data
2. Run a ListRecords or ListIdentifiers request with either or both `from` and `until` parameters e.g. `http://localhost:3000/oai?verb=ListRecords&metadataPrefix=oai_dc&from=2023-01-10T21:47:18.462902` (note the required format is `YYYY-MM-DDThh:mm:ss:ffffff`). Note the `indexed_at` values are inclusive of the date parameters.
3. Tweak the values for `from` and `until` and you should see different results that fall within the dates.
4. Test validation by passing in invalid date formats like `2023-01-10` or `2023-01-10T21:47:18.462902Z`