### PR TITLE
Makes collection representative image work_id nullable

### DIFF
--- a/docs/docs/spec/data-types.yaml
+++ b/docs/docs/spec/data-types.yaml
@@ -71,13 +71,14 @@ components:
       properties:
         work_id:
           type: string
+          nullable: true
           format: uuid
         url:
           type: string
           format: uri
       required:
-        - work_id
         - url
+        - work_id
     ControlledTerm:
       type: object
       properties:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api-build",
-  "version": "2.0.0-rc.1",
+  "version": "2.0.0-rc.4",
   "description": "NUL Digital Collections API Build Environment",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",


### PR DESCRIPTION
- Makes the `work_id` on the collection's representative image required/nullable. The url should always be present but the work_id may not.
