### PR TITLE
Adds work/id/authorization route

### DIFF
--- a/src/handlers/authorize-document.js
+++ b/src/handlers/authorize-document.js
@@ -1,0 +1,49 @@
+/**
+ * Authorizes a Document (Collection, FileSet or Work) by id
+ */
+const authorizeDocument = (event, osResponse) => {
+  if (osResponse.statusCode != 200) {
+    return sendResponse(osResponse.statusCode);
+  }
+
+  const body = JSON.parse(osResponse.body);
+  const document = body._source;
+
+  const token = event.userToken;
+
+  const visibility = document.visibility;
+  const published = document.published;
+  const readingRoom = token.isReadingRoom();
+  const workId = document.work_id || document.id;
+
+  if (token.isSuperUser()) {
+    return sendResponse(204);
+  } else if (token.hasEntitlement(workId)) {
+    return sendResponse(204);
+  } else if (isAllowedVisibility(token, visibility, readingRoom) && published) {
+    return sendResponse(204);
+  } else {
+    return sendResponse(403);
+  }
+};
+
+function sendResponse(statusCode) {
+  return {
+    statusCode: statusCode,
+  };
+}
+
+function isAllowedVisibility(token, visibility, readingRoom) {
+  switch (visibility) {
+    case "Public":
+      return true;
+    case "Institution":
+      return token.isLoggedIn() || readingRoom;
+    case "Private":
+      return readingRoom;
+    default:
+      return false;
+  }
+}
+
+module.exports = { authorizeDocument };

--- a/src/handlers/get-file-set-auth.js
+++ b/src/handlers/get-file-set-auth.js
@@ -1,4 +1,5 @@
 const { getFileSet } = require("../api/opensearch");
+const { authorizeDocument } = require("./authorize-document");
 const { wrap } = require("./middleware");
 
 const OPEN_DOCUMENT_NAMESPACE = /^0{8}-0{4}-0{4}-0{4}-0{9}[0-9A-Fa-f]{3}/;
@@ -11,53 +12,15 @@ exports.handler = wrap(async (event) => {
 
   // Special namespace for entities that aren't actual entities
   // with indexed metadata (i.e., placeholder images)
-  if (OPEN_DOCUMENT_NAMESPACE.test(id)) return sendResponse(204);
+  if (OPEN_DOCUMENT_NAMESPACE.test(id))
+    return {
+      statusCode: 204,
+    };
 
   const osResponse = await getFileSet(id, {
     allowPrivate: true,
     allowUnpublished: true,
   });
 
-  if (osResponse.statusCode != 200) {
-    return sendResponse(osResponse.statusCode);
-  }
-
-  const body = JSON.parse(osResponse.body);
-  const fileSet = body._source;
-
-  const token = event.userToken;
-
-  const visibility = fileSet.visibility;
-  const published = fileSet.published;
-  const readingRoom = token.isReadingRoom();
-  const workId = fileSet.work_id;
-
-  if (token.isSuperUser()) {
-    return sendResponse(204);
-  } else if (token.hasEntitlement(workId)) {
-    return sendResponse(204);
-  } else if (isAllowedVisibility(token, visibility, readingRoom) && published) {
-    return sendResponse(204);
-  } else {
-    return sendResponse(403);
-  }
+  return authorizeDocument(event, osResponse);
 });
-
-function sendResponse(statusCode) {
-  return {
-    statusCode: statusCode,
-  };
-}
-
-function isAllowedVisibility(token, visibility, readingRoom) {
-  switch (visibility) {
-    case "Public":
-      return true;
-    case "Institution":
-      return token.isLoggedIn() || readingRoom;
-    case "Private":
-      return readingRoom;
-    default:
-      return false;
-  }
-}

--- a/src/handlers/get-work-auth.js
+++ b/src/handlers/get-work-auth.js
@@ -1,0 +1,17 @@
+const { getWork } = require("../api/opensearch");
+const { authorizeDocument } = require("./authorize-document");
+const { wrap } = require("./middleware");
+
+/**
+ * Authorizes a Work by id
+ */
+exports.handler = wrap(async (event) => {
+  const id = event.pathParameters.id;
+
+  const osResponse = await getWork(id, {
+    allowPrivate: true,
+    allowUnpublished: true,
+  });
+
+  return authorizeDocument(event, osResponse);
+});

--- a/template.yaml
+++ b/template.yaml
@@ -254,6 +254,35 @@ Resources:
             ApiId: !Ref dcApi
             Path: /file-sets/{id}/authorization
             Method: HEAD
+  getWorkAuthFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: handlers/get-work-auth.handler
+      Description: Authorizes access to a work.
+      Environment:
+        Variables:
+          USE_PROXIED_IP: true
+      Policies:
+        Version: 2012-10-17
+        Statement:
+          - Sid: ESHTTPPolicy
+            Effect: Allow
+            Action:
+              - es:ESHttp*
+            Resource: "*"
+      Events:
+        ApiGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /works/{id}/authorization
+            Method: GET
+        ApiHead:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /works/{id}/authorization
+            Method: HEAD
   getWorkByIdFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/test/fixtures/mocks/work-netid-1234.json
