### PR TITLE
Fix test dependency issues using random seeding

### DIFF
--- a/.mocharc.js
+++ b/.mocharc.js
@@ -1,5 +1,5 @@
 module.exports = {
   ignore: ["test/test-helpers/**/*"],
   recursive: true,
-  require: "test/test-helpers"
+  require: ["test/test-helpers", "choma"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@openapitools/openapi-generator-cli": "^2.5.2",
         "chai": "^4.2.0",
         "chai-http": "^4.3.0",
+        "choma": "^1.2.1",
         "eslint": "^8.32.0",
         "eslint-plugin-json": "^3.1.0",
         "husky": "^8.0.3",
@@ -2193,6 +2194,90 @@
       },
       "optionalDependencies": {
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/choma": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/choma/-/choma-1.2.1.tgz",
+      "integrity": "sha512-4KwEouEHt6SfG8vYnN2gSJfq/cGmnY2gubnUgsgkRXzHoSRAgluX2YXQgDg6bTDWuOmUrTb/cfwMpNlvnnPZCg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.3.2",
+        "seedrandom": "^2.4.3"
+      },
+      "peerDependencies": {
+        "mocha": ">=2"
+      }
+    },
+    "node_modules/choma/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/choma/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/choma/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/choma/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "node_modules/choma/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/choma/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/choma/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/clean-stack": {
@@ -4868,6 +4953,12 @@
       "version": "1.2.4",
       "license": "ISC"
     },
+    "node_modules/seedrandom": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
+      "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==",
+      "dev": true
+    },
     "node_modules/semver": {
       "version": "6.3.0",
       "dev": true,
@@ -7030,6 +7121,74 @@
         "readdirp": "~3.6.0"
       }
     },
+    "choma": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/choma/-/choma-1.2.1.tgz",
+      "integrity": "sha512-4KwEouEHt6SfG8vYnN2gSJfq/cGmnY2gubnUgsgkRXzHoSRAgluX2YXQgDg6bTDWuOmUrTb/cfwMpNlvnnPZCg==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.3.2",
+        "seedrandom": "^2.4.3"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "clean-stack": {
       "version": "2.2.0",
       "dev": true
@@ -8758,6 +8917,12 @@
     },
     "sax": {
       "version": "1.2.4"
+    },
+    "seedrandom": {
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.4.tgz",
+      "integrity": "sha512-9A+PDmgm+2du77B5i0Ip2cxOqqHjgNxnBgglxLcX78A2D6c2rTo61z4jnVABpF4cKeDMDG+cmXXvdnqse2VqMA==",
+      "dev": true
     },
     "semver": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@openapitools/openapi-generator-cli": "^2.5.2",
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
+    "choma": "^1.2.1",
     "eslint": "^8.32.0",
     "eslint-plugin-json": "^3.1.0",
     "husky": "^8.0.3",
@@ -42,9 +43,12 @@
     },
     "root": true,
     "rules": {
-      "no-unused-vars": ["error", {
-        "argsIgnorePattern": "^_"
-      }]
+      "no-unused-vars": [
+        "error",
+        {
+          "argsIgnorePattern": "^_"
+        }
+      ]
     }
   }
 }

