### PR TITLE
Use the x-client-ip header for file set auth to allow proxying

### DIFF
--- a/src/handlers/middleware.js
+++ b/src/handlers/middleware.js
@@ -4,6 +4,7 @@ const {
   decodeToken,
   encodeToken,
   ensureCharacterEncoding,
+  maybeUseProxiedIp,
   normalizeHeaders,
   objectifyCookies,
   stubEventMembers,
@@ -26,12 +27,14 @@ const wrap = function (handler) {
 
 const _processRequest = function (event) {
   if (event.__processRequest) return event;
-  let result = stubEventMembers(event);
+  let result = maybeUseProxiedIp(event);
+  result = stubEventMembers(event);
   result = normalizeHeaders(event);
   result = objectifyCookies(result);
   result = decodeEventBody(result);
   result = decodeToken(result);
   result.__processRequest = true;
+  if (!!process.env.DEBUG) console.log("request", result);
   return result;
 };
 
@@ -39,7 +42,7 @@ const _processResponse = function (event, response) {
   let result = addCorsHeaders(event, response);
   result = encodeToken(event, result);
   result = ensureCharacterEncoding(result, "UTF-8");
-  if (process.env.DEBUG) console.log(result);
+  if (!!process.env.DEBUG) console.log("response", result);
   return result;
 };
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -199,8 +199,15 @@ function objectifyCookies(event) {
 
 function isFromReadingRoom(event) {
   const AllowedIPs = (process.env.READING_ROOM_IPS || "").split(/\s*,\s*/);
-  const sourceIp = event?.requestContext?.http?.sourceIp;
+  const sourceIp = event.requestContext?.http?.sourceIp;
   return AllowedIPs.includes(sourceIp);
+}
+
+function maybeUseProxiedIp(event) {
+  if (!!process.env.USE_PROXIED_IP && event.headers?.["x-client-ip"]) {
+    event.requestContext.http.sourceIp = event.headers["x-client-ip"];
+  }
+  return event;
 }
 
 function stubEventMembers(event) {
@@ -221,6 +228,7 @@ module.exports = {
   effectivePath,
   ensureCharacterEncoding,
   isFromReadingRoom,
+  maybeUseProxiedIp,
   normalizeHeaders,
   objectifyCookies,
   stubEventMembers,

--- a/template.yaml
+++ b/template.yaml
@@ -198,6 +198,9 @@ Resources:
     Properties:
       Handler: handlers/get-file-set-auth.handler
       Description: Authorizes access to a file set.
+      Environment:
+        Variables:
+          USE_PROXIED_IP: true
       Policies:
         Version: 2012-10-17
         Statement:

--- a/test/integration/get-file-set-auth.test.js
+++ b/test/integration/get-file-set-auth.test.js
@@ -92,7 +92,7 @@ describe("Authorize a file set by id", () => {
       expect(result.statusCode).to.eq(204);
     });
 
-    it("authorizes an restricted file set if the user is in a Reading Room", async () => {
+    it("authorizes a restricted file set if the user is in a Reading Room", async () => {
       mock
         .get("/dc-v2-file-set/_doc/1234")
         .reply(200, helpers.testFixture("mocks/fileset-restricted-1234.json"));

--- a/test/unit/api/helpers.test.js
+++ b/test/unit/api/helpers.test.js
@@ -10,6 +10,7 @@ const {
   decodeEventBody,
   decodeToken,
   isFromReadingRoom,
+  maybeUseProxiedIp,
   normalizeHeaders,
   objectifyCookies,
   stubEventMembers,
@@ -166,6 +167,38 @@ describe("helpers", () => {
       expect(isFromReadingRoom(event)).to.be.false;
       process.env.READING_ROOM_IPS = event.requestContext.http.sourceIp;
       expect(isFromReadingRoom(event)).to.be.true;
+    });
+  });
+
+  describe("maybeUseProxiedIp()", () => {
+    it("uses the original IP if USE_PROXIED_IP is not set", () => {
+      const event = helpers
+        .mockEvent("GET", "/search")
+        .headers({ "x-client-ip": "123.123.123.123" })
+        .render();
+      expect(maybeUseProxiedIp(event)).to.nested.include({
+        "requestContext.http.sourceIp": "10.9.8.7",
+      });
+    });
+
+    it("uses the original IP if the x-client-ip header is not set", () => {
+      const event = helpers.mockEvent("GET", "/search").render();
+      process.env.USE_PROXIED_IP = "true";
+      expect(maybeUseProxiedIp(event)).to.nested.include({
+        "requestContext.http.sourceIp": "10.9.8.7",
+      });
+    });
+
+    it("uses the x-client-ip header if it is present and USE_PROXIED_IP is set", () => {
+      const event = helpers
+        .mockEvent("GET", "/search")
+        .headers({ "x-client-ip": "123.123.123.123" })
+        .render();
+      process.env.USE_PROXIED_IP = "true";
+      const subject = maybeUseProxiedIp(event);
+      expect(subject).to.nested.include({
+        "requestContext.http.sourceIp": "123.123.123.123",
+      });
     });
   });
 


### PR DESCRIPTION
The IIIF - API auth pipeline wasn't able to tell if a request was coming from the reading room because the request to the API is coming from IIIF, not from the client. It used to work because we were persisting the reading room API token, so it would get sent through in the cookie header that the IIIF server forwards to the API, but that was causing other problems.

The solution is to have the IIIF auth function add the real client IP to a custom `x-client-ip` header, which the API can then check against the list of reading room IPs. However, it's important _only_ to use that header on FileSet auth requests, because otherwise any client could spoof a reading room IP address to get private metadata or search results. This PR addresses that by toggling the feature using an environment variable that is only set on the `getFileSetAuthFunction` resource.