### PR TITLE
Redirect from /collections/ to /collections

### DIFF
--- a/src/handlers/get-collection-by-id.js
+++ b/src/handlers/get-collection-by-id.js
@@ -25,10 +25,23 @@ const getIiifCollectionById = async (event) => {
   });
 };
 
+const isEmpty = (string) => {
+  return string === undefined || string === null || string === "";
+};
+
 /**
  * Get a colletion by id
  */
 exports.handler = wrap(async (event) => {
+  if (isEmpty(event.pathParameters.id)) {
+    return {
+      statusCode: 301,
+      headers: {
+        location: "/collections",
+      },
+    };
+  }
+
   return event.queryStringParameters?.as === "iiif"
     ? getIiifCollectionById(event)
     : getCollectionById(event);

--- a/src/handlers/middleware.js
+++ b/src/handlers/middleware.js
@@ -20,7 +20,9 @@ const wrap = function (handler) {
       event = __processRequest(event);
       response = await handler(event, context);
     } catch (error) {
-      await Honeybadger.notifyAsync(error);
+      if (Honeybadger.config.enableUncaught) {
+        await Honeybadger.notifyAsync(error);
+      }
       response = _convertErrorToResponse(error);
     }
     return __processResponse(event, response);

--- a/src/honeybadger-setup.js
+++ b/src/honeybadger-setup.js
@@ -4,6 +4,8 @@ Honeybadger.configure({
   apiKey: process.env.HONEYBADGER_API_KEY || "DEVELOPMENT_MODE",
   environment: process.env.HONEYBADGER_ENV || "development",
   revision: process.env.HONEYBADGER_REVISION,
+  enableUncaught: !process.env.HONEYBADGER_DISABLED,
+  enableUnhandledRejection: !process.env.HONEYBADGER_DISABLED,
 });
 
 Honeybadger.beforeNotify((notice) => {

--- a/test/integration/get-collection-by-id.test.js
+++ b/test/integration/get-collection-by-id.test.js
@@ -76,5 +76,15 @@ describe("Retrieve collection by id", () => {
       expect(resultBody.type).to.eq("Collection");
       expect(resultBody.label.none[0]).to.eq("Collection Title");
     });
+
+    it("redirects to /collections when id is missing or empty", async () => {
+      const event = helpers
+        .mockEvent("GET", "/collections/{id}")
+        .pathParams({ id: "" })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(301);
+      expect(result).to.have.header("location", "/collections");
+    });
   });
 });

--- a/test/test-helpers/index.js
+++ b/test/test-helpers/index.js
@@ -3,6 +3,7 @@ const nock = require("nock");
 const path = require("path");
 const EventBuilder = require("./event-builder.js");
 
+process.env.HONEYBADGER_DISABLED = "true";
 process.env.HONEYBADGER_ENV = "test";
 
 function requireSource(module) {


### PR DESCRIPTION
This PR also disable Honeybadger in test mode except on tests that explicitly need it. When I wrote the failing test case for `/collections/` -> `/collections`, Honeybadger was swallowing the real error and displaying a deceptive one.