### PR TITLE
Add Rights Statement to metadata

### DIFF
--- a/src/api/response/iiif/presentation-api/metadata.js
+++ b/src/api/response/iiif/presentation-api/metadata.js
@@ -92,6 +92,10 @@ function metadataLabelFields(source) {
       value: source.rights_holder,
     },
     {
+      label: "Rights Statement",
+      value: formatSingleValuedField(source.rights_statement?.label),
+    },
+    {
       label: "Scope and Contents",
       value: source.scope_and_contents,
     },

--- a/test/unit/api/response/iiif/presentation-api/metadata.test.js
+++ b/test/unit/api/response/iiif/presentation-api/metadata.test.js
@@ -24,7 +24,7 @@ describe("IIIF response presentation API metadata helpers", () => {
   it("metadataLabelFields(source)", () => {
     const metadata = metadataLabelFields(source);
     expect(Array.isArray(metadata)).to.be;
-    expect(metadata.length).to.eq(28);
+    expect(metadata.length).to.eq(29);
     metadata.forEach((item) => {
       expect(item.label).to.be.a("string");
       expect(item.value).to.be.an("array");


### PR DESCRIPTION
Adds `Rights Statement` to the IIIF Manifest for ease of use in DC v2.