### PR TITLE
Implement SuperUser access across the board

### DIFF
--- a/src/api/request/pipeline.js
+++ b/src/api/request/pipeline.js
@@ -5,9 +5,12 @@ function filterFor(query, event) {
   const beUnpublished = { term: { published: false } };
   const beRestricted = { term: { visibility: "Private" } };
 
-  const filter = event.userToken.isReadingRoom()
-    ? { must: [matchTheQuery], must_not: [beUnpublished] }
-    : { must: [matchTheQuery], must_not: [beUnpublished, beRestricted] };
+  let filter = { must: [matchTheQuery] };
+  if (!event.userToken.isSuperUser()) {
+    filter.must_not = event.userToken.isReadingRoom()
+      ? [beUnpublished]
+      : [beUnpublished, beRestricted];
+  }
 
   return { bool: filter };
 }

--- a/src/handlers/get-collection-by-id.js
+++ b/src/handlers/get-collection-by-id.js
@@ -8,8 +8,11 @@ const getOpts = (event) => {
   const id = event.pathParameters.id;
 
   const allowPrivate =
-    event.userToken.isReadingRoom() || event.userToken.hasEntitlement(id);
-  const allowUnpublished = event.userToken.hasEntitlement(id);
+    event.userToken.isSuperUser() ||
+    event.userToken.isReadingRoom() ||
+    event.userToken.hasEntitlement(id);
+  const allowUnpublished =
+    event.userToken.isSuperUser() || event.userToken.hasEntitlement(id);
   return { allowPrivate, allowUnpublished };
 };
 

--- a/src/handlers/get-file-set-by-id.js
+++ b/src/handlers/get-file-set-by-id.js
@@ -7,7 +7,9 @@ const opensearchResponse = require("../api/response/opensearch");
  */
 exports.handler = wrap(async (event) => {
   const id = event.pathParameters.id;
-  const allowPrivate = event.userToken.isReadingRoom();
-  const esResponse = await getFileSet(id, { allowPrivate });
+  const allowPrivate =
+    event.userToken.isSuperUser() || event.userToken.isReadingRoom();
+  const allowUnpublished = event.userToken.isSuperUser();
+  const esResponse = await getFileSet(id, { allowPrivate, allowUnpublished });
   return await opensearchResponse.transform(esResponse);
 });

