### PR TITLE
Deploy docs to correct bucket

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         uses: tj-actions/changed-files@v29.0.2
         with:
           files: |
-            .github/workflows/docs.yaml
+            .github/workflows/deploy.yaml
             docs/*
   publish-docs:
     needs: docs-changed
@@ -96,6 +96,7 @@ jobs:
           openapi-file: docs/site/spec/openapi.yaml
           command-args: -o docs/site/spec
       - name: Copy to S3
-        run: aws s3 sync --delete docs/site/ s3://api-docs.${ZONE}/
+        run: aws s3 sync --delete docs/site/ s3://${HOST}-docs.${ZONE}/
         env:
+          HOST: ${{ secrets.Hostname }}
           ZONE: ${{ secrets.HostedZone }}


### PR DESCRIPTION
#108 changed the name of the docs bucket, but I didn't update the GitHub actions deploy script to match. So new docs are uploading to the old bucket but the API mapping is pointing to the new bucket. This fixes it.

It hasn't affected prod because we haven't deployed to prod.