--- a/test/integration/get-file-set-auth.test.js
+++ b/test/integration/get-file-set-auth.test.js
@@ -7,10 +7,13 @@ chai.use(require("chai-http"));
 const ApiToken = requireSource("api/api-token");
 
 describe("Authorize a file set by id", () => {
-  process.env.API_TOKEN_SECRET = "abc123";
-  process.env.API_TOKEN_NAME = "dcapiTEST";
   helpers.saveEnvironment();
   const mock = helpers.mockIndex();
+
+  beforeEach(() => {
+    process.env.API_TOKEN_SECRET = "abc123";
+    process.env.API_TOKEN_NAME = "dcapiTEST";
+  });
 
   describe("GET /file-sets/{id}/authorization", () => {
     const { handler } = requireSource("handlers/get-file-set-auth");

--- a/test/integration/get-similar.test.js
+++ b/test/integration/get-similar.test.js
@@ -10,6 +10,7 @@ const RequestPipeline = requireSource("api/request/pipeline");
 describe("Similar routes", () => {
   helpers.saveEnvironment();
   const mock = helpers.mockIndex();
+
   let baseEvent = helpers
     .mockEvent("GET", "/works/{id}/similar")
     .pathParams({ id: 1234 });

--- a/test/test-helpers/event-builder.js
+++ b/test/test-helpers/event-builder.js
@@ -1,6 +1,6 @@
 const sortJson = require("sort-json");
 
-module.exports = class {
+class EventBuilder {
   constructor(method, route) {
     const now = new Date();
     this._method = method;
@@ -42,49 +42,63 @@ module.exports = class {
   }
 
   body(body) {
-    switch (typeof body) {
-      case "string":
-        this._event.body = body;
-        break;
-      case "undefined":
-        this._event.body = "";
-        break;
-      case "object":
-        this._event.body = JSON.stringify(body);
-        break;
-    }
-    return this;
+    return this.update((copy) => {
+      switch (typeof body) {
+        case "string":
+          copy._event.body = body;
+          break;
+        case "undefined":
+          copy._event.body = "";
+          break;
+        case "object":
+          copy._event.body = JSON.stringify(body);
+          break;
+      }
+    });
   }
 
   headers(headers) {
-    Object.assign(this._event.headers, headers);
-    return this;
+    return this.update((copy) => {
+      Object.assign(copy._event.headers, headers);
+    });
   }
 
   pathParams(params) {
-    this._pathParams = params;
-    return this;
+    return this.update((copy) => {
+      copy._pathParams = params;
+    });
   }
 
   queryParams(params) {
-    this._queryParams = params;
-    return this;
+    return this.update((copy) => {
+      copy._queryParams = params;
+    });
   }
 
   stageVariables(vars) {
-    this._event.stageVariables = vars;
-    return this;
+    return this.update((copy) => {
+      copy._event.stageVariables = vars;
+    });
   }
 
   base64Encode() {
-    this._base64Encode = true;
-    return this;
+    return this.update((copy) => {
+      copy._base64Encode = true;
+    });
   }
 
   cookie(name, value) {
-    if (!this._event.cookies) this._event.cookies = [];
-    this._event.cookies.push(`${name}=${encodeURIComponent(value)}`);
-    return this;
+    return this.update((copy) => {
+      if (!copy._event.cookies) copy._event.cookies = [];
+      copy._event.cookies.push(`${name}=${encodeURIComponent(value)}`);
+    });
+  }
+
+  update(func) {
+    let result = new EventBuilder();
+    result = Object.assign(result, this);
+    func(result);
+    return result;
   }
 
   render() {
@@ -121,4 +135,6 @@ module.exports = class {
 
     return sortJson(result);
   }
-};
+}
+
+module.exports = EventBuilder;

--- a/test/test-helpers/index.js
+++ b/test/test-helpers/index.js
@@ -17,6 +17,8 @@ const TestEnvironment = {
 
 for (const v in TestEnvironment) delete process.env[v];
 
+let SavedEnvironments = [];
+
 function requireSource(module) {
   const absolute = path.resolve(__dirname, "../../src", module);
   return require(absolute);
@@ -25,14 +27,13 @@ function requireSource(module) {
 const { __processRequest } = requireSource("handlers/middleware");
 
 function saveEnvironment() {
-  const env = { ...process.env };
-
   beforeEach(function () {
+    SavedEnvironments.push({ ...process.env });
     for (const v in TestEnvironment) process.env[v] = TestEnvironment[v];
   });
 
   afterEach(function () {
-    process.env = { ...env };
+    process.env = { ...SavedEnvironments.pop() };
   });
 }
 

--- a/test/unit/api/api-token.test.js
+++ b/test/unit/api/api-token.test.js
@@ -7,7 +7,8 @@ const jwt = require("jsonwebtoken");
 const ApiToken = requireSource("api/api-token");
 
 describe("ApiToken", function () {
-  this.beforeEach(() => {});
+  helpers.saveEnvironment();
+
   describe("constructor", function () {
     it("constructs an anonymous token by default", async () => {
       const token = new ApiToken();
@@ -39,62 +40,64 @@ describe("ApiToken", function () {
       expect(token.hasEntitlement("1234")).to.be.true;
     });
   });
+
   describe("user()", function () {
-    it("updates the user properties", async () => {});
+    it("updates the user properties", async () => {
+      const user = {
+        uid: "user123",
+        displayName: ["Some One"],
+        mail: "user@example.com",
+      };
 
-    const user = {
-      uid: "user123",
-      displayName: ["Some One"],
-      mail: "user@example.com",
-    };
+      const token = new ApiToken();
+      expect(token.token.sub).to.not.exist;
 
-    const token = new ApiToken();
-    expect(token.token.sub).to.not.exist;
-
-    token.user(user);
-    expect(token.token.sub).to.eq("user123");
-    expect(token.token.name).to.eq("Some One");
-    expect(token.token.email).to.eq("user@example.com");
-    expect(token.isLoggedIn()).to.be.true;
+      token.user(user);
+      expect(token.token.sub).to.eq("user123");
+      expect(token.token.name).to.eq("Some One");
+      expect(token.token.email).to.eq("user@example.com");
+      expect(token.isLoggedIn()).to.be.true;
+    });
   });
 
   describe("readingRoom()", function () {
-    it("sets the isReadingRoom flag to true", async () => {});
-
-    const token = new ApiToken().readingRoom();
-    expect(token.isReadingRoom()).to.be.true;
+    it("sets the isReadingRoom flag to true", async () => {
+      const token = new ApiToken().readingRoom();
+      expect(token.isReadingRoom()).to.be.true;
+    });
   });
 
   describe("superUser()", function () {
-    it("sets the isSuperUser flag to true", async () => {});
-
-    const token = new ApiToken().superUser();
-    expect(token.isSuperUser()).to.be.true;
+    it("sets the isSuperUser flag to true", async () => {
+      const token = new ApiToken().superUser();
+      expect(token.isSuperUser()).to.be.true;
+    });
   });
 
   describe("entitlements", function () {
-    it("addEntitlement() adds an entitlement to the token", async () => {});
+    it("addEntitlement() adds an entitlement to the token", async () => {
+      const payload = {
+        iss: "https://example.com",
+        sub: "user123",
+        name: "Some One",
+        exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
+        iat: Math.floor(Number(new Date()) / 1000),
+        email: "user@example.com",
+        isLoggedIn: true,
+        entitlements: ["1234"],
+      };
 
-    const payload = {
-      iss: "https://example.com",
-      sub: "user123",
-      name: "Some One",
-      exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
-      iat: Math.floor(Number(new Date()) / 1000),
-      email: "user@example.com",
-      isLoggedIn: true,
-      entitlements: ["1234"],
-    };
-    const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+      const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
 
-    const token = new ApiToken(existingToken);
-    expect(token.hasEntitlement("1234")).to.be.true;
-    expect(token.hasEntitlement("5678")).to.be.false;
+      const token = new ApiToken(existingToken);
+      expect(token.hasEntitlement("1234")).to.be.true;
+      expect(token.hasEntitlement("5678")).to.be.false;
 
-    token.addEntitlement("5678");
+      token.addEntitlement("5678");
 
-    expect(token.hasEntitlement("1234")).to.be.true;
-    expect(token.hasEntitlement("5678")).to.be.true;
+      expect(token.hasEntitlement("1234")).to.be.true;
+      expect(token.hasEntitlement("5678")).to.be.true;
+    });
   });
 
   it("entitlements() replaces entitlements", async () => {

--- a/test/unit/api/helpers.test.js
+++ b/test/unit/api/helpers.test.js
@@ -17,6 +17,8 @@ const {
 } = requireSource("helpers");
 
 describe("helpers", () => {
+  helpers.saveEnvironment();
+
   describe("baseUrl()", () => {
     it("extracts the base URL from a local event", () => {
       const event = {
@@ -160,8 +162,6 @@ describe("helpers", () => {
   });
 
   describe("isFromReadingRoom()", () => {
-    helpers.saveEnvironment();
-
     it("knows when a request is coming from a reading room IP", () => {
       const event = helpers.mockEvent("GET", "/search").render();
       expect(isFromReadingRoom(event)).to.be.false;


### PR DESCRIPTION
Changes in this PR:

- Add [`choma`](https://github.com/lennym/choma) for repeatable, randomized test ordering
- Make mocked event updaters idempotent
- Ensure all environment updates happen in a `beforeEach()` or an `it()` block
- Ensure all `describe()` blocks containing environment updates start with `helpers.saveEnvironment()`
- Fix corrupted blocks in `api-token.test.js` that had a bunch of test code running outside of `it()` blocks
- Use a stack for saving/restoring the environment instead of a single variable (to support nested `describe`s)