+++ b/test/fixtures/mocks/work-netid-1234.json
@@ -1,0 +1,13 @@
+{
+  "_index": "dev-dc-v2-work",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "1234",
+    "api_model": "Work",
+    "visibility": "Institution",
+    "published": true
+  }
+}

--- a/test/fixtures/mocks/work-restricted-1234.json
+++ b/test/fixtures/mocks/work-restricted-1234.json
@@ -1,0 +1,13 @@
+{
+  "_index": "dev-dc-v2-work",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "1234",
+    "api_model": "Work",
+    "visibility": "Private",
+    "published": true
+  }
+}

--- a/test/fixtures/mocks/work-restricted-unpublished-1234.json
+++ b/test/fixtures/mocks/work-restricted-unpublished-1234.json
@@ -1,0 +1,13 @@
+{
+  "_index": "dev-dc-v2-work",
+  "_type": "_doc",
+  "_id": "756ea5b9-8ca1-4bd7-a70e-4b2082dd0440",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "756ea5b9-8ca1-4bd7-a70e-4b2082dd0440",
+    "api_model": "Work",
+    "visibility": "Private",
+    "published": false
+  }
+}

--- a/test/integration/get-work-auth.test.js
+++ b/test/integration/get-work-auth.test.js
@@ -1,0 +1,206 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+chai.use(require("chai-http"));
+
+const ApiToken = requireSource("api/api-token");
+
+describe("Authorize a work by id", () => {
+  helpers.saveEnvironment();
+  const mock = helpers.mockIndex();
+
+  beforeEach(() => {
+    process.env.API_TOKEN_SECRET = "abc123";
+    process.env.API_TOKEN_NAME = "dcapiTEST";
+  });
+
+  describe("GET /works/{id}/authorization", () => {
+    const { handler } = requireSource("handlers/get-work-auth");
+
+    it("authorizes a public, published work set with no token", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(204);
+    });
+
+    it("does not authorize a public, unpublished work even with a valid token", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/unpublished-work-1234.json"));
+
+      const token = new ApiToken().user({ uid: "abc123" }).sign();
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .headers({
+          Cookie: `${process.env.API_TOKEN_NAME}=${token}`,
+        })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(403);
+    });
+
+    it("authorizes a netid, published work with a valid token", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-netid-1234.json"));
+
+      const token = new ApiToken().user({ uid: "abc123" }).sign();
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .headers({
+          Cookie: `${process.env.API_TOKEN_NAME}=${token}`,
+        })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(204);
+    });
+
+    it("does not authorize a netid, published work with no token", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-netid-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(403);
+    });
+
+    it("does authorize a netid, published work with no token if the user is in the reading room", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-netid-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .render();
+
+      process.env.READING_ROOM_IPS = event.requestContext.http.sourceIp;
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(204);
+    });
+
+    it("authorizes a restricted work if the user is in a Reading Room", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-restricted-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .render();
+      process.env.READING_ROOM_IPS = event.requestContext.http.sourceIp;
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(204);
+    });
+
+    it("does not authorize a restricted, unpublished work if the user is in a Reading Room", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-restricted-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .render();
+      process.env.READING_ROOM_IPS = event.requestContext.http.sourceIp;
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(204);
+    });
+
+    it("authorizes a netId work if the request has a superuser token", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-netid-1234.json"));
+
+      const token = new ApiToken().superUser().sign();
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .headers({
+          Cookie: `${process.env.API_TOKEN_NAME}=${token};`,
+        })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(204);
+    });
+
+    it("authorizes a restricted unpublished work if the request has a superuser token", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/work-restricted-unpublished-1234.json")
+        );
+
+      const token = new ApiToken().superUser().sign();
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .headers({
+          Cookie: `${process.env.API_TOKEN_NAME}=${token};`,
+        })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(204);
+    });
+
+    it("authorizes a restricted unpublished work if the token has an entitlement for a work id", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/work-restricted-unpublished-1234.json")
+        );
+
+      const token = new ApiToken()
+        .addEntitlement("756ea5b9-8ca1-4bd7-a70e-4b2082dd0440")
+        .sign();
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/authorization")
+        .pathParams({ id: 1234 })
+        .headers({
+          Cookie: `${process.env.API_TOKEN_NAME}=${token};`,
+        })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(204);
+    });
+
+    it("404s a missing work", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/missing-work-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}")
+        .pathParams({ id: 1234 })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(404);
+    });
+  });
+});


### PR DESCRIPTION
- Adds work/id/authorization route, which returns http status codes as follows: 
  - public, published work set with no token -> `204`
  - public, unpublished work with a valid token -> `403`
  - netid, published work with a valid token -> `204`
  - netid, published work with no token -> `403`
  - netid, published work with no token if the user is in the reading room -> `204`
  - restricted work if the user is in a Reading Room -> `204`
  - restricted, unpublished work if the user is in a Reading Room -> `403`
  - netId work if the request has a superuser token -> `204`
  - restricted unpublished work if the request has a superuser token -> `204`
  - restricted unpublished work if the token has an entitlement for a work id -> `204`
  - missing work -> `404`