### PR TITLE
Add placeholderCanvas for `Image` canvases.

### DIFF
--- a/src/api/response/iiif/manifest.js
+++ b/src/api/response/iiif/manifest.js
@@ -8,6 +8,9 @@ const {
   isAudioVideo,
 } = require("./presentation-api/items");
 const { metadataLabelFields } = require("./presentation-api/metadata");
+const {
+  buildPlaceholderCanvas,
+} = require("./presentation-api/placeholder-canvas");
 
 function transform(response) {
   if (response.statusCode === 200) {
@@ -233,6 +236,24 @@ function transform(response) {
         matched.annotations = [a];
       }
     });
+
+    /**
+     * Add a placeholderCanvas property to a Canvas if the annotation body is of type "Image"
+     * (iiif-builder package currently doesn't support adding this property)
+     */
+    for (let i = 0; i < jsonManifest.items.length; i++) {
+      if (jsonManifest.items[i].items[0].items[0].body.type === "Image") {
+        const { id, thumbnail } = jsonManifest.items[i];
+        const placeholderFileSet = source.file_sets.find(
+          (fileSet) =>
+            fileSet.representative_image_url === thumbnail[0].service[0]["@id"]
+        );
+        jsonManifest.items[i].placeholderCanvas = buildPlaceholderCanvas(
+          id,
+          placeholderFileSet
+        );
+      }
+    }
 
     return {
       statusCode: 200,

--- a/src/api/response/iiif/presentation-api/placeholder-canvas.js
+++ b/src/api/response/iiif/presentation-api/placeholder-canvas.js
@@ -1,0 +1,54 @@
+function buildPlaceholderCanvas(id, fileSet, size = 640) {
+  const { representative_image_url } = fileSet;
+  const { placeholderWidth, placeholderHeight } = getPlaceholderSizes(
+    fileSet,
+    size
+  );
+
+  return {
+    id: `${id}/placeholder`,
+    type: "Canvas",
+    width: placeholderWidth,
+    height: placeholderHeight,
+    items: [
+      {
+        id: `${id}/placeholder/annotation-page/0`,
+        type: "AnnotationPage",
+        items: [
+          {
+            id: `${id}/placeholder/annotation/0`,
+            type: "Annotation",
+            motivation: "painting",
+            body: {
+              id: `${representative_image_url}/full/!${placeholderWidth},${placeholderHeight}/0/default.jpg`,
+              type: "Image",
+              format: fileSet.mime_type,
+              width: placeholderWidth,
+              height: placeholderHeight,
+              service: [
+                {
+                  ["@id"]: representative_image_url,
+                  ["@type"]: "ImageService2",
+                  profile: "http://iiif.io/api/image/2/level2.json",
+                },
+              ],
+            },
+            target: `${id}/placeholder`,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+function getPlaceholderSizes(fileset, size) {
+  const { width, height } = fileset;
+  const placeholderWidth = width > size ? size : width;
+  const placeholderHeight = Math.floor((placeholderWidth / width) * height);
+  return { placeholderWidth, placeholderHeight };
+}
+
+module.exports = {
+  buildPlaceholderCanvas,
+  getPlaceholderSizes,
+};

--- a/test/unit/api/response/iiif/manifest.test.js
+++ b/test/unit/api/response/iiif/manifest.test.js
@@ -114,6 +114,13 @@ describe("Image Work as IIIF Manifest response transformer", () => {
     );
   });
 
+  it("adds a placeholderCanvas property to Image canvases", async () => {
+    const { manifest } = await setup();
+    const { placeholderCanvas } = manifest.items[0];
+    expect(placeholderCanvas.id).to.eq(`${manifest.items[0].id}/placeholder`);
+    expect(placeholderCanvas.type).to.eq("Canvas");
+  });
+
   it("excludes Preservation and Supplemental filesets", async () => {
     const { manifest } = await setup();
     manifest.items.forEach((canvas) => {

--- a/test/unit/api/response/iiif/presentation-api/placeholder-canvas.test.js
+++ b/test/unit/api/response/iiif/presentation-api/placeholder-canvas.test.js
@@ -1,0 +1,66 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+const transformer = requireSource("api/response/iiif/manifest");
+const { buildPlaceholderCanvas, getPlaceholderSizes } = requireSource(
+  "api/response/iiif/presentation-api/placeholder-canvas"
+);
+
+describe("IIIF response presentation API placeholderCanvas helpers", () => {
+  async function setup() {
+    const response = {
+      statusCode: 200,
+      body: helpers.testFixture("mocks/work-1234.json"),
+    };
+    const source = JSON.parse(response.body)._source;
+
+    const result = await transformer.transform(response);
+    expect(result.statusCode).to.eq(200);
+
+    return { source, manifest: JSON.parse(result.body) };
+  }
+
+  it("buildPlaceholderCanvas(value)", async () => {
+    const { source, manifest } = await setup();
+    const id = manifest.items[0].id;
+    const fileSet = source.file_sets[0];
+    const placeholder = buildPlaceholderCanvas(id, fileSet, 640);
+
+    expect(placeholder.id).to.eq(`${id}/placeholder`);
+    expect(placeholder.type).to.eq("Canvas");
+    expect(placeholder.width).to.eq(640);
+    expect(placeholder.height).to.eq(480);
+    expect(placeholder.items[0].id).to.eq(
+      `${id}/placeholder/annotation-page/0`
+    );
+    expect(placeholder.items[0].type).to.eq("AnnotationPage");
+    expect(placeholder.items[0].items[0].type).to.eq("Annotation");
+    expect(placeholder.items[0].items[0].motivation).to.eq("painting");
+    expect(placeholder.items[0].items[0].body.id).to.eq(
+      `${fileSet.representative_image_url}/full/!640,480/0/default.jpg`
+    );
+    expect(placeholder.items[0].items[0].body.type).to.eq("Image");
+    expect(placeholder.items[0].items[0].body.format).to.eq(fileSet.mime_type);
+    expect(placeholder.items[0].items[0].body.width).to.eq(640);
+    expect(placeholder.items[0].items[0].body.height).to.eq(480);
+    expect(placeholder.items[0].items[0].body.service[0]["@id"]).to.eq(
+      fileSet.representative_image_url
+    );
+  });
+
+  it("getPlaceholderSizes(fileSet, size)", () => {
+    const fileSet = {
+      width: 3125,
+      height: 2240,
+    };
+
+    const { placeholderHeight, placeholderWidth } = getPlaceholderSizes(
+      fileSet,
+      1000
+    );
+
+    expect(placeholderWidth).to.eq(1000);
+    expect(placeholderHeight).to.eq(716);
+  });
+});


### PR DESCRIPTION
## What does this do?

This adds a placeholderCanvas property to any Canvas with an annotation body of `Image` on our Manifests. The appending of this property occurs after the Canvas is generated as the `iiif-builder` package and its classes do not yet support `placeholderCanvas`. 

A width and height are generated for the placeholder canvas that is proportional to the dimensions of the source fileset. A max size is set as `640` and determines the width. The height is then proportional computed from that 