### PR TITLE
Update manifest to include logo and provider properties

### DIFF
--- a/src/api/response/iiif/manifest.js
+++ b/src/api/response/iiif/manifest.js
@@ -15,6 +15,7 @@ const {
 function transform(response) {
   if (response.statusCode === 200) {
     const builder = new IIIFBuilder();
+
     const openSearchResponse = JSON.parse(response.body);
     const source = openSearchResponse._source;
 
@@ -198,10 +199,6 @@ function transform(response) {
           ]);
         }
 
-        /** Add logo */
-
-        /** Add provider */
-
         /** Add items (Canvases) from a Work's Filesets */
         source.file_sets
           .filter((fileSet) => fileSet.role === "Access")
@@ -258,6 +255,38 @@ function transform(response) {
         }
       }
     }
+
+    /** Add logo manually (w/o IIIF Builder) */
+    const nulLogo = {
+      id: "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp",
+      type: "Image",
+      format: "image/webp",
+      height: 139,
+      width: 1190,
+    };
+    jsonManifest.logo = [nulLogo];
+
+    /** Add provider manually (w/o IIIF Builder) */
+    const provider = {
+      id: "https://www.library.northwestern.edu/",
+      type: "Agent",
+      label: { none: ["Northwestern University Libraries"] },
+      homepage: [
+        {
+          id: "https://dc.library.northwestern.edu/",
+          type: "Text",
+          label: {
+            none: [
+              "Northwestern University Libraries Digital Collections Homepage",
+            ],
+          },
+          format: "text/html",
+          language: ["en"],
+        },
+      ],
+      logo: [nulLogo],
+    };
+    jsonManifest.provider = [provider];
 
     return {
       statusCode: 200,

--- a/test/unit/api/response/iiif/manifest.test.js
+++ b/test/unit/api/response/iiif/manifest.test.js
@@ -103,6 +103,36 @@ describe("Image Work as IIIF Manifest response transformer", () => {
     expect(partOf.summary.none).to.be.an("array").that.is.not.empty;
   });
 
+  it("populates Manifest logo", async () => {
+    const { manifest } = await setup();
+    const logo = manifest.logo[0];
+    expect(logo.id).to.eq(
+      "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp"
+    );
+  });
+
+  it("populates Manifest provider", async () => {
+    const { manifest } = await setup();
+    const provider = manifest.provider[0];
+    expect(provider.id).to.eq("https://www.library.northwestern.edu/");
+    expect(provider.label).to.deep.equal({
+      none: ["Northwestern University Libraries"],
+    });
+    expect(provider.homepage[0].id).to.eq(
+      "https://dc.library.northwestern.edu/"
+    );
+    expect(provider.homepage[0].label).to.deep.eq({
+      none: ["Northwestern University Libraries Digital Collections Homepage"],
+    });
+    expect(provider.logo[0]).to.deep.eq({
+      id: "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp",
+      type: "Image",
+      format: "image/webp",
+      height: 139,
+      width: 1190,
+    });
+  });
+
   it("populates Manifest items (canvases)", async () => {
     const { source, manifest } = await setup();
     expect(manifest.items.length).to.eq(3);


### PR DESCRIPTION
## What does this do?
Hard codes the IIIF properties `logo` and `provider` into manifests we deliver.  the `iiif-builder` helper package we use doesn't support these properties yet, so just to move this one along, hard coding.

<img width="893" alt="image" src="https://github.com/nulib/dc-api-v2/assets/3020266/c08f7f71-c366-4533-85d3-25a03b0719e4">

<img width="1239" alt="image" src="https://github.com/nulib/dc-api-v2/assets/3020266/468b34ab-51ad-4516-b992-5728e2d2cf2d">
