### PR TITLE
Add shared link expiration to work response

### DIFF
--- a/docs/docs/spec/data-types.yaml
+++ b/docs/docs/spec/data-types.yaml
@@ -251,11 +251,15 @@ components:
         - id
         - label
     Info:
-      description: Global DC API properties
+      description: Additional Information
       type: object
       properties:
         description:
           type: string
+        link_expiration:
+          type: string
+          format: date-time
+          nullable: true
         name:
           type: string
         version:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api-build",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "NUL Digital Collections API Build Environment",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/src/api/response/opensearch/index.js
+++ b/src/api/response/opensearch/index.js
@@ -1,17 +1,17 @@
 const { appInfo } = require("../../../environment");
 const { transformError } = require("../error");
 
-async function transform(response, pager) {
+async function transform(response, options = {}) {
   if (response.statusCode === 200) {
     const responseBody = JSON.parse(response.body);
     return await (responseBody?.hits?.hits
-      ? transformMany(responseBody, pager)
-      : transformOne(responseBody));
+      ? transformMany(responseBody, options)
+      : transformOne(responseBody, options));
   }
   return transformError(response);
 }
 
-async function transformOne(responseBody) {
+async function transformOne(responseBody, options = {}) {
   return {
     statusCode: 200,
     headers: {
@@ -19,12 +19,12 @@ async function transformOne(responseBody) {
     },
     body: JSON.stringify({
       data: responseBody._source,
-      info: appInfo(),
+      info: appInfo(options),
     }),
   };
 }
 
-async function transformMany(responseBody, pager) {
+async function transformMany(responseBody, options) {
   return {
     statusCode: 200,
     headers: {
@@ -32,7 +32,7 @@ async function transformMany(responseBody, pager) {
     },
     body: JSON.stringify({
       data: extractSource(responseBody.hits.hits),
-      pagination: await paginationInfo(responseBody, pager),
+      pagination: await paginationInfo(responseBody, options?.pager),
       info: appInfo(),
       aggregations: responseBody.aggregations,
     }),

--- a/src/api/response/transformer.js
+++ b/src/api/response/transformer.js
@@ -11,7 +11,7 @@ async function transformSearchResult(response, pager) {
       return await iiifCollectionResponse.transform(response, pager);
     }
 
-    return await opensearchResponse.transform(response, pager);
+    return await opensearchResponse.transform(response, { pager: pager });
   }
   return transformError(response);
 }

--- a/src/environment.js
+++ b/src/environment.js
@@ -1,3 +1,4 @@
+const exp = require("constants");
 const fs = require("fs");
 const jwt = require("jsonwebtoken");
 const path = require("path");
@@ -22,11 +23,12 @@ function apiTokenSecret() {
   return process.env.API_TOKEN_SECRET;
 }
 
-function appInfo() {
+function appInfo(options = {}) {
   return {
     name: PackageInfo.name,
     description: PackageInfo.description,
     version: PackageInfo.version,
+    link_expiration: options.expires || null,
   };
 }
 

--- a/src/handlers/get-shared-link-by-id.js
+++ b/src/handlers/get-shared-link-by-id.js
@@ -21,10 +21,10 @@ exports.handler = wrap(async (event) => {
   });
   if (workResponse.statusCode !== 200) return invalidRequest("Not Found");
 
-  // add entitlement for the work id
-  // TODO make part of request/response processing
   event.userToken.addEntitlement(workId);
-  return await opensearchResponse.transform(workResponse);
+  return await opensearchResponse.transform(workResponse, {
+    expires: expirationDate,
+  });
 });
 
 const invalidRequest = (message) => {

--- a/src/package.json
+++ b/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "NUL Digital Collections API",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/test/unit/api/response/opensearch.test.js
+++ b/test/unit/api/response/opensearch.test.js
@@ -22,7 +22,7 @@ describe("OpenSearch response transformer", () => {
       statusCode: 200,
       body: helpers.testFixture("mocks/work-1234.json"),
     };
-    const result = await transformer.transform(response, pager);
+    const result = await transformer.transform(response, { pager: pager });
     expect(result.statusCode).to.eq(200);
 
     const body = JSON.parse(result.body);
@@ -36,7 +36,7 @@ describe("OpenSearch response transformer", () => {
       statusCode: 200,
       body: helpers.testFixture("mocks/search.json"),
     };
-    const result = await transformer.transform(response, pager);
+    const result = await transformer.transform(response, { pager: pager });
     expect(result.statusCode).to.eq(200);
 
     const body = JSON.parse(result.body);
@@ -60,7 +60,7 @@ describe("OpenSearch response transformer", () => {
       body: helpers.testFixture("mocks/missing-index.json"),
     };
 
-    const result = await transformer.transform(response, pager);
+    const result = await transformer.transform(response, { pager: pager });
     expect(result.statusCode).to.eq(404);
 
     const body = JSON.parse(result.body);


### PR DESCRIPTION
- Adds`link_expiration` to API response in the `info` section.
- If it is a `shared-links/id` request, populate `link_expiration` with the shared link expiration, otherwise it's `null`