### PR TITLE
Refactors chat handler for easier configuration handling.

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -14,6 +14,7 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ci
       AWS_SECRET_ACCESS_KEY: ci
+      SKIP_WEAVIATE_SETUP: 'True' 
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ lerna-debug.log*
 
 ### Python ###
 .coverage
+htmlcov
 __pycache__/
 *.py[cod]
 *$py.class

--- a/chat/dependencies/requirements.txt
+++ b/chat/dependencies/requirements.txt
@@ -1,7 +1,6 @@
+boto3~=1.34.13
 langchain~=0.0.208
-nbformat~=5.9.0
 openai~=0.27.8
-pandas~=2.0.2
 pyjwt~=2.6.0
 python-dotenv~=1.0.0
 tiktoken~=0.4.0

--- a/chat/src/event_config.py
+++ b/chat/src/event_config.py
@@ -1,0 +1,216 @@
+import os
+import json
+
+from dataclasses import dataclass, field
+from langchain.chains.qa_with_sources import load_qa_with_sources_chain
+from langchain.prompts import PromptTemplate
+from setup import (
+    weaviate_client,
+    weaviate_vector_store,
+    openai_chat_client,
+)
+from typing import List
+from handlers.streaming_socket_callback_handler import StreamingSocketCallbackHandler
+from helpers.apitoken import ApiToken
+from helpers.prompts import document_template, prompt_template
+from websocket import Websocket
+
+
+CHAIN_TYPE = "stuff"
+DOCUMENT_VARIABLE_NAME = "context"
+INDEX_NAME = "DCWork"
+K_VALUE = 10
+MAX_K = 100
+TEMPERATURE = 0.2
+TEXT_KEY = "title"
+VERSION = "2023-07-01-preview"
+
+
+@dataclass
+class EventConfig:
+    """
+    The EventConfig class represents the configuration for an event.
+    Default values are set for the following properties which can be overridden in the payload message.
+    """
+
+    api_token: ApiToken = field(init=False)
+    attributes: List[str] = field(init=False)
+    azure_endpoint: str = field(init=False)
+    azure_resource_name: str = field(init=False)
+    debug_mode: bool = field(init=False)
+    deployment_name: str = field(init=False)
+    document_prompt: PromptTemplate = field(init=False)
+    event: dict = field(default_factory=dict)
+    index_name: str = field(init=False)
+    is_logged_in: bool = field(init=False)
+    k: int = field(init=False)
+    openai_api_version: str = field(init=False)
+    payload: dict = field(default_factory=dict)
+    prompt_text: str = field(init=False)
+    prompt: PromptTemplate = field(init=False)
+    question: str = field(init=False)
+    ref: str = field(init=False)
+    request_context: dict = field(init=False)
+    temperature: float = field(init=False)
+    socket: Websocket = field(init=False, default=None)
+    text_key: str = field(init=False)
+    
+    def __post_init__(self):
+        self.payload = json.loads(self.event.get("body", "{}"))
+        self.api_token = ApiToken(signed_token=self.payload.get("auth"))
+        self.attributes = self._get_attributes()
+        self.azure_endpoint = self._get_azure_endpoint()
+        self.azure_resource_name = self._get_azure_resource_name()
+        self.azure_endpoint = self._get_azure_endpoint()
+        self.debug_mode = self._is_debug_mode_enabled()
+        self.deployment_name = self._get_deployment_name()
+        self.index_name = self._get_index_name()
+        self.is_logged_in = self.api_token.is_logged_in()
+        self.k = self._get_k()
+        self.openai_api_version = self._get_openai_api_version()
+        self.prompt_text = self._get_prompt_text()
+        self.request_context = self.event.get("requestContext", {})
+        self.question = self.payload.get("question")
+        self.ref = self.payload.get("ref")
+        self.temperature = self._get_temperature()
+        self.text_key = self._get_text_key()
+        self.attributes = self._get_attributes()
+        self.document_prompt = self._get_document_prompt()
+        self.prompt = PromptTemplate(template=self.prompt_text, input_variables=["question", "context"])
+
+    def _get_payload_value_with_superuser_check(self, key, default):
+        if self.api_token.is_superuser():
+            return self.payload.get(key, default)
+        else:
+            return default
+
+    def _get_azure_endpoint(self):
+        default = f"https://{self._get_azure_resource_name()}.openai.azure.com/"
+        return self._get_payload_value_with_superuser_check("azure_endpoint", default)
+
+    def _get_azure_resource_name(self):
+        azure_resource_name = self._get_payload_value_with_superuser_check("azure_resource_name", os.environ.get("AZURE_OPENAI_RESOURCE_NAME"))
+        if not azure_resource_name:
+            raise EnvironmentError(
+                "Either payload must contain 'azure_resource_name' or environment variable 'AZURE_OPENAI_RESOURCE_NAME' must be set"
+            )
+        return azure_resource_name
+    
+    def _get_deployment_name(self):
+        return self._get_payload_value_with_superuser_check("deployment_name", os.getenv("AZURE_OPENAI_LLM_DEPLOYMENT_ID"))
+    
+    def _get_index_name(self):
+        return self._get_payload_value_with_superuser_check("index", INDEX_NAME)
+
+    def _get_k(self):
+        value = self._get_payload_value_with_superuser_check("k", K_VALUE)
+        return min(value, MAX_K)
+
+    def _get_openai_api_version(self):
+        return self._get_payload_value_with_superuser_check("openai_api_version", VERSION)
+    
+    def _get_prompt_text(self):
+        return self._get_payload_value_with_superuser_check("prompt", prompt_template())
+    
+    def _get_temperature(self):
+        return self._get_payload_value_with_superuser_check("temperature", TEMPERATURE)
+
+    def _get_text_key(self):
+        return self._get_payload_value_with_superuser_check("text_key", TEXT_KEY)
+
+    def _get_attributes(self):
+        attributes = [
+            item
+            for item in self._get_request_attributes()
+            if item not in [self._get_text_key(), "source"]
+        ]
+        return attributes
+    
+    def _get_request_attributes(self):
+        if os.getenv("SKIP_WEAVIATE_SETUP"):
+            return []
+
+        attributes = self._get_payload_value_with_superuser_check("attributes", [])
+        if attributes:
+            return attributes
+        else:
+            client = weaviate_client()
+            schema = client.schema.get(self._get_index_name())
+            names = [prop["name"] for prop in schema.get("properties")]
+            return names
+
+    def _get_document_prompt(self):
+        return PromptTemplate(
+            template=document_template(self.attributes),
+            input_variables=["page_content", "source"] + self.attributes,
+        )
+
+    def debug_message(self):
+        return {
+            "type": "debug",
+            "message": {
+                "attributes": self.attributes,
+                "azure_endpoint": self.azure_endpoint,
+                "deployment_name": self.deployment_name,
+                "index": self.index_name,
+                "k": self.k,
+                "openai_api_version": self.openai_api_version,
+                "prompt": self.prompt_text,
+                "question": self.question,
+                "ref": self.ref,
+                "temperature": self.temperature,
+                "text_key": self.text_key,
+            },
+        }
+
+    def setup_websocket(self, socket=None):
+        if socket is None:
+            connection_id = self.request_context.get("connectionId")
+            endpoint_url = f'https://{self.request_context.get("domainName")}/{self.request_context.get("stage")}'
+            self.socket = Websocket(endpoint_url=endpoint_url, connection_id=connection_id, ref=self.ref)
+        else:
+            self.socket = socket
+        return self.socket
+
+    def setup_llm_request(self):
+        self._setup_vector_store()
+        self._setup_chat_client()
+        self._setup_chain()
+
+    def _setup_vector_store(self):
+        self.weaviate = weaviate_vector_store(
+            index_name=self.index_name,
+            text_key=self.text_key,
+            attributes=self.attributes + ["source"],
+        )
+
+    def _setup_chat_client(self):
+        self.client = openai_chat_client(
+            deployment_name=self.deployment_name,
+            openai_api_base=self.azure_endpoint,
+            openai_api_version=self.openai_api_version,
+            callbacks=[StreamingSocketCallbackHandler(self.socket, self.debug_mode)],
+            streaming=True,
+        )
+
+    def _setup_chain(self):
+        self.chain = load_qa_with_sources_chain(
+            self.client,
+            chain_type=CHAIN_TYPE,
+            prompt=self.prompt,
+            document_prompt=self.document_prompt,
+            document_variable_name=DOCUMENT_VARIABLE_NAME,
+            verbose=self._to_bool(os.getenv("VERBOSE")),
+        )
+
+    def _is_debug_mode_enabled(self):
+        debug = self.payload.get("debug", False)
+        return debug and self.api_token.is_superuser()
+
+    def _to_bool(self, val):
+        """Converts a value to boolean. If the value is a string, it considers
+        "", "no", "false", "0" as False. Otherwise, it returns the boolean of the value.
+        """
+        if isinstance(val, str):
+            return val.lower() not in ["", "no", "false", "0"]
+        return bool(val)

