### PR TITLE
Remove keyword from Manifest `metadata`.

### DIFF
--- a/src/api/response/iiif/presentation-api/metadata.js
+++ b/src/api/response/iiif/presentation-api/metadata.js
@@ -46,10 +46,6 @@ function metadataLabelFields(source) {
       value: source.genre.map((item) => item.label),
     },
     {
-      label: "Keyword",
-      value: source.keywords,
-    },
-    {
       label: "Last Modified",
       value: formatSingleValuedField(source.modified_date),
     },

--- a/test/unit/api/response/iiif/presentation-api/metadata.test.js
+++ b/test/unit/api/response/iiif/presentation-api/metadata.test.js
@@ -24,10 +24,11 @@ describe("IIIF response presentation API metadata helpers", () => {
   it("metadataLabelFields(source)", () => {
     const metadata = metadataLabelFields(source);
     expect(Array.isArray(metadata)).to.be;
-    expect(metadata.length).to.eq(29);
+    expect(metadata.length).to.eq(28);
     metadata.forEach((item) => {
       expect(item.label).to.be.a("string");
       expect(item.value).to.be.an("array");
+      expect(item.label).to.not.contain("Keyword");
     });
   });
 });


### PR DESCRIPTION
## What does this do?

This removes `keyword` from IIIF Manifests by updating the metadata helper in the IIIF response.
