### PR TITLE
Provide better error message from API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2733,6 +2733,11 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -4674,6 +4679,7 @@
         "@aws-sdk/signature-v4": "^3.130.0",
         "axios": ">=0.21.1",
         "cookie": "^0.5.0",
+        "http-status-codes": "^2.2.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
@@ -6188,6 +6194,7 @@
         "@aws-sdk/signature-v4": "^3.130.0",
         "axios": ">=0.21.1",
         "cookie": "^0.5.0",
+        "http-status-codes": "^2.2.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
@@ -6531,6 +6538,11 @@
     "html-escaper": {
       "version": "2.0.2",
       "dev": true
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "iconv-lite": {
       "version": "0.4.24",

--- a/src/api/response/error.js
+++ b/src/api/response/error.js
@@ -1,0 +1,15 @@
+const { getReasonPhrase } = require("http-status-codes");
+
+function transformError(response) {
+  const responseBody = {
+    status: response.statusCode,
+    error: getReasonPhrase(response.statusCode),
+  };
+
+  return {
+    statusCode: response.statusCode,
+    body: JSON.stringify(responseBody),
+  };
+}
+
+module.exports = { transformError };

--- a/src/api/response/iiif/collection.js
+++ b/src/api/response/iiif/collection.js
@@ -1,4 +1,5 @@
 const { dcApiEndpoint, dcUrl } = require("../../../environment");
+const { transformError } = require("../error");
 
 async function transform(response, pager) {
   if (response.statusCode === 200) {
@@ -138,15 +139,6 @@ function loadItem(item) {
         height: 400,
       },
     ],
-  };
-}
-
-function transformError(response) {
-  const responseBody = { status: response.statusCode, error: "TODO" };
-
-  return {
-    statusCode: response.statusCode,
-    body: JSON.stringify(responseBody),
   };
 }
 

--- a/src/api/response/iiif/manifest.js
+++ b/src/api/response/iiif/manifest.js
@@ -1,5 +1,6 @@
 const { IIIFBuilder } = require("iiif-builder");
 const { dcApiEndpoint, dcUrl } = require("../../../environment");
+const { transformError } = require("../error");
 const {
   buildAnnotationBody,
   buildImageResourceId,
@@ -244,18 +245,6 @@ function transform(response) {
     };
   }
   return transformError(response);
-}
-
-function transformError(response) {
-  const responseBody = {
-    status: response.statusCode,
-    error: "TODO",
-  };
-
-  return {
-    statusCode: response.statusCode,
-    body: JSON.stringify(responseBody),
-  };
 }
 
 module.exports = { transform };

--- a/src/api/response/opensearch/index.js
+++ b/src/api/response/opensearch/index.js
@@ -1,3 +1,5 @@
+const { transformError } = require("../error");
+
 async function transform(response, pager) {
   if (response.statusCode === 200) {
     const responseBody = JSON.parse(response.body);
@@ -39,18 +41,6 @@ async function paginationInfo(responseBody, pager) {
   );
 
   return pageInfo;
-}
-
-function transformError(response) {
-  const responseBody = {
-    status: response.statusCode,
-    error: "TODO",
-  };
-
-  return {
-    statusCode: response.statusCode,
-    body: JSON.stringify(responseBody),
-  };
 }
 
 function extractSource(hits) {

--- a/src/api/response/transformer.js
+++ b/src/api/response/transformer.js
@@ -1,3 +1,4 @@
+const { transformError } = require("./error.js");
 const iiifCollectionResponse = require("./iiif/collection.js");
 const opensearchResponse = require("./opensearch");
 
@@ -13,18 +14,6 @@ async function transformSearchResult(response, pager) {
     return await opensearchResponse.transform(response, pager);
   }
   return transformError(response);
-}
-
-function transformError(response) {
-  const responseBody = {
-    status: response.statusCode,
-    error: "TODO",
-  };
-
-  return {
-    statusCode: response.statusCode,
-    body: JSON.stringify(responseBody),
-  };
 }
 
 module.exports = { transformSearchResult };

--- a/src/handlers/default-request.js
+++ b/src/handlers/default-request.js
@@ -1,0 +1,6 @@
+const { transformError } = require("../api/response/error");
+const { wrap } = require("./middleware");
+
+module.exports.handler = wrap(async () => {
+  return transformError({ statusCode: 404 });
+});

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -16,6 +16,7 @@
         "@aws-sdk/signature-v4": "^3.130.0",
         "axios": ">=0.21.1",
         "cookie": "^0.5.0",
+        "http-status-codes": "^2.2.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
         "lodash": "^4.17.21",
@@ -1210,6 +1211,11 @@
       "engines": {
         "node": ">=12.20.0"
       }
+    },
+    "node_modules/http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "node_modules/iiif-builder": {
       "version": "1.0.6",
@@ -2583,6 +2589,11 @@
       "requires": {
         "fetch-blob": "^3.1.2"
       }
+    },
+    "http-status-codes": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/http-status-codes/-/http-status-codes-2.2.0.tgz",
+      "integrity": "sha512-feERVo9iWxvnejp3SEfm/+oNG517npqL2/PIA8ORjyOZjGC7TwCRQsZylciLS64i6pJ0wRYz3rkXLRwbtFa8Ng=="
     },
     "iiif-builder": {
       "version": "1.0.6",

--- a/src/package.json
+++ b/src/package.json
@@ -13,6 +13,7 @@
     "@aws-sdk/signature-v4": "^3.130.0",
     "axios": ">=0.21.1",
     "cookie": "^0.5.0",
+    "http-status-codes": "^2.2.0",
     "iiif-builder": "^1.0.6",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.21",

--- a/template.yaml
+++ b/template.yaml
@@ -391,6 +391,19 @@ Resources:
             ApiId: !Ref dcApi
             Path: /oai
             Method: POST
+  defaultFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers/default-request.handler
+      Timeout: 3
+      Description: Handles all other requests
+      Events:
+        Everything:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: $default
+            Method: ANY
   dcApi:
     Type: AWS::Serverless::HttpApi
     Properties:

--- a/test/integration/default-handler.test.js
+++ b/test/integration/default-handler.test.js
@@ -1,0 +1,21 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+const defaultHandler = require("../../src/handlers/default-request");
+
+describe("$default handler", async () => {
+  const event = helpers
+    .mockEvent("GET", "/blah")
+    .headers({
+      Origin: "https://dc.library.northwestern.edu/origin-test-path",
+    })
+    .render();
+
+  it("returns a 404 response", async () => {
+    const response = await defaultHandler.handler(event);
+    expect(response.statusCode).to.eq(404);
+    expect(JSON.parse(response.body).status).to.eq(404);
+    expect(JSON.parse(response.body).error).to.eq("Not Found");
+  });
+});

--- a/test/unit/api/response/error.test.js
+++ b/test/unit/api/response/error.test.js
@@ -1,0 +1,17 @@
+const errorTransformer = require("../../../../src/api/response/error");
+const chai = require("chai");
+const expect = chai.expect;
+
+describe("The error response", () => {
+  it("Transforms a missing work response", async () => {
+    const response = {
+      statusCode: 404,
+      body: helpers.testFixture("mocks/missing-work-1234.json"),
+    };
+    const result = errorTransformer.transformError(response);
+
+    expect(result.statusCode).to.eq(404);
+    expect(JSON.parse(result.body).status).to.eq(404);
+    expect(JSON.parse(result.body).error).to.eq("Not Found");
+  });
+});


### PR DESCRIPTION
- Provide http status reason text instead of "TODO" when the API errors or does not find a result
- Consolidate separate `transformError` functions