--- a/chat/src/handlers/chat.py
+++ b/chat/src/handlers/chat.py
@@ -1,170 +1,25 @@
-import boto3
-import json
 import os
-import setup
-import tiktoken
-from helpers.apitoken import ApiToken
-from helpers.prompts import document_template, prompt_template
-from langchain.callbacks.base import BaseCallbackHandler
-from langchain.chains.qa_with_sources import load_qa_with_sources_chain
-from langchain.prompts import PromptTemplate
-from openai.error import InvalidRequestError
-
-DEFAULT_INDEX = "DCWork"
-DEFAULT_KEY = "title"
-DEFAULT_K = 10
-MAX_K = 100
+from event_config import EventConfig
+from helpers.response import prepare_response
 
 
-class Websocket:
-    def __init__(self, endpoint_url, connection_id, ref):
-        self.client = boto3.client("apigatewaymanagementapi", endpoint_url=endpoint_url)
-        self.connection_id = connection_id
-        self.ref = ref
-
-    def send(self, data):
-        data["ref"] = self.ref
-        data_as_bytes = bytes(json.dumps(data), "utf-8")
-        self.client.post_to_connection(
-            Data=data_as_bytes, ConnectionId=self.connection_id
-        )
-
-
-class StreamingSocketCallbackHandler(BaseCallbackHandler):
-    def __init__(self, socket: Websocket, debug_mode: bool):
-        self.socket = socket
-        self.debug_mode = debug_mode
-
-    def on_llm_new_token(self, token: str, **kwargs):
-        if not self.debug_mode:
-            self.socket.send({"token": token})
-
-
-def handler(event, context):
+def handler(event, _context):
     try:
