### PR TITLE
Updates hybrid search query to match against all_titles using the 'and' operator and the 'english' stopword analyzer

### DIFF
--- a/chat/src/helpers/response.py
+++ b/chat/src/helpers/response.py
@@ -48,7 +48,15 @@ def extract_prompt_value(v):
     
 def prepare_response(config):
     try:
-        subquery = {"match": {"all_text": {"query": config.question}}}
+        subquery = { 
+            "match": {
+                "all_titles":  {
+                    "query": config.question, 
+                    "operator": "AND",
+                    "analyzer": "english"
+                }
+            }
+        }
         docs = config.opensearch.similarity_search(
             query=config.question, k=config.k, subquery=subquery, _source={"excludes": ["embedding"]}
         )


### PR DESCRIPTION
The new subquery that goes alongside the neural search query uses the `AND` operator and the `english` stopword analyzer:

```js
{
  "match": {
    "all_titles":  {
      "query": config.question,
      "operator": "AND",
      "analyzer": "english"
    }
  }
}
```