### PR TITLE
Increase thumbnail route timeout

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -238,6 +238,7 @@ Resources:
     Properties:
       Handler: handlers/get-thumbnail.handler
       Description: Gets a Work's representative thumbnail.
+      Timeout: 10
       Policies:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
Global timeout on the API is 3 seconds, but it looks like the lambda is taking over 3 seconds (extremely large image), and the /thumbnail response is timing out. 

API log:

<img width="1325" alt="Screen Shot 2023-01-13 at 8 41 29 AM" src="https://user-images.githubusercontent.com/6372022/212374912-10b6e316-29f8-45a4-a188-15c8d2e810f4.png">


IIIF server log: 

<img width="1319" alt="Screen Shot 2023-01-13 at 8 48 49 AM" src="https://user-images.githubusercontent.com/6372022/212374940-2615f5c0-d176-4178-90a9-b105415dc905.png">

