### PR TITLE
Provide HLS format for Sound annotations.

### DIFF
--- a/src/api/response/iiif/presentation-api/items.js
+++ b/src/api/response/iiif/presentation-api/items.js
@@ -42,8 +42,8 @@ function buildImageService(representativeImageUrl) {
   ];
 }
 
-function isAudioVideo(workType) {
-  return ["Audio", "Video"].includes(workType);
+function isAudioVideo(type) {
+  return ["Audio", "Video", "Sound"].includes(type);
 }
 
 function isImage(workType) {

--- a/test/unit/api/response/iiif/presentation-api/items.test.js
+++ b/test/unit/api/response/iiif/presentation-api/items.test.js
@@ -94,6 +94,7 @@ describe("IIIF response presentation API items helpers", () => {
   it("isAudioVideo(workType)", () => {
     expect(items.isAudioVideo("Audio")).to.be.true;
     expect(items.isAudioVideo("Image")).to.be.false;
+    expect(items.isAudioVideo("Sound")).to.be.true;
     expect(items.isAudioVideo("Video")).to.be.true;
   });
 


### PR DESCRIPTION
This addresses a small issue and sets an HLS mime type for the access filesets and their Canvas annotation `body` on Audio work Manifests. Previously lines 12-14 were only being applied to Video filesets.

https://github.com/nulib/dc-api-v2/blob/de632cf2db60648004c8ea75910609f8afe85cdc/src/api/response/iiif/presentation-api/items.js#L9-L17