-        payload = json.loads(event.get("body", "{}"))
+        config = EventConfig(event)
+        socket = event.get('socket', None)
+        config.setup_websocket(socket)
 
-        request_context = event.get("requestContext", {})
-        connection_id = request_context.get("connectionId")
-        endpoint_url = f'https://{request_context.get("domainName")}/{request_context.get("stage")}'
-        ref = payload.get("ref")
-        socket = Websocket(
-            connection_id=connection_id, endpoint_url=endpoint_url, ref=ref
-        )
-
-        api_token = ApiToken(signed_token=payload.get("auth"))
-        if not api_token.is_logged_in():
-            socket.send({"statusCode": 401, "body": "Unauthorized"})
+        if not config.is_logged_in:
+            config.socket.send({"type": "error", "message": "Unauthorized"})
             return {"statusCode": 401, "body": "Unauthorized"}
+        
+        if config.debug_mode:
+            config.socket.send(config.debug_message())
 
-        debug_mode = payload.get("debug", False) and api_token.is_superuser()
-
-        question = payload.get("question")
-        index_name = payload.get("index", payload.get("index", DEFAULT_INDEX))
-        print(f"Searching index {index_name}")
-        text_key = payload.get("text_key", DEFAULT_KEY)
-        attributes = [
-            item
-            for item in get_attributes(
-                index_name, payload if api_token.is_superuser() else {}
-            )
-            if item not in [text_key, "source"]
-        ]
-
-        weaviate = setup.weaviate_vector_store(
-            index_name=index_name, text_key=text_key, attributes=attributes + ["source"]
-        )
-
-        client = setup.openai_chat_client(
-            callbacks=[StreamingSocketCallbackHandler(socket, debug_mode)],
-            streaming=True,
-        )
-
-        prompt_text = (
-            payload.get("prompt", prompt_template())
-            if api_token.is_superuser()
-            else prompt_template()
-        )
-        prompt = PromptTemplate(
-            template=prompt_text, input_variables=["question", "context"]
-        )
-
-        document_prompt = PromptTemplate(
-            template=document_template(attributes),
-            input_variables=["page_content", "source"] + attributes,
-        )
-
-        k = min(payload.get("k", DEFAULT_K), MAX_K)
-        docs = weaviate.similarity_search(question, k=k, additional="certainty")
-        chain = load_qa_with_sources_chain(
-            client,
-            chain_type="stuff",
-            prompt=prompt,
-            document_prompt=document_prompt,
-            document_variable_name="context",
-            verbose=to_bool(os.getenv("VERBOSE")),
-        )
-
-        try:
-            for doc in docs:
-                doc.metadata['full_text'] = ''
-            doc_response = [doc.__dict__ for doc in docs]
-            original_question = {"question": question, "source_documents": doc_response}
-            socket.send(original_question)
-            response = chain({"question": question, "input_documents": docs})
-            if debug_mode:
-                final_response = {
-                    "answer": response["output_text"],
-                    "attributes": attributes,
-                    "isSuperuser": api_token.is_superuser(),
-                    "prompt": prompt_text,
-                    "ref": ref,
-                    "k": k,
-                    "original_question": original_question,
-                    "token_counts": {
-                        "question": count_tokens(question),
-                        "answer": count_tokens(response["output_text"]),
-                        "prompt": count_tokens(prompt_text),
-                        "source_documents": count_tokens(doc_response),
-                    },
-                }
-            else:
-                final_response = {"answer": response["output_text"], "ref": ref}
-        except InvalidRequestError as err:
-            final_response = {
-                "question": question,
-                "error": str(err),
-                "source_documents": [],
-            }
-
-        socket.send(final_response)
+        if not os.getenv("SKIP_WEAVIATE_SETUP"):
+            config.setup_llm_request()
+            final_response = prepare_response(config)
+            config.socket.send(final_response)
         return {"statusCode": 200}
     except Exception as err:
-        print(event)
         raise err
-
-
-def get_attributes(index, payload):
-    request_attributes = payload.get("attributes", None)
-    if request_attributes is not None:
-        return request_attributes
-
-    client = setup.weaviate_client()
-    schema = client.schema.get(index)
-    names = [prop["name"] for prop in schema.get("properties")]
-    print(f"Retrieved attributes: {names}")
-    return names
-
-
-def count_tokens(val):
-    encoding = tiktoken.encoding_for_model("gpt-4")
-    token_integers = encoding.encode(str(val))
-    num_tokens = len(token_integers)
-
-    return num_tokens
-
-
-def to_bool(val):
-    if isinstance(val, str):
-        return val.lower() not in ["", "no", "false", "0"]
-    return bool(val)

