### PR TITLE
Refactor auth filter to use temporary search pipeline

### DIFF
--- a/lambdas/package-lock.json
+++ b/lambdas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambdas",
-  "version": "2.2.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "lambdas",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-sdk/client-mediaconvert": "^3.410.0",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-api-build",
-  "version": "2.2.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-api-build",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -17,6 +17,7 @@
         "chai": "^4.2.0",
         "chai-http": "^4.3.0",
         "choma": "^1.2.1",
+        "deep-equal-in-any-order": "^2.0.6",
         "eslint": "^8.32.0",
         "eslint-plugin-json": "^3.1.0",
         "husky": "^8.0.3",
@@ -4956,6 +4957,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/deep-equal-in-any-order": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-2.0.6.tgz",
+      "integrity": "sha512-RfnWHQzph10YrUjvWwhd15Dne8ciSJcZ3U6OD7owPwiVwsdE5IFSoZGg8rlwJD11ES+9H5y8j3fCofviRHOqLQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash.mapvalues": "^4.6.0",
+        "sort-any": "^2.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -6539,6 +6550,12 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true
     },
+    "node_modules/lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -7819,6 +7836,15 @@
         "node": ">=0.3.1"
       }
     },
+    "node_modules/sort-any": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-2.0.0.tgz",
+      "integrity": "sha512-T9JoiDewQEmWcnmPn/s9h/PH9t3d/LSWi0RgVmXSuDYeZXTZOZ1/wrK2PHaptuR1VXe3clLLt0pD6sgVOwjNEA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
     "node_modules/sort-json": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/sort-json/-/sort-json-2.0.1.tgz",
@@ -8484,7 +8510,7 @@
     },
     "src": {
       "name": "dc-api",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-crypto/sha256-browser": "^2.0.1",
@@ -12914,6 +12940,16 @@
         "type-detect": "^4.0.0"
       }
     },
+    "deep-equal-in-any-order": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-2.0.6.tgz",
+      "integrity": "sha512-RfnWHQzph10YrUjvWwhd15Dne8ciSJcZ3U6OD7owPwiVwsdE5IFSoZGg8rlwJD11ES+9H5y8j3fCofviRHOqLQ==",
+      "dev": true,
+      "requires": {
+        "lodash.mapvalues": "^4.6.0",
+        "sort-any": "^2.0.0"
+      }
+    },
     "deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -14072,6 +14108,12 @@
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
       "dev": true
     },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha512-JPFqXFeZQ7BfS00H58kClY7SPVeHertPE0lNuCyZ26/XlN8TvakYD7b9bGyNmXbT/D3BbtPAAmq90gPWqLkxlQ==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -15015,6 +15057,15 @@
           "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
           "dev": true
         }
