### PR TITLE
Add support for the set parameter in ListIdentifiers and ListRecords

### DIFF
--- a/src/handlers/oai.js
+++ b/src/handlers/oai.js
@@ -49,6 +49,7 @@ exports.handler = wrap(async (event) => {
     resumptionToken = event.queryStringParameters?.resumptionToken;
     from = event.queryStringParameters?.from;
     until = event.queryStringParameters?.until;
+    set = event.queryStringParameters?.set;
   } else {
     const body = new URLSearchParams(event.body);
     verb = body.get("verb");
@@ -57,6 +58,7 @@ exports.handler = wrap(async (event) => {
     resumptionToken = body.get("resumptionToken");
     from = body.get("from");
     until = body.get("until");
+    set = body.get("set");
   }
 
   const dates = { from, until };
@@ -73,11 +75,23 @@ exports.handler = wrap(async (event) => {
     case "Identify":
       return await identify(url);
     case "ListIdentifiers":
-      return await listIdentifiers(url, metadataPrefix, dates, resumptionToken);
+      return await listIdentifiers(
+        url,
+        metadataPrefix,
+        dates,
+        set,
+        resumptionToken
+      );
     case "ListMetadataFormats":
       return await listMetadataFormats(url);
     case "ListRecords":
-      return await listRecords(url, metadataPrefix, dates, resumptionToken);
+      return await listRecords(
+        url,
+        metadataPrefix,
+        dates,
+        set,
+        resumptionToken
+      );
     case "ListSets":
       return await listSets(url, resumptionToken);
     default:

--- a/src/handlers/oai/verbs.js
+++ b/src/handlers/oai/verbs.js
@@ -40,7 +40,7 @@ function header(work) {
     };
   }
 
-  return { header: fields };
+  return fields;
 }
 
 function transform(work) {
@@ -66,7 +66,7 @@ function transform(work) {
     },
   };
 
-  return { ...header(work), ...metadata };
+  return { header: { ...header(work) }, ...metadata };
 }
 
 const getRecord = async (url, id) => {
@@ -129,7 +129,13 @@ const identify = async (url) => {
   return output(obj);
 };
 
-const listIdentifiers = async (url, metadataPrefix, dates, resumptionToken) => {
+const listIdentifiers = async (
+  url,
+  metadataPrefix,
+  dates,
+  set,
+  resumptionToken
+) => {
   if (!metadataPrefix) {
     return invalidOaiRequest(
       "badArgument",
@@ -139,8 +145,7 @@ const listIdentifiers = async (url, metadataPrefix, dates, resumptionToken) => {
   const response =
     typeof resumptionToken === "string" && resumptionToken.length !== 0
       ? await scroll(resumptionToken)
-      : await oaiSearch(dates);
-  let headers = [];
+      : await oaiSearch(dates, set);
   let resumptionTokenElement;
 
   if (response.statusCode == 200) {
@@ -152,8 +157,8 @@ const listIdentifiers = async (url, metadataPrefix, dates, resumptionToken) => {
       await deleteScroll(scrollId);
       scrollId = "";
     }
-    headers = hits.map((hit) => header(hit._source));
 
+    const headers = hits.map((hit) => header(hit._source));
     resumptionTokenElement = {
       _attributes: {
         expirationDate: response.expiration,
@@ -172,7 +177,7 @@ const listIdentifiers = async (url, metadataPrefix, dates, resumptionToken) => {
           _text: url,
         },
         ListIdentifiers: {
-          header: headers,
+          headers: { header: headers },
           resumptionToken: resumptionTokenElement,
         },
       },
@@ -219,7 +224,13 @@ const listMetadataFormats = (url) => {
   return output(obj);
 };
 
-const listRecords = async (url, metadataPrefix, dates, resumptionToken) => {
+const listRecords = async (
+  url,
+  metadataPrefix,
+  dates,
+  set,
+  resumptionToken
+) => {
   if (!metadataPrefix) {
     return invalidOaiRequest(
       "badArgument",
@@ -229,7 +240,7 @@ const listRecords = async (url, metadataPrefix, dates, resumptionToken) => {
   const response =
     typeof resumptionToken === "string" && resumptionToken.length !== 0
       ? await scroll(resumptionToken)
-      : await oaiSearch(dates);
+      : await oaiSearch(dates, set);
   let records = [];
   let resumptionTokenElement;
 

--- a/test/fixtures/mocks/oai-list-identifiers-sets.json
+++ b/test/fixtures/mocks/oai-list-identifiers-sets.json
@@ -1,0 +1,100 @@
+{
+  "took": 29,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": [
+      {
+        "_index": "dc-v2-work-1673550300442",
+        "_type": "_doc",
+        "_id": "c6b8a744-aa8a-4437-b885-175f3816f9cd",
+        "_score": null,
+        "_source": {
+          "folder_names": [],
+          "catalog_key": [],
+          "related_url": [],
+          "batch_ids": [],
+          "legacy_identifier": [],
+          "publisher": [],
+          "creator": [],
+          "work_type": "Image",
+          "accession_number": "Accession:inu-test",
+          "date_created": [],
+          "genre": [],
+          "box_name": [],
+          "abstract": [],
+          "modified_date": "2022-11-22T06:16:12.323005Z",
+          "keywords": [],
+          "description": [],
+          "location": [],
+          "preservation_level": "Level 1",
+          "box_number": ["2"],
+          "cultural_context": [],
+          "caption": [],
+          "rights_holder": [],
+          "physical_description_material": [],
+          "title": "Test Collection",
+          "collection": {
+            "description": "Test Description",
+            "id": "c4f30015-88b5-4291-b3a6-8ac9b7c7069c",
+            "title": "Test Collection"
+          },
+          "source": [],
+          "scope_and_contents": [],
+          "ingest_project": {},
+          "thumbnail": "https://dcapi.test.library.northwestern.edu/works/c6b8a744-aa8a-4437-b885-175f3816f9cd/thumbnail",
+          "identifier": [],
+          "physical_description_size": [],
+          "ark": "ark:/test/test",
+          "file_sets": [],
+          "related_material": [],
+          "language": [],
+          "api_link": "https://dcapi.test.library.northwestern.edu/works/c6b8a744-aa8a-4437-b885-175f3816f9cd",
+          "alternate_title": [],
+          "series": [],
+          "api_model": "Work",
+          "id": "c6b8a744-aa8a-4437-b885-175f3816f9cd",
+          "project": {},
+          "published": true,
+          "rights_statement": {
+            "id": "http://rightsstatements.org/vocab/NoC-US/1.0/",
+            "label": "No Copyright - United States"
+          },
+          "notes": [],
+          "visibility": "Public",
+          "table_of_contents": [],
+          "indexed_at": "2023-01-12T19:05:00.626875",
+          "representative_file_set": {
+            "aspect_ratio": 1.59402,
+            "id": "a04e4a28-340f-46cb-aca2-9e7f5713ae84",
+            "url": "https://iiif.test.rdc.library.northwestern.edu/iiif/2/dev/a04e4a28-340f-46cb-aca2-9e7f5713ae84"
+          },
+          "library_unit": "",
+          "subject": [],
+          "status": "Done",
+          "ingest_sheet": {},
+          "technique": [],
+          "folder_numbers": [],
+          "license": null,
+          "terms_of_use": "",
+          "provenance": [],
+          "iiif_manifest": "https://dcapi.rdc-staging.library.northwestern.edu/works/c6b8a744-aa8a-4437-b885-175f3816f9cd?as=iiif",
+          "style_period": [],
+          "create_date": "2021-03-16T16:22:09.679863Z",
+          "csv_metadata_update_jobs": []
+        },
+        "sort": [1669097772323]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
### Steps to test

- Index some works with collections
- Run either a `ListIdentifiers` or `ListRecords` request with a collection id as the `set` parameter e.g. `'http://localhost:3000/oai?verb=ListRecords&metadataPrefix=oai_dc&set=c4f30015-88b5-4291-b3a6-8ac9b7c7069c'`
- Check that the records returned are all members of the same collection.