### PR TITLE
Remove download_url from work documentation

### DIFF
--- a/docs/docs/spec/data-types.yaml
+++ b/docs/docs/spec/data-types.yaml
@@ -501,9 +501,6 @@ components:
         embedding_model:
           type: string
           description: The name of the inference model used to generate the `embedding` from the resource's content.
-        download_url:
-          type: string
-          nullable: true
         file_sets:
           type: array
           description: File sets associated with the resource.
@@ -766,7 +763,6 @@ components:
         - description
         - embedding
         - embedding_model
-        - download_url
         - file_sets
         - folder_name
         - folder_number

--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambdas",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Non-API handler lambdas",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/layers/api_dependencies/package.json
+++ b/layers/api_dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api-dependencies",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "NUL Digital Collections API Dependencies",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api-build",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "NUL Digital Collections API Build Environment",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/node/src/package.json
+++ b/node/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "NUL Digital Collections API",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",


### PR DESCRIPTION
Shouldn't be there, noticed here: https://github.com/nulib/repodev_planning_and_docs/issues/4738#issuecomment-2112658487