### PR TITLE
Add support for sets in ListSets, ListRecords, and GetRecords OAI requests

### DIFF
--- a/src/handlers/oai.js
+++ b/src/handlers/oai.js
@@ -5,6 +5,7 @@ const {
   listIdentifiers,
   listMetadataFormats,
   listRecords,
+  listSets,
 } = require("./oai/verbs");
 const { invalidOaiRequest } = require("./oai/xml-transformer");
 const { wrap } = require("./middleware");
@@ -72,29 +73,13 @@ exports.handler = wrap(async (event) => {
     case "Identify":
       return await identify(url);
     case "ListIdentifiers":
-      return await listIdentifiers(
-        url,
-        event,
-        metadataPrefix,
-        dates,
-        resumptionToken
-      );
+      return await listIdentifiers(url, metadataPrefix, dates, resumptionToken);
     case "ListMetadataFormats":
       return await listMetadataFormats(url);
     case "ListRecords":
-      return await listRecords(
-        url,
-        event,
-        metadataPrefix,
-        dates,
-        resumptionToken
-      );
+      return await listRecords(url, metadataPrefix, dates, resumptionToken);
     case "ListSets":
-      return invalidOaiRequest(
-        "noSetHierarchy",
-        "This repository does not support Sets",
-        401
-      );
+      return await listSets(url, resumptionToken);
     default:
       return invalidOaiRequest("badVerb", "Illegal OAI verb");
   }

--- a/src/handlers/oai/search.js
+++ b/src/handlers/oai/search.js
@@ -64,4 +64,27 @@ async function oaiSearch(dates) {
   };
 }
 
-module.exports = { earliestRecord, oaiSearch };
+async function oaiSets() {
+  const body = {
+    size: 10000,
+    _source: ["id", "title"],
+    query: {
+      bool: {
+        must: [
+          { term: { api_model: "Collection" } },
+          { term: { published: true } },
+          { term: { visibility: "Public" } },
+        ],
+      },
+    },
+    sort: [{ title: "asc" }],
+  };
+
+  const esResponse = await search(
+    modelsToTargets(["collections"]),
+    JSON.stringify(body)
+  );
+  return esResponse;
+}
+
+module.exports = { earliestRecord, oaiSearch, oaiSets };

--- a/test/fixtures/mocks/oai-sets.json
+++ b/test/fixtures/mocks/oai-sets.json
@@ -1,0 +1,44 @@
+{
+  "took": 1,
+  "timed_out": false,
+  "_shards": { "total": 1, "successful": 1, "skipped": 0, "failed": 0 },
+  "hits": {
+    "total": { "value": 43, "relation": "eq" },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "dc-v2-collection-1673551116148",
+        "_type": "_doc",
+        "_id": "1c2e2200-c12d-4c7f-8b87-a935c349898a",
+        "_score": null,
+        "_source": {
+          "id": "1c2e2200-c12d-4c7f-8b87-a935c349898a",
+          "title": "16th-Early 20th Century Maps of Africa"
+        },
+        "sort": ["16th-Early 20th Century Maps of Africa"]
+      },
+      {
+        "_index": "dc-v2-collection-1673551116148",
+        "_type": "_doc",
+        "_id": "c4f30015-88b5-4291-b3a6-8ac9b7c7069c",
+        "_score": null,
+        "_source": {
+          "id": "c4f30015-88b5-4291-b3a6-8ac9b7c7069c",
+          "title": "Alexander Hesler Photograph Collection"
+        },
+        "sort": ["Alexander Hesler Photograph Collection"]
+      },
+      {
+        "_index": "dc-v2-collection-1673551116148",
+        "_type": "_doc",
+        "_id": "30d59215-8f2b-470d-967b-5a721fa366b7",
+        "_score": null,
+        "_source": {
+          "id": "30d59215-8f2b-470d-967b-5a721fa366b7",
+          "title": "Ann C. Gunter Slide Collection"
+        },
+        "sort": ["Ann C. Gunter Slide Collection"]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for OAI-PMH `sets`. Sets map one-to-one with our public/published collections. Each record in `GetRecord` or `ListRecord` requests should return `set` information (when a work is part of a collection). Also adds support for the `ListSets` verb which returns a list of all possible sets in the repository.

## Steps to test

1. Index some works associated with collections
2. Run `GetRecord` and `ListRecords` requests and look for `setSpec` and `setName` elements
3. Run `ListSets` and you should get a list of `set` elements containing `setSpec` and `setName`