--- a/chat/src/handlers/streaming_socket_callback_handler.py
+++ b/chat/src/handlers/streaming_socket_callback_handler.py
@@ -1,0 +1,11 @@
+from langchain.callbacks.base import BaseCallbackHandler
+from websocket import Websocket
+
+class StreamingSocketCallbackHandler(BaseCallbackHandler):
+    def __init__(self, socket: Websocket, debug_mode: bool):
+        self.socket = socket
+        self.debug_mode = debug_mode
+
+    def on_llm_new_token(self, token: str, **kwargs):
+        if self.socket and not self.debug_mode:
+            return self.socket.send({"token": token})

--- a/chat/src/helpers/apitoken.py
+++ b/chat/src/helpers/apitoken.py
@@ -2,30 +2,34 @@ from datetime import datetime
 import jwt
 import os
 
-class ApiToken:
-  @classmethod
-  def empty_token(cls):
-    time = int(datetime.now().timestamp())
-    return {
-      'iss': os.getenv('DC_API_ENDPOINT'),
-      'exp': datetime.fromtimestamp(time + 12 * 60 * 60).timestamp(), # 12 hours
-      'iat': time,
-      'entitlements': [],
-      'isLoggedIn': False,
-    }
-  
-  def __init__(self, signed_token=None):
-    if signed_token is None:
-      self.token = ApiToken.empty_token()
-    else:
-      try:
-        secret = os.getenv("API_TOKEN_SECRET")
-        self.token = jwt.decode(signed_token, secret, algorithms=["HS256"])
-      except Exception:
-        self.token = ApiToken.empty_token()
 
-  def is_logged_in(self):
-    return self.token.get("isLoggedIn", False)
-  
-  def is_superuser(self):
-    return self.token.get("isSuperUser", False)
+class ApiToken:
+    @classmethod
+    def empty_token(cls):
+        time = int(datetime.now().timestamp())
+        return {
+            "iss": os.getenv("DC_API_ENDPOINT"),
+            "exp": datetime.fromtimestamp(time + 12 * 60 * 60).timestamp(),  # 12 hours
+            "iat": time,
+            "entitlements": [],
+            "isLoggedIn": False,
+        }
+
+    def __init__(self, signed_token=None):
+        if signed_token is None:
+            self.token = ApiToken.empty_token()
+        else:
+            try:
+                secret = os.getenv("API_TOKEN_SECRET")
+                self.token = jwt.decode(signed_token, secret, algorithms=["HS256"])
+            except Exception:
+                self.token = ApiToken.empty_token()
+
+    def __str__(self):
+        return f"ApiToken(token={self.token})"
+
+    def is_logged_in(self):
+        return self.token.get("isLoggedIn", False)
+
+    def is_superuser(self):
+        return self.token.get("isSuperUser", False)

--- a/chat/src/helpers/metrics.py
+++ b/chat/src/helpers/metrics.py
@@ -1,0 +1,18 @@
+import tiktoken
+
+
+def token_usage(config, response, original_question):
+    return {
+        "question": count_tokens(config.question),
+        "answer": count_tokens(response["output_text"]),
+        "prompt": count_tokens(config.prompt_text),
+        "source_documents": count_tokens(original_question["source_documents"]),
+    }
+
+
+def count_tokens(val):
+    encoding = tiktoken.encoding_for_model("gpt-4")
+    token_integers = encoding.encode(str(val))
+    num_tokens = len(token_integers)
+
+    return num_tokens

--- a/chat/src/helpers/prompts.py
+++ b/chat/src/helpers/prompts.py
@@ -1,5 +1,7 @@
-# ruff: noqa: E501
-def prompt_template():
+from typing import List, Optional
+
+
+def prompt_template() -> str:
     return """Please answer the question based on the documents provided, and include some details about why the documents might be relevant to the particular question:
 
 Documents:
@@ -10,7 +12,9 @@ Question:
 """
 
 
