### PR TITLE
Ensure tests can't corrupt the environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5523,6 +5523,7 @@
         "@honeybadger-io/js": "^4.9.3",
         "axios": ">=0.21.1",
         "cookie": "^0.5.0",
+        "debug": "^4.3.4",
         "http-status-codes": "^2.2.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
@@ -5532,6 +5533,27 @@
         "sort-json": "^2.0.1",
         "xml-js": "^1.6.11"
       }
+    },
+    "src/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "src/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     }
   },
   "dependencies": {
@@ -7166,6 +7188,7 @@
         "@honeybadger-io/js": "^4.9.3",
         "axios": ">=0.21.1",
         "cookie": "^0.5.0",
+        "debug": "^4.3.4",
         "http-status-codes": "^2.2.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
@@ -7174,6 +7197,21 @@
         "parse-http-header": "^1.0.1",
         "sort-json": "^2.0.1",
         "xml-js": "^1.6.11"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "debug": {

--- a/src/handlers/middleware.js
+++ b/src/handlers/middleware.js
@@ -10,6 +10,7 @@ const {
   stubEventMembers,
 } = require("../helpers");
 
+const debug = require("debug")("api.middleware");
 const Honeybadger = require("../honeybadger-setup");
 const { StatusCodes } = require("http-status-codes");
 
@@ -56,7 +57,7 @@ const __processRequest = function (event) {
   result.__processRequest = true;
 
   Honeybadger.setContext({ event: result });
-  if (process.env.DEBUG) console.log(result);
+  debug(result);
   return result;
 };
 
@@ -64,7 +65,7 @@ const __processResponse = function (event, response) {
   let result = addCorsHeaders(event, response);
   result = encodeToken(event, result);
   result = ensureCharacterEncoding(result, "UTF-8");
-  if (process.env.DEBUG) console.log(result);
+  debug(result);
   return result;
 };
 

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -17,6 +17,7 @@
         "@honeybadger-io/js": "^4.9.3",
         "axios": ">=0.21.1",
         "cookie": "^0.5.0",
+        "debug": "^4.3.4",
         "http-status-codes": "^2.2.0",
         "iiif-builder": "^1.0.6",
         "jsonwebtoken": "^8.5.1",
@@ -1205,6 +1206,27 @@
       "engines": {
         "node": ">= 12"
       }
+    },
+    "node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -2734,6 +2756,21 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
       "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
     },
     "delayed-stream": {
       "version": "1.0.0",

--- a/src/package.json
+++ b/src/package.json
@@ -14,6 +14,7 @@
     "@honeybadger-io/js": "^4.9.3",
     "axios": ">=0.21.1",
     "cookie": "^0.5.0",
+    "debug": "^4.3.4",
     "http-status-codes": "^2.2.0",
     "iiif-builder": "^1.0.6",
     "jsonwebtoken": "^8.5.1",

--- a/test/test-helpers/index.js
+++ b/test/test-helpers/index.js
@@ -6,6 +6,17 @@ const EventBuilder = require("./event-builder.js");
 process.env.HONEYBADGER_DISABLED = "true";
 process.env.HONEYBADGER_ENV = "test";
 
+const TestEnvironment = {
+  API_TOKEN_SECRET: "abc123",
+  API_TOKEN_NAME: "dcapiTEST",
+  DC_URL: "https://thisisafakedcurl",
+  DC_API_ENDPOINT: "https://thisisafakeapiurl",
+  NUSSO_BASE_URL: "https://nusso-base.com/",
+  NUSSO_API_KEY: "abc123",
+};
+
+for (const v in TestEnvironment) delete process.env[v];
+
 function requireSource(module) {
   const absolute = path.resolve(__dirname, "../../src", module);
   return require(absolute);
@@ -14,19 +25,14 @@ function requireSource(module) {
 const { __processRequest } = requireSource("handlers/middleware");
 
 function saveEnvironment() {
-  const env = Object.assign({}, process.env);
+  const env = { ...process.env };
 
   beforeEach(function () {
-    process.env.API_TOKEN_SECRET = "abc123";
-    process.env.API_TOKEN_NAME = "dcapiTEST";
-    process.env.DC_URL = "https://thisisafakedcurl";
-    process.env.DC_API_ENDPOINT = "https://thisisafakeapiurl";
-    process.env.NUSSO_BASE_URL = "https://nusso-base.com/";
-    process.env.NUSSO_API_KEY = "abc123";
+    for (const v in TestEnvironment) process.env[v] = TestEnvironment[v];
   });
 
   afterEach(function () {
-    process.env = env;
+    process.env = { ...env };
   });
 }
 

--- a/test/unit/api/response/iiif/collection.test.js
+++ b/test/unit/api/response/iiif/collection.test.js
@@ -7,6 +7,8 @@ const transformer = requireSource("api/response/iiif/collection");
 const { Paginator } = requireSource("api/pagination");
 
 describe("IIIF Collection response transformer", () => {
+  helpers.saveEnvironment();
+
   let pager;
   beforeEach(() => {
     pager = new Paginator(


### PR DESCRIPTION
`process.env = env` made it so that any other tests in the same block that modified `process.env` were modifying the saved copy as well, causing knock-on effects.

I also changed how environment setup works to delete variables that exist by default in developer environments that do not exist in the test environment.