### PR TITLE
Add AnnotationPage label to IIIF response

### DIFF
--- a/src/api/response/iiif/manifest.js
+++ b/src/api/response/iiif/manifest.js
@@ -72,6 +72,7 @@ function transform(response) {
               canvas.createAnnotationPage(
                 `${canvasId}/annotations/page/0`,
                 (annotationPageBuilder) => {
+                  annotationPageBuilder.addLabel("Chapters", "en");
                   annotationPageBuilder.createAnnotation(
                     buildSupplementingAnnotation({ canvasId, fileSet })
                   );

--- a/src/api/response/iiif/presentation-api/items.js
+++ b/src/api/response/iiif/presentation-api/items.js
@@ -51,9 +51,6 @@ function buildSupplementingAnnotation({ canvasId, fileSet }) {
       id: fileSet?.webvtt,
       type: "Text",
       format: "text/vtt",
-      label: {
-        en: ["Chapters"],
-      },
       language: "none",
     },
     target: canvasId,

--- a/test/unit/api/response/iiif/manifest.test.js
+++ b/test/unit/api/response/iiif/manifest.test.js
@@ -268,6 +268,12 @@ describe("A/V Work as IIIF Manifest response transformer", () => {
     expect(annotation.body.format).to.eq("application/x-mpegurl");
     expect(annotation.body.id).to.eq(source.file_sets[0].streaming_url);
   });
+
+  it("renders a label for AnnotationPage with default value", async () => {
+    const { manifest } = await setup();
+    const annotationPageLabel = manifest.items[1].annotations[0].label["en"][0];
+    expect(annotationPageLabel).to.eq("Chapters");
+  });
 });
 
 describe("404 network response", () => {

--- a/test/unit/api/response/iiif/presentation-api/items.test.js
+++ b/test/unit/api/response/iiif/presentation-api/items.test.js
@@ -104,7 +104,6 @@ describe("IIIF response presentation API items helpers", () => {
     expect(annotation.body.id).to.eq(accessImage.webvtt);
     expect(annotation.body.type).to.eq("Text");
     expect(annotation.body.format).to.eq("text/vtt");
-    expect(annotation.body.label.en[0]).to.eq("Chapters");
     expect(annotation.body.language).to.eq("none");
     expect(annotation.target).to.eq(canvasId);
   });


### PR DESCRIPTION
## What does this do?

To support recent Clover `Viewer` Annotations work, we need to move the "Chapters" default `label` to `AnnotationPage` in our IIIF manifests, from previous `Annotation` `body` location.

## How to test?
A IIIF response for a Work containing a VTT Fileset should look like:

![image](https://github.com/nulib/dc-api-v2/assets/3020266/33cb9f51-cb47-4353-8839-f0d0028baae6)
