### PR TITLE
Make download image dimesnsions smaller

### DIFF
--- a/node/src/handlers/get-file-set-download.js
+++ b/node/src/handlers/get-file-set-download.js
@@ -136,7 +136,7 @@ const getAxiosResponse = (url, config) => {
 };
 
 const IIIFImageRequest = async (doc) => {
-  const dimensions = "/full/max/0/default.jpg";
+  const dimensions = "/full/!3000,3000/0/default.jpg";
   const iiifImageBaseUrl = doc._source.representative_image_url;
   const url = `${iiifImageBaseUrl}${dimensions}`;
   const { status, headers, data } = await getAxiosResponse(url, {


### PR DESCRIPTION
- Change dimensions to something we know should be under the 6MB limit, until we can implement a better solution.