### PR TITLE
Collection handle /similar endpoint

### DIFF
--- a/src/api/response/iiif/collection.js
+++ b/src/api/response/iiif/collection.js
@@ -102,11 +102,19 @@ function homepageUrl(pageInfo) {
     result = new URL(`/collections/${collectionId}`, dcUrl());
   } else {
     result = new URL("/search", dcUrl());
-    if (pageInfo.options?.queryStringParameters?.query)
+    if (pageInfo.options?.queryStringParameters?.query) {
       result.searchParams.set(
         "q",
         pageInfo.options.queryStringParameters.query
       );
+    }
+
+    if (pageInfo.query_url.includes("similar")) {
+      // Grab the work id from the query_url and add it to the search params
+      const regex = /works\/(.*)\/similar/;
+      const found = pageInfo.query_url.match(regex);
+      result.searchParams.set("similar", found[1]);
+    }
   }
 
   return result;

--- a/test/unit/api/response/iiif/collection.test.js
+++ b/test/unit/api/response/iiif/collection.test.js
@@ -54,4 +54,31 @@ describe("IIIF Collection response transformer", () => {
     expect(body.status).to.eq(404);
     expect(body.error).to.be.a("string");
   });
+
+  it("handles a request including /similar route", async () => {
+    let pagerWorkSimilar = new Paginator(
+      "http://dcapi.library.northwestern.edu/api/v2/",
+      "works/1234/similar",
+      ["works"],
+      { query: { query_string: { query: "genre.label:architecture" } } },
+      "iiif",
+      {
+        includeToken: false,
+        queryStringParameters: {
+          collectionLabel: "The collection label",
+          collectionSummary: "The collection Summary",
+        },
+      }
+    );
+
+    const response = {
+      statusCode: 200,
+      body: helpers.testFixture("mocks/search.json"),
+    };
+    const result = await transformer.transform(response, pagerWorkSimilar);
+    expect(result.statusCode).to.eq(200);
+
+    const body = JSON.parse(result.body);
+    expect(body.homepage[0].id).to.contain("search?similar=1234");
+  });
 });


### PR DESCRIPTION
## What does this do?
Updates the IIIF `homepageUrl()` creator function to generate a URL which includes a `?similar=` query param.  DC's Search page will recognize this `similar` param and build it's Search `query` object to include similar Works from the index.

A url like this:

`https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/f2e42c77-b7da-4632-bd87-5a65bf096afb/similar?collectionLabel=More Like This&collectionSummary=Similar%20to%20v1-indexing-test-work&as=iiif`

Should return something like this in the IIIF Manifest:

```js
{
  ...
  homepage: {
    id: "https://dcapi.rdc-staging.library.northwestern.edu/search?similar=f2e42c77-b7da-4632-bd87-5a65bf096afb",
    ...
  }
}
```