-def document_template(attributes):
+def document_template(attributes: Optional[List[str]] = None) -> str:
+    if attributes is None:
+        attributes = []
     lines = (
         ["Content: {page_content}", "Metadata:"]
         + [f"  {attribute}: {{{attribute}}}" for attribute in attributes]

--- a/chat/src/helpers/response.py
+++ b/chat/src/helpers/response.py
@@ -1,0 +1,56 @@
+from helpers.metrics import token_usage
+from openai.error import InvalidRequestError
+
+
+def base_response(config, response):
+    return {"answer": response["output_text"], "ref": config.ref}
+
+
+def debug_response(config, response, original_question):
+    response_base = base_response(config, response)
+    debug_info = {
+        "attributes": config.attributes,
+        "azure_endpoint": config.azure_endpoint,
+        "deployment_name": config.deployment_name,
+        "index": config.index_name,
+        "is_superuser": config.api_token.is_superuser(),
+        "k": config.k,
+        "openai_api_version": config.openai_api_version,
+        "prompt": config.prompt_text,
+        "ref": config.ref,
+        "temperature": config.temperature,
+        "text_key": config.text_key,
+        "token_counts": token_usage(config, response, original_question),
+    }
+    return {**response_base, **debug_info}
+
+
+def get_and_send_original_question(config, docs):
+    doc_response = [doc.__dict__ for doc in docs]
+    original_question = {
+        "question": config.question,
+        "source_documents": doc_response,
+    }
+    config.socket.send(original_question)
+    return original_question
+
+
+def prepare_response(config):
+    try:
+        docs = config.weaviate.similarity_search(
+            config.question, k=config.k, additional="certainty"
+        )
+        original_question = get_and_send_original_question(config, docs)
+        response = config.chain({"question": config.question, "input_documents": docs})
+
+        if config.debug_mode:
+            prepared_response = debug_response(config, response, original_question)
+        else:
+            prepared_response = base_response(config, response)
+    except InvalidRequestError as err:
+        prepared_response = {
+            "question": config.question,
+            "error": str(err),
+            "source_documents": [],
+        }
+    return prepared_response

--- a/chat/src/helpers/utils.py
+++ b/chat/src/helpers/utils.py
@@ -1,0 +1,7 @@
+def to_bool(val):
+    """Converts a value to boolean. If the value is a string, it considers
+    "", "no", "false", "0" as False. Otherwise, it returns the boolean of the value.
+    """
+    if isinstance(val, str):
+        return val.lower() not in ["", "no", "false", "0"]
+    return bool(val)

--- a/chat/src/requirements.txt
+++ b/chat/src/requirements.txt
@@ -1,8 +1,7 @@
 # Runtime Dependencies
+boto3~=1.34.13
 langchain~=0.0.208
-nbformat~=5.9.0
 openai~=0.27.8
-pandas~=2.0.2
 pyjwt~=2.6.0
 python-dotenv~=1.0.0
 tiktoken~=0.4.0

--- a/chat/src/setup.py
+++ b/chat/src/setup.py
@@ -3,34 +3,57 @@ from langchain.vectorstores import Weaviate
 from typing import List
 import os
 import weaviate
+import boto3
+
 
 def openai_chat_client(**kwargs):
-  deployment = os.getenv("AZURE_OPENAI_LLM_DEPLOYMENT_ID")
-  key = os.getenv("AZURE_OPENAI_API_KEY")
-  resource = os.getenv("AZURE_OPENAI_RESOURCE_NAME")
-  version = "2023-07-01-preview"
+    return AzureChatOpenAI(
+        openai_api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+        **kwargs,
+    )
 
-  return AzureChatOpenAI(deployment_name=deployment, 
-                         openai_api_key=key, 
-                         openai_api_base=f"https://{resource}.openai.azure.com/",
-                         openai_api_version=version,
-                         **kwargs)
-                         
 
 def weaviate_client():
-  weaviate_url = os.environ['WEAVIATE_URL']
-  weaviate_api_key = os.environ['WEAVIATE_API_KEY']
-  auth_config = weaviate.AuthApiKey(api_key=weaviate_api_key)
+    if os.getenv("SKIP_WEAVIATE_SETUP"):
+        return None
+    
+    weaviate_url = os.environ.get("WEAVIATE_URL")
+    try:
+        if weaviate_url is None:
+            raise EnvironmentError(
+                "WEAVIATE_URL is not set in the environment variables"
+            )
 
-  return weaviate.Client(
-      url=weaviate_url,
-      auth_client_secret=auth_config
-  )
+        weaviate_api_key = os.environ.get("WEAVIATE_API_KEY")
+        if weaviate_api_key is None:
+            raise EnvironmentError(
+                "WEAVIATE_API_KEY is not set in the environment variables"
+            )
+
+        auth_config = weaviate.AuthApiKey(api_key=weaviate_api_key)
+
+        client = weaviate.Client(url=weaviate_url, auth_client_secret=auth_config)
+    except Exception as e:
+        print(f"An error occurred: {e}")
+        client = None
+    return client
+
 
 def weaviate_vector_store(index_name: str, text_key: str, attributes: List[str] = []):
-  client = weaviate_client()
+    if os.getenv("SKIP_WEAVIATE_SETUP"):
+        return None
+    
+    client = weaviate_client()
 
-  return Weaviate(client=client, 
-                  index_name=index_name, 
-                  text_key=text_key, 
-                  attributes=attributes)
+    return Weaviate(
+        client=client, index_name=index_name, text_key=text_key, attributes=attributes
+    )
+
+
+def websocket_client(endpoint_url: str):
+    endpoint_url = endpoint_url or os.getenv("APIGATEWAY_URL")
+    try:
+        client = boto3.client("apigatewaymanagementapi", endpoint_url=endpoint_url)
+        return client
+    except Exception as e:
+        raise e

--- a/chat/src/websocket.py
+++ b/chat/src/websocket.py
@@ -1,0 +1,16 @@
+import json
+from setup import websocket_client
+
+class Websocket:
+    def __init__(self, client=None, endpoint_url=None, connection_id=None, ref=None):
+        self.client = client or websocket_client(endpoint_url)
+        self.connection_id = connection_id
+        self.ref = ref if ref else {}
+
+    def send(self, data):
+        if isinstance(data, str):
+            data = {"message": data}
+        data["ref"] = self.ref
+        data_as_bytes = bytes(json.dumps(data), "utf-8")
+        self.client.post_to_connection(Data=data_as_bytes, ConnectionId=self.connection_id)
+        return data

--- a/chat/test/handlers/test_chat.py
+++ b/chat/test/handlers/test_chat.py
@@ -1,0 +1,74 @@
+# ruff: noqa: E402
+
+import json
+import os
+import sys
+
+sys.path.append('./src')
+
+from unittest import mock, TestCase
+from unittest.mock import patch
+from handlers.chat import handler
+from helpers.apitoken import ApiToken
+from websocket import Websocket
+from event_config import EventConfig
+
+class MockClient:
+    def __init__(self):
+        self.received_data = None
+
+    def post_to_connection(self, Data, ConnectionId):
+        self.received_data = Data
+        return Data
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "AZURE_OPENAI_RESOURCE_NAME": "test",
+    },
+)
+class TestHandler(TestCase):
+    def test_handler_unauthorized(self):        
+        event = {"socket": Websocket(client=MockClient(), endpoint_url="test", connection_id="test", ref="test")}
+        self.assertEqual(handler(event, {}), {'body': 'Unauthorized', 'statusCode': 401})
+      
+    @patch.object(ApiToken, 'is_logged_in')
+    def test_handler_success(self, mock_is_logged_in):
+      mock_is_logged_in.return_value = True
+      event = {"socket": Websocket(client=MockClient(), endpoint_url="test", connection_id="test", ref="test")}
+      self.assertEqual(handler(event, {}), {'statusCode': 200})
+    
+    @patch.object(ApiToken, 'is_logged_in')
+    @patch.object(ApiToken, 'is_superuser')
+    @patch.object(EventConfig, '_is_debug_mode_enabled')
+    def test_handler_debug_mode(self, mock_is_debug_enabled, mock_is_logged_in, mock_is_superuser):
+      mock_is_debug_enabled.return_value = True
+      mock_is_logged_in.return_value = True
+      mock_is_superuser.return_value = True
+      mock_client = MockClient()
+      mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
+      event = {"socket": mock_websocket, "debug": True}
+      handler(event, {})
+      response = json.loads(mock_client.received_data)
+      self.assertEqual(response["type"], "debug")
+      
+    @patch.object(ApiToken, 'is_logged_in')
+    @patch.object(ApiToken, 'is_superuser')
+    @patch.object(EventConfig, '_is_debug_mode_enabled')
+    def test_handler_debug_mode_for_superusers_only(self, mock_is_debug_enabled, mock_is_logged_in, mock_is_superuser):
+      mock_is_debug_enabled.return_value = True
+      mock_is_logged_in.return_value = True
+      mock_is_superuser.return_value = False
+      mock_client = MockClient()
+      mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
+      event = {"socket": mock_websocket, "debug": True}
+      handler(event, {})
+      response = json.loads(mock_client.received_data)
+      self.assertEqual(response["type"], "error")
+    
+    @patch.object(EventConfig, 'setup_websocket')
+    def test_error_handling(self, mock_event):
+      mock_event.side_effect = Exception("Some error occurred")
+      with self.assertRaises(Exception):
+        handler({}, {})

