### PR TITLE
Handle IIIF response for a Work with no Collection

### DIFF
--- a/src/api/response/iiif/manifest.js
+++ b/src/api/response/iiif/manifest.js
@@ -148,51 +148,52 @@ function transform(response) {
         manifest.setHomepage(homepage);
 
         /** Add partOf */
-        const collectionEndpoint = `${dcApiEndpoint()}/collections/${
-          source.collection.id
-        }`;
-        manifest.setPartOf([
-          {
-            id: `${collectionEndpoint}?as=iiif`,
-            type: "Collection",
-            label: { none: [source.collection.title] },
-            ...(source.collection.description && {
-              summary: {
-                none: [source.collection.description],
-              },
-            }),
-
-            /**
-             * TODO: iiif-builder mangles this property, come back to it
-             */
-            // thumbnail: [
-            //   {
-            //     id: `${collectionEndpoint}/thumbnail`,
-            //     type: "Image",
-            //     width: 300,
-            //     height: 300,
-            //     format: "image/jpeg",
-            //   },
-            // ],
-
-            /**
-             * TODO: iiif-builder cleanses this property and doesn't include it.
-             * Come back to it.
-             */
-            homepage: [
-              {
-                id: `${dcUrl()}/collections/${source.collection.id}`,
-                type: "Text",
-                format: "text/html",
-                label: {
-                  none: [
-                    "Homepage at Northwestern University Libraries Digital Collections",
-                  ],
+        if (source.collection?.id) {
+          const collectionId = source.collection.id;
+          const collectionEndpoint = `${dcApiEndpoint()}/collections/${collectionId}`;
+          manifest.setPartOf([
+            {
+              id: `${collectionEndpoint}?as=iiif`,
+              type: "Collection",
+              label: { none: [source.collection.title] },
+              ...(source.collection.description && {
+                summary: {
+                  none: [source.collection.description],
                 },
-              },
-            ],
-          },
-        ]);
+              }),
+
+              /**
+               * TODO: iiif-builder mangles this property, come back to it
+               */
+              // thumbnail: [
+              //   {
+              //     id: `${collectionEndpoint}/thumbnail`,
+              //     type: "Image",
+              //     width: 300,
+              //     height: 300,
+              //     format: "image/jpeg",
+              //   },
+              // ],
+
+              /**
+               * TODO: iiif-builder cleanses this property and doesn't include it.
+               * Come back to it.
+               */
+              homepage: [
+                {
+                  id: `${dcUrl()}/collections/${collectionId}`,
+                  type: "Text",
+                  format: "text/html",
+                  label: {
+                    none: [
+                      "Homepage at Northwestern University Libraries Digital Collections",
+                    ],
+                  },
+                },
+              ],
+            },
+          ]);
+        }
 
         /** Add logo */
 

--- a/test/fixtures/mocks/work-1234-no-collection.json
+++ b/test/fixtures/mocks/work-1234-no-collection.json
@@ -1,0 +1,374 @@
+{
+  "_index": "dev-dc-v2-work",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "_seq_no": 719,
+  "_primary_term": 1,
+  "found": true,
+  "_source": {
+    "abstract": [],
+    "accession_number": "Canary_002",
+    "alternate_title": ["This is an alternative title"],
+    "api_link": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/1234",
+    "api_model": "Work",
+    "ark": "ark:/99999/fk47h32p0m",
+    "batch_ids": [
+      "a846a5f2-da57-49e6-a138-f5462d113a55",
+      "97aac3e3-389a-47ac-a7b3-5dd6ffffd558",
+      "e2529123-6a8c-4f6d-89d5-0257a1b947d4",
+      "b3d3462d-c03e-4cae-9219-4e38335a25fc",
+      "1591cc1e-009d-4b39-97a2-7d8743fb957b",
+      "80a15dc2-92d5-48a4-9aa4-73ecdcb1d130"
+    ],
+    "box_name": ["The name of a box"],
+    "box_number": ["88"],
+    "caption": ["Beebo"],
+    "catalog_key": ["MS-1984-1982-1989"],
+    "collection": null,
+    "contributor": [
+      {
+        "facet": "http://id.loc.gov/authorities/names/n91114928|ctg|Metallica (Musical group) (Cartographer)",
+        "id": "http://id.loc.gov/authorities/names/n91114928",
+        "label": "Metallica (Musical group)",
+        "label_with_role": "Metallica (Musical group) (Cartographer)",
+        "role": "Cartographer",
+        "variants": []
+      },
+      {
+        "facet": "http://id.worldcat.org/fast/1204616|abr|South Africa (Abridger)",
+        "id": "http://id.worldcat.org/fast/1204616",
+        "label": "South Africa",
+        "label_with_role": "South Africa (Abridger)",
+        "role": "Abridger",
+        "variants": []
+      },
+      {
+        "facet": "http://id.worldcat.org/fast/1150166|app|Thistles (Applicant)",
+        "id": "http://id.worldcat.org/fast/1150166",
+        "label": "Thistles",
+        "label_with_role": "Thistles (Applicant)",
+        "role": "Applicant",
+        "variants": []
+      }
+    ],
+    "create_date": "2022-03-02T20:38:29.813494Z",
+    "creator": [
+      {
+        "facet": "http://id.loc.gov/authorities/names/no2011059409||Dessa (Vocalist)",
+        "id": "http://id.loc.gov/authorities/names/no2011059409",
+        "label": "Dessa (Vocalist)",
+        "variants": [
+          "Dessa, 1981-",
+          "Wander, Dessa, 1981-",
+          "Dessa Darling",
+          "Wander, Margret"
+        ]
+      },
+      {
+        "facet": "http://id.worldcat.org/fast/1152763||Tornadoes",
+        "id": "http://id.worldcat.org/fast/1152763",
+        "label": "Tornadoes",
+        "variants": []
+      },
+      {
+        "facet": "http://vocab.getty.edu/aat/300443944||photo editors",
+        "id": "http://vocab.getty.edu/aat/300443944",
+        "label": "photo editors",
+        "variants": []
+      },
+      {
+        "facet": "http://id.worldcat.org/fast/1717972||Schober, Franz von, 1796-1882",
+        "id": "http://id.worldcat.org/fast/1717972",
+        "label": "Schober, Franz von, 1796-1882",
+        "variants": []
+      }
+    ],
+    "csv_metadata_update_jobs": [
+      "5753101a-42fa-4838-9b71-f1594a5b1d5f",
+      "6b46db60-6f6a-45e8-8b8d-ab0029a1e8fe",
+      "38988b3e-5778-41da-85a5-e16d13cb098a",
+      "21838181-8d12-4015-8b98-0874061adb98"
+    ],
+    "cultural_context": ["Test Context"],
+    "date_created": ["August 1906 to December 1910", "1958"],
+    "description": [
+      "This is a private record for RepoDev testing on production"
+    ],
+    "file_sets": [
+      {
+        "duration": null,
+        "height": 3024,
+        "id": "076dcbd8-8c57-40e8-bdf7-dc9153c87a36",
+        "label": "Access File - Tiff",
+        "mime_type": "image/tiff",
+        "original_filename": "Squirrel.tif",
+        "poster_offset": null,
+        "rank": 0,
+        "representative_image_url": "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/076dcbd8-8c57-40e8-bdf7-dc9153c87a36",
+        "role": "Access",
+        "streaming_url": null,
+        "webvtt": null,
+        "width": 4032
+      },
+      {
+        "duration": null,
+        "height": 3024,
+        "id": "d51cc0b6-562a-4a8f-8443-5e20221c308b",
+        "label": "Access File - Tiff",
+        "mime_type": "image/tiff",
+        "original_filename": "PXL_20211203_142315620.tif",
+        "poster_offset": null,
+        "rank": 1073741824,
+        "representative_image_url": "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/d51cc0b6-562a-4a8f-8443-5e20221c308b",
+        "role": "Supplemental",
+        "streaming_url": null,
+        "webvtt": null,
+        "width": 4032
+      },
+      {
+        "duration": null,
+        "height": 4032,
+        "id": "5a4ffcfb-e231-4a59-9e4d-92d1814604fb",
+        "label": "Preservation File - Tiff",
+        "mime_type": "image/tiff",
+        "original_filename": "distillery.tif",
+        "poster_offset": null,
+        "rank": 1073741824,
+        "representative_image_url": null,
+        "role": "Preservation",
+        "streaming_url": null,
+        "webvtt": null,
+        "width": 3024
+      },
+      {
+        "duration": null,
+        "height": null,
+        "id": "09617d98-9c67-414e-a0f7-4e69ca99546b",
+        "label": "Auxiliary File - PNG",
+        "mime_type": "image/jpeg",
+        "original_filename": "CoopersHawk.png",
+        "poster_offset": null,
+        "rank": 0,
+        "representative_image_url": "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/09617d98-9c67-414e-a0f7-4e69ca99546b",
+        "role": "Auxiliary",
+        "streaming_url": null,
+        "webvtt": null,
+        "width": null
+      },
+      {
+        "duration": null,
+        "height": null,
+        "id": "51862c1c-c024-45dc-ab26-694bd8ebc16c",
+        "label": "Access File - Jpeg",
+        "mime_type": "image/jpeg",
+        "original_filename": "Cassettetape.jpg",
+        "poster_offset": null,
+        "rank": 1610612736,
+        "representative_image_url": "https://iiif.stack.rdc-staging.library.northwestern.edu/iiif/2/51862c1c-c024-45dc-ab26-694bd8ebc16c",
+        "role": "Access",
+        "streaming_url": null,
+        "webvtt": null,
+        "width": null
+      },
+      {
+        "duration": null,
+        "height": null,
+        "id": "a10c1829-265c-44cf-996a-f8c59b16ba97",
+        "label": "Preservation File - Jpeg",
+        "mime_type": "image/jpeg",
+        "original_filename": "Cassettetape.jpg",
+        "poster_offset": null,
+        "rank": 0,
+        "representative_image_url": null,
+        "role": "Preservation",
+        "streaming_url": null,
+        "webvtt": null,
+        "width": null
+      }
+    ],
+    "folder_names": ["Blue folder"],
+    "folder_numbers": ["88"],
+    "genre": [
+      {
+        "facet": "http://id.worldcat.org/fast/1919896||Biographies",
+        "id": "http://id.worldcat.org/fast/1919896",
+        "label": "Biographies",
+        "variants": []
+      },
+      {
+        "facet": "http://id.worldcat.org/fast/1019337||Mice",
+        "id": "http://id.worldcat.org/fast/1019337",
+        "label": "Mice",
+        "variants": []
+      }
+    ],
+    "id": "1234",
+    "identifier": ["555"],
+    "iiif_manifest": "https://iiif.stack.rdc-staging.library.northwestern.edu/public/15/6a/8f/8e/-5/49/b-/49/82/-8/6c/c-/37/5b/f0/41/04/ff-manifest.json",
+    "indexed_at": "2022-10-14T14:19:42.844994",
+    "keywords": ["leaves"],
+    "language": [
+      {
+        "facet": "http://id.loc.gov/vocabulary/languages/crh||Crimean Tatar",
+        "id": "http://id.loc.gov/vocabulary/languages/crh",
+        "label": "Crimean Tatar",
+        "variants": []
+      }
+    ],
+    "legacy_identifier": ["555"],
+    "library_unit": "Charles Deering McCormick Library of Special Collections",
+    "license": {
+      "id": "http://www.europeana.eu/portal/rights/rr-r.html",
+      "label": "All rights reserved",
+      "scheme": "license"
+    },
+    "location": [
+      {
+        "facet": "https://sws.geonames.org/4999069/||Leland Township",
+        "id": "https://sws.geonames.org/4999069/",
+        "label": "Leland Township",
+        "variants": []
+      }
+    ],
+    "modified_date": "2022-10-13T20:56:31.249155Z",
+    "notes": [
+      {
+        "note": "Here are some notes",
+        "type": "General Note"
+      },
+      {
+        "note": "Awards type",
+        "type": "Awards"
+      },
+      {
+        "note": "Biographical note",
+        "type": "Biographical/Historical Note"
+      },
+      {
+        "note": "creation production credits",
+        "type": "Creation/Production Credits"
+      },
+      {
+        "note": "Language note",
+        "type": "Language Note"
+      },
+      {
+        "note": "Local Note",
+        "type": "Local Note"
+      },
+      {
+        "note": "Performers",
+        "type": "Performers"
+      },
+      {
+        "note": "Statement of Responsibility",
+        "type": "Statement of Responsibility"
+      },
+      {
+        "note": "Venue/event date",
+        "type": "Venue/Event Date"
+      },
+      {
+        "note": "massive add to all pages/check",
+        "type": "General Note"
+      }
+    ],
+    "physical_description_material": ["Acrylic paint on cement block"],
+    "physical_description_size": ["16 x 24 inches"],
+    "preservation_level": "Level 1",
+    "provenance": [
+      "Artist; sold to Mr. Blank in 1955; sold to Lancelot in 2017; gifted to Northwestern University in 2019"
+    ],
+    "published": true,
+    "publisher": ["Northwestern University Press"],
+    "related_material": ["See Also: related material"],
+    "related_url": [
+      {
+        "label": "Finding Aid",
+        "url": "https://findingaids.library.northwestern.edu/"
+      },
+      {
+        "label": "Research Guide",
+        "url": "https://www.wbez.org/"
+      },
+      {
+        "label": "Related Information",
+        "url": "https://www.nationalgeographic.com/animals/mammals/facts/squirrels"
+      },
+      {
+        "label": "Hathi Trust Digital Library",
+        "url": "https://www.hathitrust.org/"
+      }
+    ],
+    "representative_file_set": {
+      "fileSetId": "5678",
+      "url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/5678"
+    },
+    "rights_holder": ["Artist"],
+    "rights_statement": {
+      "id": "http://rightsstatements.org/vocab/InC-EDU/1.0/",
+      "label": "In Copyright - Educational Use Permitted"
+    },
+    "scope_and_contents": ["I promise there is scope and content"],
+    "series": ["Canaries and How to Care for Them"],
+    "source": ["Mars"],
+    "status": "Done",
+    "style_period": [
+      {
+        "facet": "http://vocab.getty.edu/aat/300018478||Qing (dynastic styles and periods)",
+        "id": "http://vocab.getty.edu/aat/300018478",
+        "label": "Qing (dynastic styles and periods)",
+        "variants": []
+      }
+    ],
+    "subject": [
+      {
+        "facet": "http://id.worldcat.org/fast/1902713|TOPICAL|Cats on postage stamps (Topical)",
+        "id": "http://id.worldcat.org/fast/1902713",
+        "label": "Cats on postage stamps",
+        "label_with_role": "Cats on postage stamps (Topical)",
+        "role": "Topical",
+        "variants": []
+      },
+      {
+        "facet": "info:nul/6cba23b5-a91a-4c13-8398-54967b329d48|TOPICAL|Test Record Canary (Topical)",
+        "id": "info:nul/6cba23b5-a91a-4c13-8398-54967b329d48",
+        "label": "Test Record Canary",
+        "label_with_role": "Test Record Canary (Topical)",
+        "role": "Topical",
+        "variants": []
+      },
+      {
+        "facet": "http://vocab.getty.edu/tgn/2000971|GEOGRAPHICAL|Leelanau (Geographical)",
+        "id": "http://vocab.getty.edu/tgn/2000971",
+        "label": "Leelanau",
+        "label_with_role": "Leelanau (Geographical)",
+        "role": "Geographical",
+        "variants": []
+      },
+      {
+        "facet": "http://id.worldcat.org/fast/1204587|GEOGRAPHICAL|Michigan--Ann Arbor (Geographical)",
+        "id": "http://id.worldcat.org/fast/1204587",
+        "label": "Michigan--Ann Arbor",
+        "label_with_role": "Michigan--Ann Arbor (Geographical)",
+        "role": "Geographical",
+        "variants": []
+      }
+    ],
+    "table_of_contents": ["1. cats; 2. dogs"],
+    "technique": [
+      {
+        "facet": "http://vocab.getty.edu/aat/300053228||drypoint (printing process)",
+        "id": "http://vocab.getty.edu/aat/300053228",
+        "label": "drypoint (printing process)",
+        "variants": []
+      }
+    ],
+    "terms_of_use": "Terms ",
+    "thumbnail": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/5678/square/!300,300/0/default.jpg",
+    "title": "Canary Record TEST 1",
+    "visibility": "Public",
+    "work_type": "Image"
+  }
+}

--- a/test/unit/api/response/iiif/manifest.test.js
+++ b/test/unit/api/response/iiif/manifest.test.js
@@ -138,6 +138,26 @@ describe("Image Work as IIIF Manifest response transformer", () => {
       source.file_sets[0].representative_image_url
     );
   });
+
+  it("includes partOf property only if Work has a Collection", async () => {
+    const { manifest } = await setup();
+    expect(manifest).to.have.property("partOf");
+
+    async function setup2() {
+      const response = {
+        statusCode: 200,
+        body: helpers.testFixture("mocks/work-1234-no-collection.json"),
+      };
+      const source = JSON.parse(response.body)._source;
+
+      const result = await transformer.transform(response);
+      expect(result.statusCode).to.eq(200);
+
+      return { source, manifest: JSON.parse(result.body) };
+    }
+    const { manifest: manifest2 } = await setup2();
+    expect(manifest2).to.not.have.property("partOf");
+  });
 });
 
 describe("A/V Work as IIIF Manifest response transformer", () => {


### PR DESCRIPTION
## What does this do?
For the `?as=iiif` response, only include the `partOf` property on a response if a Work has a Collection.  The code now handles a `collection: null` response from OpenSearch for a `Work`.