+      }
+    },
+    "sort-any": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-2.0.0.tgz",
+      "integrity": "sha512-T9JoiDewQEmWcnmPn/s9h/PH9t3d/LSWi0RgVmXSuDYeZXTZOZ1/wrK2PHaptuR1VXe3clLLt0pD6sgVOwjNEA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21"
       }
     },
     "sort-json": {

--- a/node/package.json
+++ b/node/package.json
@@ -22,6 +22,7 @@
     "chai": "^4.2.0",
     "chai-http": "^4.3.0",
     "choma": "^1.2.1",
+    "deep-equal-in-any-order": "^2.0.6",
     "eslint": "^8.32.0",
     "eslint-plugin-json": "^3.1.0",
     "husky": "^8.0.3",

--- a/node/src/package-lock.json
+++ b/node/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-api",
-  "version": "2.2.0",
+  "version": "2.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-api",
-      "version": "2.2.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-crypto/sha256-browser": "^2.0.1",

--- a/node/test/unit/api/request/pipeline.test.js
+++ b/node/test/unit/api/request/pipeline.test.js
@@ -1,15 +1,24 @@
 "use strict";
 
 const chai = require("chai");
+const deepEqualInAnyOrder = require("deep-equal-in-any-order");
 const expect = chai.expect;
 
 const ApiToken = requireSource("api/api-token");
 const RequestPipeline = requireSource("api/request/pipeline");
 
+chai.use(deepEqualInAnyOrder);
+
+const findFilterQuery = (searchContext) => {
+  if (!searchContext.search_pipeline?.request_processors) return null;
+  const filter = searchContext.search_pipeline.request_processors.find(
+    (processor) => processor?.filter_query?.tag == "access_filter"
+  );
+  return filter?.filter_query?.query?.bool;
+};
+
 describe("RequestPipeline", () => {
   helpers.saveEnvironment();
-
-  let event = helpers.mockEvent("GET", "/search").render();
 
   const requestBody = {
     query: { match: { term: { title: "The Title" } } },
@@ -20,8 +29,9 @@ describe("RequestPipeline", () => {
     aggs: { collection: { terms: { field: "contributor.label", size: 10 } } },
   };
 
-  let pipeline;
+  let event, pipeline;
   beforeEach(() => {
+    event = helpers.mockEvent("GET", "/search").render();
     pipeline = new RequestPipeline(requestBody);
   });
 
@@ -30,11 +40,13 @@ describe("RequestPipeline", () => {
 
     const result = pipeline.authFilter(helpers.preprocess(event));
     expect(result.searchContext.size).to.eq(50);
-    expect(result.searchContext.query.bool.must).to.include(requestBody.query);
-    expect(result.searchContext.query.bool.must_not).to.deep.include(
-      { term: { visibility: "Private" } },
-      { term: { published: false } }
-    );
+    expect(result.searchContext.query).to.eq(requestBody.query);
+    expect(findFilterQuery(result.searchContext)).to.deep.equalInAnyOrder({
+      must_not: [
+        { term: { visibility: "Private" } },
+        { term: { published: false } },
+      ],
+    });
   });
 
   it("serializes JSON", () => {
@@ -48,28 +60,23 @@ describe("RequestPipeline", () => {
       // process.env.READING_ROOM_IPS = "192.168.0.1,172.16.10.2";
       const result = pipeline.authFilter(helpers.preprocess(event));
       expect(result.searchContext.size).to.eq(50);
-      expect(result.searchContext.query.bool.must).to.include(
-        requestBody.query
-      );
-      expect(result.searchContext.query.bool.must_not).to.deep.include(
-        { term: { visibility: "Private" } },
-        { term: { published: false } }
-      );
+      expect(result.searchContext.query).to.eq(requestBody.query);
+      expect(findFilterQuery(result.searchContext)).to.deep.equalInAnyOrder({
+        must_not: [
+          { term: { visibility: "Private" } },
+          { term: { published: false } },
+        ],
+      });
     });
 
     it("includes private results if the user is in the reading room", () => {
+      event = helpers.preprocess(event);
       event.userToken = new ApiToken().readingRoom();
-
-      const result = pipeline.authFilter(helpers.preprocess(event));
+      const result = pipeline.authFilter(event);
       expect(result.searchContext.size).to.eq(50);
-      expect(result.searchContext.query.bool.must).to.include(
-        requestBody.query
-      );
-      expect(result.searchContext.query.bool.must_not).to.deep.include({
-        term: { published: false },
-      });
-      expect(result.searchContext.query.bool.must_not).not.to.deep.include({
-        term: { visibility: "Private" },
+      expect(result.searchContext.query).to.eq(requestBody.query);
+      expect(findFilterQuery(result.searchContext)).to.deep.equal({
+        must_not: [{ term: { published: false } }],
       });
     });
   });
@@ -81,24 +88,34 @@ describe("RequestPipeline", () => {
       // process.env.READING_ROOM_IPS = "192.168.0.1,172.16.10.2";
       const result = pipeline.authFilter(helpers.preprocess(event));
       expect(result.searchContext.size).to.eq(50);
-      expect(result.searchContext.query.bool.must).to.include(
-        requestBody.query
-      );
-      expect(result.searchContext.query.bool.must_not).to.deep.include(
-        { term: { visibility: "Private" } },
-        { term: { published: false } }
-      );
+      expect(result.searchContext.query).to.eq(requestBody.query);
+      expect(findFilterQuery(result.searchContext)).to.deep.equalInAnyOrder({
+        must_not: [
+          { term: { visibility: "Private" } },
+          { term: { published: false } },
+        ],
+      });
     });
 
     it("includes private results if the user is in the reading room", () => {
+      event = helpers.preprocess(event);
       event.userToken = new ApiToken().superUser();
 
-      const result = pipeline.authFilter(helpers.preprocess(event));
+      const result = pipeline.authFilter(event);
       expect(result.searchContext.size).to.eq(50);
-      expect(result.searchContext.query.bool.must).to.include(
-        requestBody.query
-      );
-      expect(result.searchContext.query.bool).not.to.have.any.keys("must_not");
+      expect(result.searchContext.query).to.eq(requestBody.query);
+      expect(findFilterQuery(result.searchContext)).to.be.null;
+    });
+  });
+
+  describe("search_pipeline in request", () => {
+    it("does not add a search filter when a pipeline is specified", () => {
+      event.queryStringParameters = {
+        ...event.queryStringParameters,
+        search_pipeline: "alternate-pipeline",
+      };
+      const result = pipeline.authFilter(helpers.preprocess(event));
+      expect(result.searchContext).not.to.have.keys("search_pipeline");
     });
   });
 });


### PR DESCRIPTION
Hybrid queries cannot be nested inside other queries (such as `bool` queries). Instead, we should use a search pipeline to add a `request_processors[].filter_query` processor to the query. Our `dc-v2-work-pipeline` already does this, limiting the search to published results with a visibility of public or institution. This PR updates the search preprocessor to respect the search pipeline (if provided), or to add one on the fly if not. This is safe to do in this context because:

- users can't create named search pipelines
- OpenSearch will error if a nonexistent search pipeline is specified

This PR also strips out any `search_pipeline` stanza included in the query DSL to prevent users from circumventing the built-in restrictions.

In the future, we may want to create multiple saved search pipelines to handle each of our four use cases (anonymous/institution search, superuser search, reading room search, and hybrid search) and simply update the `search_pipeline` query param on the way to OpenSearch. But this is our best option for now.

To test, run the API using `sam local start-api` and then use Postman to post some search requests.
- Use a superuser token to make sure you get private & unpublished results back
- Update your `READING_ROOM_IPS` server environment variable to match your own IP to make sure you get private, published works back

Remember that you may have to narrow your search or increase the `size` in the search DSL to make sure you're not just excluding private/unpublished due to a result size cutoff.