### PR TITLE
Add requireSource global to test helpers to make test imports less ugly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,3 +214,4 @@ $RECYCLE.BIN/
 .vscode
 /samconfig.toml
 /env.json
+/env.*.json

--- a/test/integration/default-handler.test.js
+++ b/test/integration/default-handler.test.js
@@ -2,7 +2,8 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const defaultHandler = require("../../src/handlers/default-request");
+
+const defaultHandler = requireSource("handlers/default-request");
 
 describe("$default handler", async () => {
   const event = helpers

--- a/test/integration/get-auth-callback.test.js
+++ b/test/integration/get-auth-callback.test.js
@@ -3,8 +3,9 @@
 const chai = require("chai");
 const expect = chai.expect;
 const nock = require("nock");
-const getAuthCallbackHandler = require("../../src/handlers/get-auth-callback");
-const ApiToken = require("../../src/api/api-token");
+
+const getAuthCallbackHandler = requireSource("handlers/get-auth-callback");
+const ApiToken = requireSource("api/api-token");
 
 describe("auth callback", function () {
   helpers.saveEnvironment();

--- a/test/integration/get-auth-login.test.js
+++ b/test/integration/get-auth-login.test.js
@@ -3,7 +3,8 @@
 const chai = require("chai");
 const expect = chai.expect;
 const nock = require("nock");
-const getAuthLoginHandler = require("../../src/handlers/get-auth-login");
+
+const getAuthLoginHandler = requireSource("handlers/get-auth-login");
 
 describe("auth login", function () {
   helpers.saveEnvironment();

--- a/test/integration/get-auth-logout.test.js
+++ b/test/integration/get-auth-logout.test.js
@@ -3,8 +3,9 @@
 const chai = require("chai");
 const expect = chai.expect;
 const nock = require("nock");
-const getAuthLogoutHandler = require("../../src/handlers/get-auth-logout");
-const ApiToken = require("../../src/api/api-token");
+
+const getAuthLogoutHandler = requireSource("handlers/get-auth-logout");
+const ApiToken = requireSource("api/api-token");
 
 describe("auth logout", function () {
   helpers.saveEnvironment();

--- a/test/integration/get-auth-whoami.test.js
+++ b/test/integration/get-auth-whoami.test.js
@@ -2,8 +2,9 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const getAuthWhoamiHandler = require("../../src/handlers/get-auth-whoami");
 const jwt = require("jsonwebtoken");
+
+const getAuthWhoamiHandler = requireSource("handlers/get-auth-whoami");
 
 describe("auth whoami", function () {
   helpers.saveEnvironment();

--- a/test/integration/get-collection-by-id.test.js
+++ b/test/integration/get-collection-by-id.test.js
@@ -2,15 +2,16 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const RequestPipeline = require("../../src/api/request/pipeline");
 chai.use(require("chai-http"));
+
+const RequestPipeline = requireSource("api/request/pipeline");
 
 describe("Retrieve collection by id", () => {
   helpers.saveEnvironment();
   const mock = helpers.mockIndex();
 
   describe("GET /collections/{id}", () => {
-    const { handler } = require("../../src/handlers/get-collection-by-id");
+    const { handler } = requireSource("handlers/get-collection-by-id");
 
     it("retrieves a single collection link document", async () => {
       mock

--- a/test/integration/get-collections.test.js
+++ b/test/integration/get-collections.test.js
@@ -2,9 +2,10 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const getCollectionsHandler = require("../../src/handlers/get-collections");
-const RequestPipeline = require("../../src/api/request/pipeline");
 chai.use(require("chai-http"));
+
+const getCollectionsHandler = requireSource("handlers/get-collections");
+const RequestPipeline = requireSource("api/request/pipeline");
 
 describe("Collections route", () => {
   helpers.saveEnvironment();

--- a/test/integration/get-doc.test.js
+++ b/test/integration/get-doc.test.js
@@ -9,7 +9,7 @@ describe("Doc retrieval routes", () => {
   const mock = helpers.mockIndex();
 
   describe("GET /works/{id}", () => {
-    const { handler } = require("../../src/handlers/get-work-by-id");
+    const { handler } = requireSource("handlers/get-work-by-id");
 
     it("retrieves a single work", async () => {
       mock
@@ -87,7 +87,7 @@ describe("Doc retrieval routes", () => {
   });
 
   describe("GET /collections/{id}", () => {
-    const { handler } = require("../../src/handlers/get-collection-by-id");
+    const { handler } = requireSource("handlers/get-collection-by-id");
 
     it("retrieves a single collection", async () => {
       mock
@@ -112,7 +112,7 @@ describe("Doc retrieval routes", () => {
   });
 
   describe("GET /file-sets/{id}", () => {
-    const { handler } = require("../../src/handlers/get-file-set-by-id");
+    const { handler } = requireSource("handlers/get-file-set-by-id");
 
     it("retrieves a single file-set", async () => {
       mock

--- a/test/integration/get-file-set-auth.test.js
+++ b/test/integration/get-file-set-auth.test.js
@@ -1,9 +1,10 @@
 "use strict";
 
-const ApiToken = require("../../src/api/api-token");
 const chai = require("chai");
 const expect = chai.expect;
 chai.use(require("chai-http"));
+
+const ApiToken = requireSource("api/api-token");
 
 describe("Authorize a file set by id", () => {
   process.env.API_TOKEN_SECRET = "abc123";
@@ -12,7 +13,7 @@ describe("Authorize a file set by id", () => {
   const mock = helpers.mockIndex();
 
   describe("GET /file-sets/{id}/authorization", () => {
-    const { handler } = require("../../src/handlers/get-file-set-auth");
+    const { handler } = requireSource("handlers/get-file-set-auth");
 
     it("authorizes a public, published file set with no token", async () => {
       mock

--- a/test/integration/get-shared-link-by-id.test.js
+++ b/test/integration/get-shared-link-by-id.test.js
@@ -3,14 +3,15 @@
 const chai = require("chai");
 const expect = chai.expect;
 chai.use(require("chai-http"));
-const ApiToken = require("../../src/api/api-token");
+
+const ApiToken = requireSource("api/api-token");
 
 describe("Retrieve shared link by id", () => {
   helpers.saveEnvironment();
   const mock = helpers.mockIndex();
 
   describe("GET /shared-links/{id}", () => {
-    const { handler } = require("../../src/handlers/get-shared-link-by-id");
+    const { handler } = requireSource("handlers/get-shared-link-by-id");
 
     it("retrieves a single shared link document", async () => {
       process.env.API_TOKEN_SECRET = "abc123";

--- a/test/integration/get-similar.test.js
+++ b/test/integration/get-similar.test.js
@@ -2,9 +2,10 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const { handler } = require("../../src/handlers/get-similar");
-const RequestPipeline = require("../../src/api/request/pipeline");
 chai.use(require("chai-http"));
+
+const { handler } = requireSource("handlers/get-similar");
+const RequestPipeline = requireSource("api/request/pipeline");
 
 describe("Similar routes", () => {
   helpers.saveEnvironment();

--- a/test/integration/get-thumbnail.test.js
+++ b/test/integration/get-thumbnail.test.js
@@ -1,9 +1,10 @@
 "use strict";
 
 const chai = require("chai");
-const ApiToken = require("../../src/api/api-token");
 const expect = chai.expect;
-const { handler } = require("../../src/handlers/get-thumbnail");
+
+const ApiToken = requireSource("api/api-token");
+const { handler } = requireSource("handlers/get-thumbnail");
 
 function expectCorsHeaders(result) {
   expect(result.headers["Access-Control-Allow-Credentials"]).to.eq("true");

--- a/test/integration/get-work-by-id.test.js
+++ b/test/integration/get-work-by-id.test.js
@@ -2,16 +2,16 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const RequestPipeline = require("../../src/api/request/pipeline");
 chai.use(require("chai-http"));
-const ApiToken = require("../../src/api/api-token");
+
+const ApiToken = requireSource("api/api-token");
 
 describe("Retrieve work by id", () => {
   helpers.saveEnvironment();
   const mock = helpers.mockIndex();
 
   describe("GET /works/{id}", () => {
-    const { handler } = require("../../src/handlers/get-work-by-id");
+    const { handler } = requireSource("handlers/get-work-by-id");
 
     it("retrieves a single work document", async () => {
       mock

--- a/test/integration/oai.test.js
+++ b/test/integration/oai.test.js
@@ -2,10 +2,11 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const { handler } = require("../../src/handlers/oai");
 const convert = require("xml-js");
 const nock = require("nock");
 chai.use(require("chai-http"));
+
+const { handler } = requireSource("handlers/oai");
 
 const xmlOpts = {
   compact: true,

--- a/test/integration/options-request.test.js
+++ b/test/integration/options-request.test.js
@@ -2,7 +2,8 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const optionsHandler = require("../../src/handlers/options-request");
+
+const optionsHandler = requireSource("handlers/options-request");
 
 describe("OPTIONS handler", async () => {
   const event = helpers

--- a/test/integration/search.test.js
+++ b/test/integration/search.test.js
@@ -2,8 +2,9 @@
 
 const chai = require("chai");
 const expect = chai.expect;
-const searchHandlers = require("../../src/handlers/search");
-const RequestPipeline = require("../../src/api/request/pipeline");
+
+const searchHandlers = requireSource("handlers/search");
+const RequestPipeline = requireSource("api/request/pipeline");
 
 chai.use(require("chai-http"));
 

--- a/test/test-helpers/index.js
+++ b/test/test-helpers/index.js
@@ -1,9 +1,14 @@
-const { _processRequest } = require("../../src/handlers/middleware");
 const fs = require("fs");
 const nock = require("nock");
 const path = require("path");
 const EventBuilder = require("./event-builder.js");
 
+function requireSource(module) {
+  const absolute = path.resolve(__dirname, "../../src", module);
+  return require(absolute);
+}
+
+const { _processRequest } = requireSource("handlers/middleware");
 function saveEnvironment() {
   const env = Object.assign({}, process.env);
 
@@ -79,3 +84,5 @@ global.helpers = {
   cookieValue,
   preprocess: _processRequest,
 };
+
+global.requireSource = requireSource;

--- a/test/unit/api/api-token.test.js
+++ b/test/unit/api/api-token.test.js
@@ -1,9 +1,10 @@
 "use strict";
 
-const ApiToken = require("../../../src/api/api-token");
 const chai = require("chai");
 const expect = chai.expect;
 const jwt = require("jsonwebtoken");
+
+const ApiToken = requireSource("api/api-token");
 
 describe("ApiToken", function () {
   this.beforeEach(() => {});

--- a/test/unit/api/helpers.test.js
+++ b/test/unit/api/helpers.test.js
@@ -1,5 +1,10 @@
 "use strict";
 
+const chai = require("chai");
+const expect = chai.expect;
+const jwt = require("jsonwebtoken");
+
+const ApiToken = requireSource("api/api-token");
 const {
   baseUrl,
   decodeEventBody,
@@ -8,11 +13,7 @@ const {
   normalizeHeaders,
   objectifyCookies,
   stubEventMembers,
-} = require("../../../src/helpers");
-const chai = require("chai");
-const expect = chai.expect;
-const ApiToken = require("../../../src/api/api-token");
-const jwt = require("jsonwebtoken");
+} = requireSource("helpers");
 
 describe("helpers", () => {
   describe("baseUrl()", () => {

--- a/test/unit/api/opensearch.test.js
+++ b/test/unit/api/opensearch.test.js
@@ -1,8 +1,9 @@
 "use strict";
 
-const opensearch = require("../../../src/api/opensearch");
 const chai = require("chai");
 const expect = chai.expect;
+
+const opensearch = requireSource("api/opensearch");
 
 describe("getWork()", function () {
   helpers.saveEnvironment();

--- a/test/unit/api/pagination.test.js
+++ b/test/unit/api/pagination.test.js
@@ -1,8 +1,9 @@
 "use strict";
 
-const { decodeSearchToken, Paginator } = require("../../../src/api/pagination");
 const chai = require("chai");
 const expect = chai.expect;
+
+const { decodeSearchToken, Paginator } = requireSource("api/pagination");
 
 describe("Paginator", function () {
   const requestBody = {

--- a/test/unit/api/request/models.test.js
+++ b/test/unit/api/request/models.test.js
@@ -1,8 +1,9 @@
 "use strict";
 
-const models = require("../../../../src/api/request/models");
 const chai = require("chai");
 const expect = chai.expect;
+
+const models = requireSource("api/request/models");
 
 describe("models", () => {
   helpers.saveEnvironment();

--- a/test/unit/api/request/pipeline.test.js
+++ b/test/unit/api/request/pipeline.test.js
@@ -1,9 +1,10 @@
 "use strict";
 
-const RequestPipeline = require("../../../../src/api/request/pipeline");
 const chai = require("chai");
 const expect = chai.expect;
-const ApiToken = require("../../../../src/api/api-token");
+
+const ApiToken = requireSource("api/api-token");
+const RequestPipeline = requireSource("api/request/pipeline");
 
 describe("RequestPipeline", () => {
   helpers.saveEnvironment();

--- a/test/unit/api/response/error.test.js
+++ b/test/unit/api/response/error.test.js
@@ -1,6 +1,7 @@
-const errorTransformer = require("../../../../src/api/response/error");
 const chai = require("chai");
 const expect = chai.expect;
+
+const errorTransformer = requireSource("api/response/error");
 
 describe("The error response", () => {
   it("Transforms a missing work response", async () => {

--- a/test/unit/api/response/iiif/collection.test.js
+++ b/test/unit/api/response/iiif/collection.test.js
@@ -1,9 +1,10 @@
 "use strict";
 
-const transformer = require("../../../../../src/api/response/iiif/collection");
-const { Paginator } = require("../../../../../src/api/pagination");
 const chai = require("chai");
 const expect = chai.expect;
+
+const transformer = requireSource("api/response/iiif/collection");
+const { Paginator } = requireSource("api/pagination");
 
 describe("IIIF Collection response transformer", () => {
   let pager;

--- a/test/unit/api/response/iiif/manifest.test.js
+++ b/test/unit/api/response/iiif/manifest.test.js
@@ -1,9 +1,10 @@
 "use strict";
 
-const transformer = require("../../../../../src/api/response/iiif/manifest");
 const chai = require("chai");
 const expect = chai.expect;
-const { dcApiEndpoint, dcUrl } = require("../../../../../src/environment");
+
+const { dcApiEndpoint, dcUrl } = requireSource("environment");
+const transformer = requireSource("api/response/iiif/manifest");
 
 describe("Image Work as IIIF Manifest response transformer", () => {
   function getMetadataValueByLabel(metadataArray, targetLabel) {
@@ -114,7 +115,7 @@ describe("Image Work as IIIF Manifest response transformer", () => {
   });
 
   it("excludes Preservation and Supplemental filesets", async () => {
-    const { source, manifest } = await setup();
+    const { manifest } = await setup();
     manifest.items.forEach((canvas) => {
       expect(canvas.id).not.contains(["preservation", "supplemental"]);
     });

--- a/test/unit/api/response/iiif/presentation-api/items.test.js
+++ b/test/unit/api/response/iiif/presentation-api/items.test.js
@@ -1,8 +1,9 @@
 "use strict";
 
-const items = require("../../../../../../src/api/response/iiif/presentation-api/items");
 const chai = require("chai");
 const expect = chai.expect;
+
+const items = requireSource("api/response/iiif/presentation-api/items");
 
 describe("IIIF response presentation API items helpers", () => {
   const accessImage = {

--- a/test/unit/api/response/iiif/presentation-api/metadata.test.js
+++ b/test/unit/api/response/iiif/presentation-api/metadata.test.js
@@ -1,11 +1,11 @@
 "use strict";
 
-const {
-  formatSingleValuedField,
-  metadataLabelFields,
-} = require("../../../../../../src/api/response/iiif/presentation-api/metadata");
 const chai = require("chai");
 const expect = chai.expect;
+
+const { formatSingleValuedField, metadataLabelFields } = requireSource(
+  "api/response/iiif/presentation-api/metadata"
+);
 
 describe("IIIF response presentation API metadata helpers", () => {
   const response = {

--- a/test/unit/api/response/opensearch.test.js
+++ b/test/unit/api/response/opensearch.test.js
@@ -1,9 +1,10 @@
 "use strict";
 
-const transformer = require("../../../../src/api/response/opensearch");
-const { Paginator } = require("../../../../src/api/pagination");
 const chai = require("chai");
 const expect = chai.expect;
+
+const transformer = requireSource("api/response/opensearch");
+const { Paginator } = requireSource("api/pagination");
 
 describe("OpenSearch response transformer", () => {
   let pager;

--- a/test/unit/aws/environment.test.js
+++ b/test/unit/aws/environment.test.js
@@ -1,9 +1,9 @@
 "use strict";
 
-const environment = require("../../../src/environment");
-
 const chai = require("chai");
 const expect = chai.expect;
+
+const environment = requireSource("environment");
 
 describe("environment", function () {
   helpers.saveEnvironment();


### PR DESCRIPTION
The heavy lifting is being done by a new global test helper, [`requireSource`](https://github.com/nulib/dc-api-v2/pull/76/files#diff-65e92cd02c29f453eda8f7d41b04563f735c86cf21ec2fc5d528a5a863912a79R6-R9), which acts just like `require` but always requires things relative to the project's `/src` directory. Like `chai`, `mocha`, and the other `helpers`, `requireSource` is only defined within the scope of the testing framework.

I changed existing test files such that:
- all regular `require`s come before the first `requireSource`
- there is a blank line between the last `require` and the first `requireSource`
- calls to `requireSource` occurring elsewhere (e.g., inside a `describe` or `it` block) do not require a preceding blank line

I propose we stick to this convention going forward.