### PR TITLE
Fix typos in production-types.yml workflow

### DIFF
--- a/.github/workflows/production-types.yml
+++ b/.github/workflows/production-types.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - "docs/docs/spec/data-types.yaml"
       - ".github/flags/deploy-data-types"
-      - ".github/workflows/production-types.yml"
   workflow_dispatch:
 jobs:
   Push-To-Types-Repo-Production:
@@ -26,7 +25,7 @@ jobs:
       GH_TOKEN: ${{secrets.GH_TOKEN}}
     steps:
       - run: |
-          echo PR with changes to datatypes.yml was merged into staging
+          echo PR with changes to datatypes.yml was merged into main
       - name: Checkout dc-api-v2
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/staging-types.yml
+++ b/.github/workflows/staging-types.yml
@@ -8,7 +8,6 @@ on:
     paths:
       - "docs/docs/spec/data-types.yaml"
       - ".github/flags/deploy-data-types"
-      - ".github/workflows/staging-types.yml"
   workflow_dispatch:
 jobs:
   Push-To-Types-Repo-Staging:


### PR DESCRIPTION
- Printed output says "staging" instead of "main"
- Workflow does not need to watch for changes in self since we added a flag file (`.github/flags/deploy-data-types`)