### PR TITLE
Name downloaded pdf file download.pdf

### DIFF
--- a/node/src/handlers/get-file-set-download.js
+++ b/node/src/handlers/get-file-set-download.js
@@ -112,9 +112,9 @@ async function getDownloadLink(doc) {
   const getObjectParams = {
     Bucket: bucket,
     Key: key,
-    ResponseContentDisposition: `attachment; filename=${
-      doc._source.label
-    }.${mime.extension(doc._source.mime_type)}`,
+    ResponseContentDisposition: `attachment; filename=download.${mime.extension(
+      doc._source.mime_type
+    )}`,
   };
 
   const client = new S3Client(clientParams);


### PR DESCRIPTION
- Using the label with various characters for the filename when creating the presigned url is causing problems for some browsers. Change the downloaded filename to just `download` + .extension.