### PR TITLE
Refactor getThumbnail endpoint to support new indexed collection representative_image data shape

### DIFF
--- a/test/fixtures/mocks/collection-1234-private-published.json
+++ b/test/fixtures/mocks/collection-1234-private-published.json
@@ -11,7 +11,8 @@
     "published": true,
     "visibility": "Private",
     "representative_image": {
-      "work_id": "1234"
+      "work_id": "1234",
+      "url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/5678"
     }
   }
 }

--- a/test/fixtures/mocks/collection-1234.json
+++ b/test/fixtures/mocks/collection-1234.json
@@ -10,7 +10,8 @@
     "api_model": "Collection",
     "published": true,
     "representative_image": {
-      "work_id": "1234"
+      "work_id": "1234",
+      "url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/5678"
     }
   }
 }

--- a/test/integration/get-thumbnail.test.js
+++ b/test/integration/get-thumbnail.test.js
@@ -32,9 +32,6 @@ describe("Thumbnail routes", () => {
         .get("/dc-v2-collection/_doc/1234")
         .reply(200, helpers.testFixture("mocks/collection-1234.json"));
       mock
-        .get("/dc-v2-work/_doc/1234")
-        .reply(200, helpers.testFixture("mocks/work-1234.json"));
-      mock
         .get("/iiif/2/mbk-dev/5678/full/!300,300/0/default.jpg")
         .reply(200, helpers.testFixture("mocks/thumbnail_full.jpg"), {
           "Content-Type": "image/jpeg",
@@ -51,9 +48,6 @@ describe("Thumbnail routes", () => {
         .get("/dc-v2-collection/_doc/1234")
         .reply(200, helpers.testFixture("mocks/collection-1234.json"));
       mock
-        .get("/dc-v2-work/_doc/1234")
-        .reply(200, helpers.testFixture("mocks/work-1234.json"));
-      mock
         .get("/iiif/2/mbk-dev/5678/full/!300,300/0/default.jpg")
         .reply(403, "Forbidden", { "Content-Type": "text/plain" });
 
@@ -69,20 +63,7 @@ describe("Thumbnail routes", () => {
         .reply(200, helpers.testFixture("mocks/missing-collection-1234.json"));
 
       const result = await handler(event.render());
-      expect(result.statusCode).to.eq(404);
-      expectCorsHeaders(result);
-    });
-
-    it("returns 404 if the work doc can't be found", async () => {
-      mock
-        .get("/dc-v2-collection/_doc/1234")
-        .reply(200, helpers.testFixture("mocks/collection-1234.json"));
-      mock
-        .get("/dc-v2-work/_doc/1234")
-        .reply(200, helpers.testFixture("mocks/missing-work-1234.json"));
-
-      const result = await handler(event.render());
-      expect(result.statusCode).to.eq(404);
+      expect(result.error.statusCode).to.eq(404);
       expectCorsHeaders(result);
     });
 
@@ -93,19 +74,6 @@ describe("Thumbnail routes", () => {
           200,
           helpers.testFixture("mocks/collection-1234-no-thumbnail.json")
         );
-
-      const result = await handler(event.render());
-      expect(result.statusCode).to.eq(404);
-      expectCorsHeaders(result);
-    });
-
-    it("returns 404 if the work doc has no thumbnail", async () => {
-      mock
-        .get("/dc-v2-collection/_doc/1234")
-        .reply(200, helpers.testFixture("mocks/collection-1234.json"));
-      mock
-        .get("/dc-v2-work/_doc/1234")
-        .reply(200, helpers.testFixture("mocks/work-1234-no-thumbnail.json"));
 
       const result = await handler(event.render());
       expect(result.statusCode).to.eq(404);
@@ -155,7 +123,7 @@ describe("Thumbnail routes", () => {
         .reply(200, helpers.testFixture("mocks/missing-work-1234.json"));
 
       const result = await handler(event.render());
-      expect(result.statusCode).to.eq(404);
+      expect(result.error.statusCode).to.eq(404);
       expectCorsHeaders(result);
     });
 
@@ -175,7 +143,7 @@ describe("Thumbnail routes", () => {
         .reply(200, helpers.testFixture("mocks/private-work-1234.json"));
 
       const result = await handler(event.render());
-      expect(result.statusCode).to.eq(404);
+      expect(result.error.statusCode).to.eq(404);
     });
 
     it("returns 200 if the work is private and the user is in the reading room", async () => {
@@ -200,7 +168,7 @@ describe("Thumbnail routes", () => {
         .reply(200, helpers.testFixture("mocks/unpublished-work-1234.json"));
 
       const result = await handler(event.render());
-      expect(result.statusCode).to.eq(404);
+      expect(result.error.statusCode).to.eq(404);
     });
 
     it("returns 200 if there is an entitlement for an unpublished, private work", async () => {


### PR DESCRIPTION
Example collection from dev environment running both DC API / next app:
![SCR-20230203-lmt](https://user-images.githubusercontent.com/1395707/216719741-07c42e4e-d4e3-48e2-8ff7-dc338fa77823.png)

## Steps to test
- create a meadow collection without a representative work in Meadow
- hit the `collections/{id}/thumbnail` endpoint and you should get the placeholder image