### PR TITLE
Do not include pager options in pagination block by default

### DIFF
--- a/src/api/pagination.js
+++ b/src/api/pagination.js
@@ -54,7 +54,7 @@ class Paginator {
     this.options = options;
   }
 
-  async pageInfo(count) {
+  async pageInfo(count, opts = {}) {
     let url = new URL(this.route, this.baseUrl);
     let searchToken;
 
@@ -91,9 +91,11 @@ class Paginator {
       offset: from(this.body),
       total_hits: count,
       total_pages: maxPage(this.body, count),
-      options: this.options,
       format: this.format,
     };
+    if (opts.includeOptions) {
+      result.options = this.options;
+    }
     if (prev) {
       url.searchParams.set("page", prev);
       result.prev_url = url.toString();

--- a/src/api/response/iiif/collection.js
+++ b/src/api/response/iiif/collection.js
@@ -4,7 +4,9 @@ const { transformError } = require("../error");
 async function transform(response, pager) {
   if (response.statusCode === 200) {
     const responseBody = JSON.parse(response.body);
-    const pageInfo = await pager.pageInfo(responseBody.hits.total.value);
+    const pageInfo = await pager.pageInfo(responseBody.hits.total.value, {
+      includeOptions: true,
+    });
 
     return {
       statusCode: 200,

--- a/test/unit/api/pagination.test.js
+++ b/test/unit/api/pagination.test.js
@@ -87,4 +87,16 @@ describe("Paginator", function () {
     const url = new URL(result.query_url);
     expect(url.searchParams.get("size")).to.eq("5");
   });
+
+  it("does not include options by default", async () => {
+    pager.options = { queryStringParameters: { size: 5 } };
+    const result = await pager.pageInfo(1275);
+    expect(result).not.to.have.key("options");
+  });
+
+  it("includes options on request", async () => {
+    pager.options = { queryStringParameters: { size: 5 } };
+    const result = await pager.pageInfo(1275, { includeOptions: true });
+    expect(result.options).to.have.key("queryStringParameters");
+  });
 });


### PR DESCRIPTION
To test:
- Do a search that returns pagination info. Make sure the `pagination` block does not contain an `options` property.
- Repeat the search `?as=iiif` and make sure it succeeds