### PR TITLE
Send chat handler metrics to a dedicated CloudWatch Logs group

### DIFF
--- a/chat/dependencies/requirements.txt
+++ b/chat/dependencies/requirements.txt
@@ -1,5 +1,5 @@
 boto3~=1.34.13
-langchain~=0.1.8
+langchain
 langchain-community
 openai~=0.27.8
 opensearch-py

--- a/chat/src/helpers/metrics.py
+++ b/chat/src/helpers/metrics.py
@@ -2,12 +2,14 @@ import tiktoken
 
 
 def token_usage(config, response, original_question):
-    return {
+    data = {
         "question": count_tokens(config.question),
         "answer": count_tokens(response["output_text"]),
         "prompt": count_tokens(config.prompt_text),
         "source_documents": count_tokens(original_question["source_documents"]),
     }
+    data["total"] = sum(data.values())
+    return data
 
 
 def count_tokens(val):

--- a/chat/src/helpers/response.py
+++ b/chat/src/helpers/response.py
@@ -1,13 +1,9 @@
 from helpers.metrics import token_usage
 from openai.error import InvalidRequestError
 
-def base_response(config, response):
-    return {"answer": response["output_text"], "ref": config.ref}
-
-
 def debug_response(config, response, original_question):
-    response_base = base_response(config, response)
-    debug_info = {
+    return {
+        "answer": response["output_text"],
         "attributes": config.attributes,
         "azure_endpoint": config.azure_endpoint,
         "deployment_name": config.deployment_name,
@@ -15,13 +11,12 @@ def debug_response(config, response, original_question):
         "k": config.k,
         "openai_api_version": config.openai_api_version,
         "prompt": config.prompt_text,
+        "question": config.question,
         "ref": config.ref,
         "temperature": config.temperature,
         "text_key": config.text_key,
         "token_counts": token_usage(config, response, original_question),
     }
-    return {**response_base, **debug_info}
-
 
 def get_and_send_original_question(config, docs):
     doc_response = []
@@ -55,10 +50,7 @@ def prepare_response(config):
         original_question = get_and_send_original_question(config, docs)
         response = config.chain({"question": config.question, "input_documents": docs})
 
-        if config.debug_mode:
-            prepared_response = debug_response(config, response, original_question)
-        else:
-            prepared_response = base_response(config, response)
+        prepared_response = debug_response(config, response, original_question)
     except InvalidRequestError as err:
         prepared_response = {
             "question": config.question,

--- a/chat/src/requirements.txt
+++ b/chat/src/requirements.txt
@@ -1,6 +1,6 @@
 # Runtime Dependencies
 boto3~=1.34.13
-langchain~=0.1.8
+langchain
 langchain-community
 openai~=0.27.8
 opensearch-py

--- a/chat/template.yaml
+++ b/chat/template.yaml
@@ -203,6 +203,7 @@ Resources:
           AZURE_OPENAI_LLM_DEPLOYMENT_ID: !Ref AzureOpenaiLlmDeploymentId
           AZURE_OPENAI_RESOURCE_NAME: !Ref AzureOpenaiResourceName
           ENV_PREFIX: !Ref EnvironmentPrefix
+          METRICS_LOG_GROUP: !Ref ChatMetricsLog
           OPENSEARCH_ENDPOINT: !Ref OpenSearchEndpoint
           OPENSEARCH_MODEL_ID: !Ref OpenSearchModelId
       Policies:
@@ -218,8 +219,20 @@ Resources:
           - 'es:ESHttpGet'
           - 'es:ESHttpPost'
           Resource: '*'
+      - Statement:
+        - Effect: Allow
+          Action:
+          - logs:CreateLogStream
+          - logs:PutLogEvents
+          Resource: !Sub "${ChatMetricsLog.Arn}:*"
     Metadata:
       BuildMethod: nodejs18.x
+  ChatMetricsLog:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/nul/${AWS::StackName}/ChatFunction-Metrics"
+      LogGroupClass: STANDARD
+      RetentionInDays: 90
   Deployment:
     Type: AWS::ApiGatewayV2::Deployment
     DependsOn:

--- a/chat/test/handlers/test_chat.py
+++ b/chat/test/handlers/test_chat.py
@@ -23,6 +23,9 @@ class MockClient:
         self.received_data = Data
         return Data
 
+class MockContext:
+   def __init__(self):
+      self.log_stream_name = 'test'
 
 @mock.patch.dict(
     os.environ,
@@ -33,13 +36,13 @@ class MockClient:
 class TestHandler(TestCase):
     def test_handler_unauthorized(self):        
         event = {"socket": Websocket(client=MockClient(), endpoint_url="test", connection_id="test", ref="test")}
-        self.assertEqual(handler(event, {}), {'body': 'Unauthorized', 'statusCode': 401})
+        self.assertEqual(handler(event, MockContext()), {'body': 'Unauthorized', 'statusCode': 401})
       
     @patch.object(ApiToken, 'is_logged_in')
     def test_handler_success(self, mock_is_logged_in):
       mock_is_logged_in.return_value = True
       event = {"socket": Websocket(client=MockClient(), endpoint_url="test", connection_id="test", ref="test")}
-      self.assertEqual(handler(event, {}), {'statusCode': 200})
+      self.assertEqual(handler(event, MockContext()), {'statusCode': 200})
     
     @patch.object(ApiToken, 'is_logged_in')
     @patch.object(ApiToken, 'is_superuser')
@@ -51,7 +54,7 @@ class TestHandler(TestCase):
       mock_client = MockClient()
       mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
       event = {"socket": mock_websocket, "debug": True}
-      handler(event, {})
+      handler(event, MockContext())
       response = json.loads(mock_client.received_data)
       self.assertEqual(response["type"], "debug")
       
@@ -65,7 +68,7 @@ class TestHandler(TestCase):
       mock_client = MockClient()
       mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
       event = {"socket": mock_websocket, "debug": True}
-      handler(event, {})
+      handler(event, MockContext())
       response = json.loads(mock_client.received_data)
       self.assertEqual(response["type"], "error")
     

--- a/chat/test/helpers/test_metrics.py
+++ b/chat/test/helpers/test_metrics.py
@@ -51,6 +51,7 @@ class TestMetrics(TestCase):
             "prompt": 328,
             "question": 15,
             "source_documents": 1,
+            "total": 350
         }
 
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
## Steps to test:
1. Log in to staging with `aws sso login`
1. From the `chat` directory, deploy the `4641-chat-metrics` branch to a CloudFormation stack: `sam build && sam deploy --config-file samconfig.toml --stack-name dc-api-kdid-chat`
1. Grab the websocket URL from the output of `sam deploy`
1. Use `Postman` to generate a few requests against your deployed CloudFormation stack
1. Check AWS Cloudwatch for the dedicated metrics log at `/nul/dc-api-kdid-chat/ChatFunction-Metrics`