--- a/chat/test/handlers/test_streaming_socket_callback_handler.py
+++ b/chat/test/handlers/test_streaming_socket_callback_handler.py
@@ -1,0 +1,26 @@
+# ruff: noqa: E402
+import sys
+sys.path.append('./src')
+
+from unittest import TestCase
+from handlers.streaming_socket_callback_handler import (
+    StreamingSocketCallbackHandler,
+)
+from websocket import Websocket
+
+
+
+class MockClient:
+    def post_to_connection(self, Data, ConnectionId):
+        return Data
+
+class TestMyStreamingSocketCallbackHandler(TestCase):
+    def test_on_new_llm_token(self):
+        handler = StreamingSocketCallbackHandler(Websocket(client=MockClient()), False)
+        result = handler.on_llm_new_token(token="test")
+        self.assertEqual(result, {'token': 'test', 'ref': {}})
+        self.assertFalse(handler.debug_mode)
+
+    def test_debug_mode(self):
+        handler = StreamingSocketCallbackHandler(Websocket(client=MockClient()), debug_mode=True)
+        self.assertTrue(handler.debug_mode)

--- a/chat/test/helpers/test_apitoken.py
+++ b/chat/test/helpers/test_apitoken.py
@@ -1,30 +1,44 @@
+# ruff: noqa: E402
 import os
-from src.helpers.apitoken import ApiToken
+import sys
+sys.path.append('./src')
+
+from helpers.apitoken import ApiToken
 from test.fixtures.apitoken import SUPER_TOKEN, TEST_SECRET, TEST_TOKEN
 from unittest import mock, TestCase
 