--- a/src/handlers/get-thumbnail.js
+++ b/src/handlers/get-thumbnail.js
@@ -31,7 +31,8 @@ function validateRequest(event) {
 }
 
 const getThumbnail = async (id, aspect, size, event) => {
-  const allowUnpublished = event.userToken.hasEntitlement(id);
+  const allowUnpublished =
+    event.userToken.isSuperUser() || event.userToken.hasEntitlement(id);
   const allowPrivate = allowUnpublished || event.userToken.isReadingRoom();
 
   let esResponse;

--- a/src/handlers/get-work-by-id.js
+++ b/src/handlers/get-work-by-id.js
@@ -10,8 +10,11 @@ exports.handler = wrap(async (event) => {
   const id = event.pathParameters.id;
 
   const allowPrivate =
-    event.userToken.isReadingRoom() || event.userToken.hasEntitlement(id);
-  const allowUnpublished = event.userToken.hasEntitlement(id);
+    event.userToken.isSuperUser() ||
+    event.userToken.isReadingRoom() ||
+    event.userToken.hasEntitlement(id);
+  const allowUnpublished =
+    event.userToken.isSuperUser() || event.userToken.hasEntitlement(id);
 
   const esResponse = await getWork(id, { allowPrivate, allowUnpublished });
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -91,8 +91,14 @@ function decodeEventBody(event) {
   return event;
 }
 
+function getEventToken(event) {
+  const bearerRe = /^Bearer (?<token>.+)$/;
+  const result = bearerRe.exec(event.headers.authorization);
+  return result?.groups?.token || event.cookieObject[apiTokenName()];
+}
+
 function decodeToken(event) {
-  const existingToken = event.cookieObject[apiTokenName()];
+  const existingToken = getEventToken(event);
 
   try {
     event.userToken = new ApiToken(existingToken);

--- a/test/fixtures/mocks/unpublished-work-1234.json
+++ b/test/fixtures/mocks/unpublished-work-1234.json
@@ -8,6 +8,10 @@
     "id": "1234",
     "api_model": "Work",
     "published": false,
-    "visibility": "Public"
+    "visibility": "Public",
+    "representative_file_set": {
+      "fileSetId": "5678",
+      "url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/5678"
+    }
   }
 }

--- a/test/integration/get-doc.test.js
+++ b/test/integration/get-doc.test.js
@@ -4,6 +4,8 @@ const chai = require("chai");
 const expect = chai.expect;
 chai.use(require("chai-http"));
 
+const ApiToken = requireSource("api/api-token");
+
 describe("Doc retrieval routes", () => {
   helpers.saveEnvironment();
   const mock = helpers.mockIndex();
@@ -109,6 +111,23 @@ describe("Doc retrieval routes", () => {
       expect(resultBody.data.api_model).to.eq("Collection");
       expect(resultBody.data.id).to.eq("1234");
     });
+
+    it("403s a private collection", async () => {
+      const event = helpers
+        .mockEvent("GET", "/collections/{id}")
+        .pathParams({ id: 1234 })
+        .render();
+
+      mock
+        .get("/dc-v2-collection/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/collection-1234-private-published.json")
+        );
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(403);
+    });
   });
 
   describe("GET /file-sets/{id}", () => {
@@ -133,6 +152,111 @@ describe("Doc retrieval routes", () => {
       const resultBody = JSON.parse(result.body);
       expect(resultBody.data.api_model).to.eq("FileSet");
       expect(resultBody.data.id).to.eq("1234");
+    });
+
+    it("403s a private file-set", async () => {
+      const event = helpers
+        .mockEvent("GET", "/file-sets/{id}")
+        .pathParams({ id: 1234 })
+        .render();
+
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/fileset-restricted-1234.json"));
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(403);
+    });
+  });
+
+  describe("Superuser", () => {
+    helpers.saveEnvironment();
+    let event;
+    let token;
+
+    beforeEach(() => {
+      process.env.API_TOKEN_SECRET = "abcdef";
+      token = new ApiToken().superUser().sign();
+    });
+
+    describe("works", () => {
+      const { handler } = requireSource("handlers/get-work-by-id");
+
+      beforeEach(() => {
+        event = helpers
+          .mockEvent("GET", "/works/{id}")
+          .headers({
+            authorization: `Bearer ${token}`,
+          })
+          .pathParams({ id: 1234 })
+          .render();
+      });
+
+      it("returns an unpublished work", async () => {
+        mock
+          .get("/dc-v2-work/_doc/1234")
+          .reply(200, helpers.testFixture("mocks/unpublished-work-1234.json"));
+
+        const result = await handler(event);
+        expect(result.statusCode).to.eq(200);
+      });
+
+      it("returns a private work", async () => {
+        mock
+          .get("/dc-v2-work/_doc/1234")
+          .reply(200, helpers.testFixture("mocks/private-work-1234.json"));
+
+        const result = await handler(event);
+        expect(result.statusCode).to.eq(200);
+      });
+    });
+
+    describe("collections", () => {
+      const { handler } = requireSource("handlers/get-collection-by-id");
+
+      it("returns a private collection", async () => {
+        const event = helpers
+          .mockEvent("GET", "/collections/{id}")
+          .headers({
+            authorization: `Bearer ${token}`,
+          })
+          .pathParams({ id: 1234 })
+          .render();
+
+        mock
+          .get("/dc-v2-collection/_doc/1234")
+          .reply(
+            200,
+            helpers.testFixture("mocks/collection-1234-private-published.json")
+          );
+
+        const result = await handler(event);
+        expect(result.statusCode).to.eq(200);
+      });
+    });
+
+    describe("file sets", () => {
+      const { handler } = requireSource("handlers/get-file-set-by-id");
+
+      it("returns a private file-set", async () => {
+        const event = helpers
+          .mockEvent("GET", "/file-sets/{id}")
+          .headers({
+            authorization: `Bearer ${token}`,
+          })
+          .pathParams({ id: 1234 })
+          .render();
+
+        mock
+          .get("/dc-v2-file-set/_doc/1234")
+          .reply(
+            200,
+            helpers.testFixture("mocks/fileset-restricted-1234.json")
+          );
+
+        const result = await handler(event);
+        expect(result.statusCode).to.eq(200);
+      });
     });
   });
 });


### PR DESCRIPTION
- Remove restrictive filters from searches for superuser
- Allow all document access for superuser
- Allow all thumbnail access for superuser
- Add bearer token auth