### PR TITLE
Remove unattended deploy params from manual deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,6 @@ ln -s ~/environment/tfvars/dc-api/staging.parameters .
 CONFIG_ENV=staging
 HONEYBADGER_REVISION=$(git rev-parse HEAD)
 sam deploy \
-  --no-confirm-changeset \
-  --no-fail-on-empty-changeset \
   --config-env $CONFIG_ENV \
   --config-file ./samconfig.toml \
   --parameter-overrides $(while IFS='=' read -r key value; do params+=" $key=$value"; done < ./$CONFIG_ENV.parameters && echo "$params HoneybadgerRevision=$HONEYBADGER_REVISION")


### PR DESCRIPTION
The `--no-confirm-changeset` and `--no-fail-on-empty-changeset` parameters on `sam deploy` are only supposed to be used on unattended deploys. When deploying manually, we do want people to review and confirm the changes that will be made before it happens.