### PR TITLE
Update format for .m3u8 A/V IIIF canvas annotation body.

### DIFF
--- a/src/api/response/iiif/presentation-api/items.js
+++ b/src/api/response/iiif/presentation-api/items.js
@@ -5,10 +5,13 @@ function annotationType(workType) {
 }
 
 function buildAnnotationBody(fileSet, workType) {
+  const bodyType = annotationType(workType);
   const body = {
     id: buildAnnotationBodyId(fileSet, workType),
-    type: annotationType(workType),
-    format: fileSet.mime_type,
+    type: bodyType,
+    format: isAudioVideo(bodyType)
+      ? "application/x-mpegurl"
+      : fileSet.mime_type,
     height: fileSet.height || 100,
     width: fileSet.width || 100,
   };

--- a/test/unit/api/response/iiif/manifest.test.js
+++ b/test/unit/api/response/iiif/manifest.test.js
@@ -190,6 +190,7 @@ describe("A/V Work as IIIF Manifest response transformer", () => {
 
     expect(annotation.body.duration).to.eq(5.599);
     expect(annotation.body.type).to.eq("Video");
+    expect(annotation.body.format).to.eq("application/x-mpegurl");
     expect(annotation.body.id).to.eq(source.file_sets[0].streaming_url);
   });
 });


### PR DESCRIPTION
## What does this do?

This update the `format` property of our IIIF Canvas annotation body for our A/V filesets. If thes `annotation.body.type` is **Sound** or **Video**, then the format will now be `application/x-mpegurl`. Doing so will help IIIF viewer know better that the resources are HLS streams for .m3u8 playlists.

```json
{
  "id": "https://example.org/whatever.m3u8",
  "type": "Video",
  "format": "application/x-mpegurl",
  "height": 100,
  "width": 100,
  "duration": 360,
}
```