-@mock.patch.dict(
-  os.environ, 
-  {
-    "API_TOKEN_SECRET": TEST_SECRET
-  }
-)
+
+
+
+@mock.patch.dict(os.environ, {"API_TOKEN_SECRET": TEST_SECRET})
 class TestFunction(TestCase):
-  def test_empty_token(self):
-    subject = ApiToken()
-    self.assertFalse(subject.is_logged_in())
+    def test_empty_token(self):
+        subject = ApiToken()
+        self.assertIsInstance(subject, ApiToken)
+        self.assertFalse(subject.is_logged_in())
 
-  def test_valid_token(self):
-    subject = ApiToken(TEST_TOKEN)
-    self.assertTrue(subject.is_logged_in())
-    self.assertFalse(subject.is_superuser())
+    def test_valid_token(self):
+        subject = ApiToken(TEST_TOKEN)
+        self.assertIsInstance(subject, ApiToken)
+        self.assertTrue(subject.is_logged_in())
+        self.assertFalse(subject.is_superuser())
 
-  def test_superuser_token(self):
-    subject = ApiToken(SUPER_TOKEN)
-    self.assertTrue(subject.is_logged_in())
-    self.assertTrue(subject.is_superuser())
+    def test_superuser_token(self):
+        subject = ApiToken(SUPER_TOKEN)
+        self.assertIsInstance(subject, ApiToken)
+        self.assertTrue(subject.is_logged_in())
+        self.assertTrue(subject.is_superuser())
 
-  def test_invalid_token(self):
-    subject = ApiToken("INVALID_TOKEN")
-    self.assertFalse(subject.is_logged_in())
-  
+    def test_invalid_token(self):
+        subject = ApiToken("INVALID_TOKEN")
+        self.assertIsInstance(subject, ApiToken)
+        self.assertFalse(subject.is_logged_in())
+
+    def test_empty_token_class_method(self):
+        empty_token = ApiToken.empty_token()
+        self.assertIsInstance(empty_token, dict)
+        self.assertFalse(empty_token["isLoggedIn"])
+
+    def test_str_method(self):
+        subject = ApiToken(TEST_TOKEN)
+        self.assertEqual(str(subject), f"ApiToken(token={subject.token})")

--- a/chat/test/helpers/test_metrics.py
+++ b/chat/test/helpers/test_metrics.py
@@ -1,0 +1,64 @@
+# ruff: noqa: E402
+import json
+import os
+import sys
+sys.path.append('./src')
+
+from unittest import TestCase, mock
+from helpers.metrics import count_tokens, token_usage
+from event_config import EventConfig 
+
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "AZURE_OPENAI_RESOURCE_NAME": "test",
+        "WEAVIATE_URL": "http://test",
+        "WEAVIATE_API_KEY": "test"
+    },
+)
+class TestMetrics(TestCase):
+    def test_token_usage(self):
+        original_question = {
+            "question": "What is your name?",
+            "source_documents": [],
+        }
+        event = {
+            "body": json.dumps({
+                "deployment_name": "test",
+                "index": "test",
+                "k": 1,
+                "openai_api_version": "2019-05-06",
+                "prompt": "This is a test prompt.",
+                "question": original_question,
+                "ref": "test",
+                "temperature": 0.5,
+                "text_key": "text",
+                "auth": "test123"
+            })
+        }
+        config = EventConfig(event=event)
+
+        response = {
+            "output_text": "This is a test response.",
+        }
+
+        result = token_usage(config, response, original_question)
+
+        expected_result = {
+            "answer": 6,
+            "prompt": 36,
+            "question": 15,
+            "source_documents": 1,
+        }
+
+        self.assertEqual(result, expected_result)
+
+    def test_count_tokens(self):
+        val = "Hello, world!"
+        expected_result = 4
+
+        result = count_tokens(val)
+
+        self.assertEqual(result, expected_result)

--- a/chat/test/helpers/test_prompts.py
+++ b/chat/test/helpers/test_prompts.py
@@ -1,0 +1,33 @@
+# ruff: noqa: E402
+import sys
+sys.path.append('./src')
+
+from helpers.prompts import prompt_template, document_template
+from unittest import TestCase
+
+
+class TestPromptTemplate(TestCase):
+    def test_prompt_template(self):
+        prompt = prompt_template()
+        assert isinstance(prompt, str)
+        assert len(prompt) > 0
+
+
+class TestDocumentTemplate(TestCase):
+    def test_empty_attributes(self):
+        self.assertEqual(
+            document_template(),
+            "Content: {page_content}\nMetadata:\nSource: {source}",
+        )
+
+    def test_single_attribute(self):
+        self.assertEqual(
+            document_template(["title"]),
+            "Content: {page_content}\nMetadata:\n  title: {title}\nSource: {source}",
+        )
+
+    def test_multiple_attributes(self):
+        self.assertEqual(
+            document_template(["title", "author", "subject", "description"]),
+            "Content: {page_content}\nMetadata:\n  title: {title}\n  author: {author}\n  subject: {subject}\n  description: {description}\nSource: {source}",
+        )

