### PR TITLE
Update github action to have 'sam deploy' read parameter overrides from .parameter files

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,6 +33,7 @@ jobs:
           role-to-assume: arn:aws:iam::${{ secrets.AwsAccount }}:role/github-actions-role
           aws-region: us-east-1
       - run: ln -s .tfvars/dc-api/samconfig.toml .
+      - run: ln -s .tfvars/dc-api/$CONFIG_ENV.parameters .
       - run: sam build
       - run: | 
           sam deploy \
@@ -40,7 +41,7 @@ jobs:
             --no-fail-on-empty-changeset \
             --config-env $CONFIG_ENV \
             --config-file ./samconfig.toml \
-            --parameter-overrides HoneybadgerRevision=$HONEYBADGER_REVISION
+            --parameter-overrides $(while IFS='=' read -r key value; do params+=" $key=$value"; done < ./$CONFIG_ENV.parameters && echo "$params HoneybadgerRevision=$HONEYBADGER_REVISION")
         env:
           HONEYBADGER_REVISION: ${{ github.sha }}
   docs-changed:

--- a/.gitignore
+++ b/.gitignore
@@ -215,3 +215,4 @@ $RECYCLE.BIN/
 /samconfig.toml
 /env.json
 /env.*.json
+/*.parameters

--- a/README.md
+++ b/README.md
@@ -69,6 +69,25 @@ Use the [https-proxy](https://github.com/nulib/aws-developer-environment#conveni
 https-proxy start 3002 3000
 ```
 
+## Deploying the API manually
+- Symlink the `*.parameters` file you need from `tfvars/dc-api/` to the application root
+- Set your `CONFIG_ENV` and `HONEYBADGER_REVISION` environment variables
+- Run `sam deploy`
+
+```sh
+# staging environment example:
+
+ln -s ~/environment/tfvars/dc-api/staging.parameters .
+CONFIG_ENV=staging
+HONEYBADGER_REVISION=$(git rev-parse HEAD)
+sam deploy \
+  --no-confirm-changeset \
+  --no-fail-on-empty-changeset \
+  --config-env $CONFIG_ENV \
+  --config-file ./samconfig.toml \
+  --parameter-overrides $(while IFS='=' read -r key value; do params+=" $key=$value"; done < ./$CONFIG_ENV.parameters && echo "$params HoneybadgerRevision=$HONEYBADGER_REVISION")
+```
+
 ## Writing Documentation
 
 API documentation is automatically regenerated and deployed on pushes to the staging and production branches. The documentation is in two parts:


### PR DESCRIPTION
### Description
Our parameter overrides from samconfig.toml are being clobbered by the `sam deploy` step in the build, so this PR modifies `sam deploy` to read the parameter overrides from files checked into the `tfvars` repository.

### Changes
- Updates `deploy.yml` described above
- Updates `README` to include steps for manual deployment
- Adds `/*.parameters` to `.gitignore`

### Steps to test
- Review the code as best you can, and we'll figure out if it works when it deploys.