### PR TITLE
Query string parameters pass through goto redirects on login

### DIFF
--- a/node/src/handlers/get-auth-login.js
+++ b/node/src/handlers/get-auth-login.js
@@ -3,7 +3,6 @@ const axios = require("axios").default;
 const cookie = require("cookie");
 const { wrap } = require("./middleware");
 const Honeybadger = require("../honeybadger-setup");
-const url = require("url");
 
 /**
  * Performs NUSSO login
@@ -19,12 +18,7 @@ exports.handler = wrap(async (event) => {
     };
   }
 
-  const parsedUrl = url.parse(returnPath, true);
-  const mergedQueryParams = { ...event.queryStringParameters };
-  delete mergedQueryParams.goto;
-  parsedUrl.search = null;
-  parsedUrl.query = { ...parsedUrl.query, ...mergedQueryParams };
-  returnPath = url.format(parsedUrl);
+  returnPath = encodeURIComponent(returnPath);
 
   try {
     const response = await axios.get(nussoUrl, {

--- a/node/test/integration/get-auth-login.test.js
+++ b/node/test/integration/get-auth-login.test.js
@@ -3,6 +3,7 @@
 const chai = require("chai");
 const expect = chai.expect;
 const nock = require("nock");
+const url = require("url");
 
 const getAuthLoginHandler = requireSource("handlers/get-auth-login");
 
@@ -13,6 +14,8 @@ describe("auth login", function () {
     process.env.NUSSO_BASE_URL = "https://nusso-base.com/";
     process.env.NUSSO_API_KEY = "abc123";
 
+    const gotoUrl = "https://test-goto.com";
+
     nock(process.env.NUSSO_BASE_URL)
       .get("/get-ldap-redirect-url")
       .reply(200, {
@@ -21,10 +24,24 @@ describe("auth login", function () {
 
     const event = helpers
       .mockEvent("GET", "/auth/login")
-      .queryParams({ goto: "https://test-goto.com" })
+      .queryParams({
+        goto: gotoUrl,
+        q: "baseball",
+        subject: "College+students",
+        ai: true,
+      })
       .render();
 
     const result = await getAuthLoginHandler.handler(event);
     expect(result.statusCode).to.eq(302);
+
+    const cookie = result.cookies[0];
+    const [cookieName, encodedString] = cookie.split("=");
+    expect(cookieName).to.eq("redirectUrl");
+    const decoded = Buffer.from(encodedString, "base64").toString("utf8");
+    const parsed = url.parse(decoded, true);
+    expect(parsed.query.q).to.eq("baseball");
+    expect(parsed.query.subject).to.eq("College+students");
+    expect(parsed.query.ai).to.eq("true");
   });
 });

--- a/node/test/integration/get-auth-login.test.js
+++ b/node/test/integration/get-auth-login.test.js
@@ -3,7 +3,6 @@
 const chai = require("chai");
 const expect = chai.expect;
 const nock = require("nock");
-const url = require("url");
 
 const getAuthLoginHandler = requireSource("handlers/get-auth-login");
 
@@ -14,7 +13,7 @@ describe("auth login", function () {
     process.env.NUSSO_BASE_URL = "https://nusso-base.com/";
     process.env.NUSSO_API_KEY = "abc123";
 
-    const gotoUrl = "https://test-goto.com";
+    const gotoUrl = "https://test-goto.com/api/search?=College+sports?ai=true";
 
     nock(process.env.NUSSO_BASE_URL)
       .get("/get-ldap-redirect-url")
@@ -26,9 +25,6 @@ describe("auth login", function () {
       .mockEvent("GET", "/auth/login")
       .queryParams({
         goto: gotoUrl,
-        q: "baseball",
-        subject: "College+students",
-        ai: true,
       })
       .render();
 
@@ -39,9 +35,8 @@ describe("auth login", function () {
     const [cookieName, encodedString] = cookie.split("=");
     expect(cookieName).to.eq("redirectUrl");
     const decoded = Buffer.from(encodedString, "base64").toString("utf8");
-    const parsed = url.parse(decoded, true);
-    expect(parsed.query.q).to.eq("baseball");
-    expect(parsed.query.subject).to.eq("College+students");
-    expect(parsed.query.ai).to.eq("true");
+    expect(decoded).to.eq(
+      "https%3A%2F%2Ftest-goto.com%2Fapi%2Fsearch%3F%3DCollege%2Bsports%3Fai%3Dtrue"
+    );
   });
 });


### PR DESCRIPTION
## Description

This change passes query string parameters through to `goto` redirects during the user auth process. This allows the front end to pass in a parameter such as `ai=true`, which will now get carried through the redirect.