### PR TITLE
Staging PR merge workflow to push commit to nulib/dcapi-types

### DIFF
--- a/.github/workflows/staging-types.yml
+++ b/.github/workflows/staging-types.yml
@@ -1,0 +1,60 @@
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - "deploy/staging"
+    paths:
+      - "docs/docs/spec/data-types.yaml"
+jobs:
+  Push-To-Types-Repo-Staging:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    environment: staging
+    env:
+      TARGET_BRANCH: "staging"
+      TMP_SRCDIR: "./source"
+      TMP_DSTDIR: "./dest"
+      TYPES_REPO: "nulib/dcapi-types"
+    steps:
+      - run: |
+          echo PR with changes to datatypes.yml was merged into staging
+      - name: Checkout dc-api-v2
+        uses: actions/checkout@v3
+        with:
+          path: "${{ env.TMP_SRCDIR }}"
+      - uses: actions/setup-node@v3
+        with:
+          cache-dependency-path: "${{ env.TMP_SRCDIR }}/package-lock.json"
+          node-version: 16.x
+          cache: "npm"
+      - name: get-npm-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+        with:
+          path: "${{ env.TMP_SRCDIR }}/package.json"
+      - name: Generate Typescript file
+        working-directory: "${{ env.TMP_SRCDIR }}"
+        run: |
+          npm ci
+          npx openapi-typescript data-types.yaml --output schema.ts
+      - name: Checkout dcapi-types
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.TMP_DSTDIR }}
+          ref: ${{ env.TARGET_BRANCH }}
+          repository: ${{env.TYPES_REPO}}
+      - run: mv -f "${{ env.TMP_SRCDIR }}/schema.ts" "${{ env.TMP_DSTDIR }}/schema.ts"
+        shell: bash
+      - name: Set GitHub Deploy Key
+        uses: webfactory/ssh-agent@v0.5.3
+        with:
+          ssh-private-key: ${{ secrets.DCAPI_TYPES_DEPLOY_KEY }}
+      - working-directory: "${{ env.TMP_DSTDIR }}"
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add .
+          git commit -m "nulib/dc-api-v2 commit: $GITHUB_SHA, package.json version: ${{ steps.package-version.outputs.current-version}}"
+          git push origin HEAD
+        shell: bash

--- a/docs/docs/spec/data-types.yaml
+++ b/docs/docs/spec/data-types.yaml
@@ -281,7 +281,7 @@ components:
       description: The type of the note
       type: string
       enum:
-        - Awards,
+        - Awards
         - Bibliographical/Historical Note
         - Creation/Production Credits
         - General Note


### PR DESCRIPTION
The `dcapi-types` workflow I'm envisioning is: 
 - For a merge into `dc-api-v2` `deploy/staging` branch that contains changes to `data-types.yaml`, we trigger a commit to the `staging` branch in the `nulib/dcapi-types` repo. If the front end wants to work with what's deployed on staging they can reference the package by branch directly. Since no one else has access to the staging environment, we are not going to publish the package at that point. 
 - When there is a production deployment of `nulib/dc-api-v2` (`main` branch that contains changes to `data-types.yaml`), that will trigger a PR into the `dcapi-types` package's `main` branch. (From there we will either have the PR auto merge (+ auto publish?), or it will be manually reviewed/merged + published. Haven't totally decided on that yet.)

This PR contains only the staging workflow (first part of ☝️)

And what do you know, I found a typo to correct in `data-types.yaml` to test the on merge workflow....