### PR TITLE
Update subject value to `label`.

### DIFF
--- a/src/api/response/iiif/presentation-api/metadata.js
+++ b/src/api/response/iiif/presentation-api/metadata.js
@@ -109,7 +109,7 @@ function metadataLabelFields(source) {
     },
     {
       label: "Subject",
-      value: source.subject.map((item) => item.label_with_role),
+      value: source.subject.map((item) => item.label),
     },
     {
       label: "Table of Contents",


### PR DESCRIPTION
## What does this do?

This simply updates a IIIF Manifest for a work to output a metadata entry for Subject using the value of `label` rather than `label_with_role` to match aggregation keys on facets.