### PR TITLE
Production dcapi types Github action workflow

### DIFF
--- a/.github/workflows/production-types.yml
+++ b/.github/workflows/production-types.yml
@@ -1,0 +1,84 @@
+on:
+  pull_request_target:
+    types:
+      - closed
+    branches:
+      - "main"
+    paths:
+      - "docs/docs/spec/data-types.yaml"
+jobs:
+  Push-To-Types-Repo-Production:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    environment: production
+    env:
+      TARGET_BRANCH: "main"
+      TMP_SRCDIR: "./source"
+      TMP_DSTDIR: "./dest"
+      TMP_REPODEVDIR: "./repodev"
+      GH_TOKEN: ${{secrets.GH_TOKEN}}
+    steps:
+      - run: |
+          echo PR with changes to datatypes.yml was merged into staging
+      - name: Checkout dc-api-v2
+        uses: actions/checkout@v3
+        with:
+          path: "${{ env.TMP_SRCDIR }}"
+      - uses: actions/setup-node@v3
+        with:
+          cache-dependency-path: "${{ env.TMP_SRCDIR }}/package-lock.json"
+          node-version: 16.x
+          cache: "npm"
+      - name: Set short git commit SHA
+        working-directory: "${{ env.TMP_SRCDIR }}"
+        id: short-sha
+        run: |
+          echo "short-sha=$(git rev-parse --short ${{ github.sha }})" >> $GITHUB_OUTPUT
+      - name: get-api-version
+        id: package-version
+        uses: martinbeentjes/npm-get-version-action@main
+        with:
+          path: "${{ env.TMP_SRCDIR }}"
+      - name: Generate Typescript file
+        working-directory: "${{ env.TMP_SRCDIR }}"
+        run: |
+          npm ci
+          npx openapi-typescript docs/docs/spec/data-types.yaml --output schema.ts
+      - name: Checkout nulib/dcapi-types
+        uses: actions/checkout@v3
+        with:
+          path: ${{ env.TMP_DSTDIR }}
+          ref: ${{ env.TARGET_BRANCH }}
+          repository: "nulib/dcapi-types"
+          token: ${{env.GH_TOKEN}}
+      - run: mv -f "${{ env.TMP_SRCDIR }}/schema.ts" "${{ env.TMP_DSTDIR }}/schema.ts"
+        shell: bash
+      - working-directory: "${{ env.TMP_DSTDIR }}"
+        run: |
+          git checkout -b dcapi-${{ steps.vars.outputs.short-sha }}
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add .
+          git commit -m "nulib/dc-api-v2 v${{ steps.package-version.outputs.current-version}} release"
+          git push origin HEAD
+        shell: bash
+      - name: Open nulib/dcapi-client PR
+        id: open-types-pr
+        working-directory: "${{ env.TMP_DSTDIR }}"
+        run: |
+          echo 'pr=$(gh pr create --base main --title "Update types for DC API release v${{ steps.package-version.outputs.current-version}}" --body "A new version of `nulib/dc-api-v2` has been released. Please review changes and release a new version of the types package if needed." --reviewer adamjarling --reviewer mathewjordan)' >> $GITHUB_OUTPUT
+            - name: Checkout dcapi-types
+      - name: Checkout nulib/repodev_planning_and_docs
+        uses: actions/checkout@v3
+        with:
+          path: "${{env.TMP_REPODEVDIR}}"
+          repository: "nulib/repodev_planning_and_docs"
+          token: ${{env.GH_TOKEN}}
+      - name: Open issue in nulib/repodev_planning_and_docs
+        working-directory: "${{env.TMP_REPODEVDIR}}"
+        run: |
+          gh issue create -t "Update nulib/dcapi-types for API release v${{ steps.package-version.outputs.current-version}}" -b "Review PR: ${{ steps.open-types-pr.outputs.pr}} and release nulib/dcapi-types if needed." -a adamjarling,mathewjordan -l "digital collections" -l "front end"
+        shell: bash

--- a/.github/workflows/staging-types.yml
+++ b/.github/workflows/staging-types.yml
@@ -35,7 +35,7 @@ jobs:
         id: package-version
         uses: martinbeentjes/npm-get-version-action@main
         with:
-          path: "${{ env.TMP_SRCDIR }}/package.json"
+          path: "${{ env.TMP_SRCDIR }}"
       - name: Generate Typescript file
         working-directory: "${{ env.TMP_SRCDIR }}"
         run: |

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ https-proxy start 3002 3000
 ```
 
 ## Deploying the API manually
+
 - Symlink the `*.parameters` file you need from `tfvars/dc-api/` to the application root
 - Set your `CONFIG_ENV` and `HONEYBADGER_REVISION` environment variables
 - Run `sam deploy`
@@ -119,7 +120,16 @@ For an in-depth look, or to learn how to define things for which there aren't go
 #### Build Artifacts
 
 `openapi.html` renders the Swagger UI directly from the unmodified `openapi.yaml`. In addition, the build process generates a JSON copy of the spec using the [OpenAPI Generator CLI](https://openapi-generator.tech). In order to make sure the spec is valid before checking it in, run:
+
 ```shell
 npm run validate-spec
 ```
+
 This check is also part of the CI test workflow, so an invalid spec file will cause the branch to fail CI.
+
+## DC API Typescript NPM package
+
+Typescript types for the schemas (Works, Collections, FileSets) are automatically published to the [nulib/dcapi-types](https://github.com/nulib/dcapi-types) repo on deploys.
+
+- If a deploy to the `deploy/staging` branch contains changes to the `docs/docs/spec/data-types.yaml` file, new types are generated and a commit is made to the `staging` branch of `nulib/dcapi`. This is intended to be for local testing by NUL devs against the private staging API.
+- If a deploy to production (`main` branch) contains changes to the `docs/docs/spec/data-types.yaml` file, new types are generated and a PR is opened into the `main` branch of `nulib/dcapi-types`. Also, an issue is created in `nulib/repodev_planning_and_docs` to review the PR and publish the types package (manually).


### PR DESCRIPTION
- Production workflow added
- Readme updated


### Overview of workflow

Typescript types for the schemas (Works, Collections, FileSets) are automatically published to the [nulib/dcapi-types](https://github.com/nulib/dcapi-types) repo on deploys.

- If a deploy to the `deploy/staging` branch contains changes to the `docs/docs/spec/data-types.yaml` file, new types are generated and a commit is made to the `staging` branch of `nulib/dcapi`. This is intended to be for local testing by NUL devs against the private staging API.
- If a deploy to production (`main` branch) contains changes to the `docs/docs/spec/data-types.yaml` file, new types are generated and a PR is opened into the `main` branch of `nulib/dcapi-types`. Also, an issue is created in `nulib/repodev_planning_and_docs` to review the PR and publish the types package (manually).
