### PR TITLE
Return 403 instead of 404 for private published documents

### DIFF
--- a/test/integration/get-collection-by-id.test.js
+++ b/test/integration/get-collection-by-id.test.js
@@ -50,7 +50,7 @@ describe("Retrieve collection by id", () => {
       expect(result.statusCode).to.eq(404);
     });
 
-    it("404's if the collection is private", async () => {
+    it("403's if the collection is private", async () => {
       mock
         .get("/dc-v2-collection/_doc/1234")
         .reply(
@@ -64,7 +64,7 @@ describe("Retrieve collection by id", () => {
         .render();
 
       const result = await handler(event);
-      expect(result.statusCode).to.eq(404);
+      expect(result.statusCode).to.eq(403);
     });
 
     it("200's if the collection is private but the user is in the reading room", async () => {

--- a/test/integration/get-doc.test.js
+++ b/test/integration/get-doc.test.js
@@ -58,7 +58,7 @@ describe("Doc retrieval routes", () => {
       expect(result.statusCode).to.eq(404);
     });
 
-    it("404s a private work by default", async () => {
+    it("403's a private work by default", async () => {
       mock
         .get("/dc-v2-work/_doc/1234")
         .reply(200, helpers.testFixture("mocks/private-work-1234.json"));
@@ -68,7 +68,7 @@ describe("Doc retrieval routes", () => {
         .pathParams({ id: 1234 })
         .render();
       const result = await handler(event);
-      expect(result.statusCode).to.eq(404);
+      expect(result.statusCode).to.eq(403);
     });
 
     it("returns a private work to allowed IPs", async () => {

--- a/test/integration/get-thumbnail.test.js
+++ b/test/integration/get-thumbnail.test.js
@@ -137,13 +137,13 @@ describe("Thumbnail routes", () => {
       expectCorsHeaders(result);
     });
 
-    it("returns 404 if the work is private", async () => {
+    it("returns 403 if the work is private", async () => {
       mock
         .get("/dc-v2-work/_doc/1234")
         .reply(200, helpers.testFixture("mocks/private-work-1234.json"));
 
       const result = await handler(event.render());
-      expect(result.error.statusCode).to.eq(404);
+      expect(result.error.statusCode).to.eq(403);
     });
 
     it("returns 200 if the work is private and the user is in the reading room", async () => {


### PR DESCRIPTION
- Return `403` instead of `404` for private published documents (this includes `Works`, `FileSets` and `Collections` responses.)