--- a/chat/test/test_event_config.py
+++ b/chat/test/test_event_config.py
@@ -1,0 +1,112 @@
+# ruff: noqa: E402
+import json
+import os
+import sys
+sys.path.append('./src')
+
+from event_config import EventConfig
+from unittest import TestCase, mock
+
+
+class TestEventConfigWithoutAzureResource(TestCase):
+    def test_requires_an_azure_resource(self):
+        with self.assertRaises(EnvironmentError):
+            EventConfig()
+
+
+@mock.patch.dict(
+    os.environ,
+    {
+        "AZURE_OPENAI_RESOURCE_NAME": "test",
+    },
+)
+class TestEventConfig(TestCase):
+    def test_fetches_attributes_from_vector_database(self):
+        os.environ.pop("AZURE_OPENAI_RESOURCE_NAME", None)
+        with self.assertRaises(EnvironmentError):
+            EventConfig()
+
+    def test_defaults(self):
+        actual = EventConfig(event={"body": json.dumps({"attributes": ["title"]})})
+        expected_defaults = {"azure_endpoint": "https://test.openai.azure.com/"}
+        self.assertEqual(actual.azure_endpoint, expected_defaults["azure_endpoint"])
+
+    def test_attempt_override_without_superuser_status(self):
+        actual = EventConfig(
+            event={
+                "body": json.dumps(
+                    {
+                        "azure_resource_name": "new_name_for_test",
+                        "attributes": ["title", "subject", "date_created"],
+                        "index": "testIndex",
+                        "k": 100,
+                        "openai_api_version": "2024-01-01",
+                        "question": "test question",
+                        "ref": "test ref",
+                        "temperature": 0.9,
+                        "text_key": "accession_number",
+                    }
+                )
+            }
+        )
+        expected_output = {
+            "attributes": [],
+            "azure_endpoint": "https://test.openai.azure.com/",
+            "index_name": "DCWork",
+            "k": 10,
+            "openai_api_version": "2023-07-01-preview",
+            "question": "test question",
+            "ref": "test ref",
+            "temperature": 0.2,
+            "text_key": "title",
+        }
+        self.assertEqual(actual.azure_endpoint, expected_output["azure_endpoint"])
+        self.assertEqual(actual.index_name, expected_output["index_name"])
+        self.assertEqual(actual.attributes, expected_output["attributes"])
+        self.assertEqual(actual.k, expected_output["k"])
+        self.assertEqual(
+            actual.openai_api_version, expected_output["openai_api_version"]
+        )
+        self.assertEqual(actual.question, expected_output["question"])
+        self.assertEqual(actual.ref, expected_output["ref"])
+        self.assertEqual(actual.temperature, expected_output["temperature"])
+        self.assertEqual(actual.text_key, expected_output["text_key"])
+
+    def test_text_key_removed_from_attributes_list(self):
+        actual = EventConfig(
+            event={
+                "body": json.dumps(
+                    {
+                        "attributes": ["title", "description"],
+                        "text_key": "description",
+                    }
+                )
+            }
+        )
+        self.assertNotIn(actual.text_key, actual.attributes)
+
+    def test_source_removed_from_attributes_list(self):
+        actual = EventConfig(event={"body": json.dumps({"attributes": ["source"]})})
+        self.assertNotIn("source", actual.attributes)
+
+    def test_debug_message(self):
+        self.assertEqual(
+            EventConfig(
+                event={"body": json.dumps({"attributes": ["source"]})}
+            ).debug_message()["type"],
+            "debug",
+        )
+    
+    def test_to_bool(self):
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool(""), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("0"), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("no"), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("false"), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("False"), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("FALSE"), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("no"), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("No"), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("NO"), False)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool("true"), True)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool(True), True)
+        self.assertEqual(EventConfig(event={"body": json.dumps({"attributes": ["source"]})})._to_bool(False), False)

--- a/chat/test/test_websocket.py
+++ b/chat/test/test_websocket.py
@@ -1,0 +1,18 @@
+# ruff: noqa: E402
+import sys
+sys.path.append('./src')
+
+from unittest import TestCase
+from websocket import Websocket
+
+
+class MockClient:
+    def post_to_connection(self, Data, ConnectionId):
+        return Data
+
+class TestWebsocket(TestCase):
+    def test_post_to_connection(self):
+        websocket = Websocket(client=MockClient(), connection_id="test_connection_id", ref="test_ref")
+        message = "test_message"
+        expected = {"message": "test_message", "ref": "test_ref"}
+        self.assertEqual(websocket.send(message), expected)


### PR DESCRIPTION
- Refactors chat prototype configuration allowing clients to override more attributes like the `deployment_name` and `version` in the event payload sent to the API. **Note:** this refactor should be backwards-compatible and the existing prototype behavior should continue working without any changes.
- Extracts functionality into files based on responsibility to make clearer code organization

Changes have already been deployed to the `prototype-dev` stack and can be tested in Postman.