### PR TITLE
Reject missing/empty questions

### DIFF
--- a/chat/src/handlers/chat.py
+++ b/chat/src/handlers/chat.py
@@ -24,6 +24,10 @@ def handler(event, context):
     if not config.is_logged_in:
         config.socket.send({"type": "error", "message": "Unauthorized"})
         return {"statusCode": 401, "body": "Unauthorized"}
+
+    if config.question is None or config.question == "":
+        config.socket.send({"type": "error", "message": "Question cannot be blank"})
+        return {"statusCode": 400, "body": "Question cannot be blank"}
     
     debug_message = config.debug_message()
     if config.debug_mode:

--- a/chat/test/handlers/test_chat.py
+++ b/chat/test/handlers/test_chat.py
@@ -35,11 +35,11 @@ class TestHandler(TestCase):
     def test_handler_unauthorized(self):        
         event = {"socket": Websocket(client=MockClient(), endpoint_url="test", connection_id="test", ref="test")}
         self.assertEqual(handler(event, MockContext()), {'body': 'Unauthorized', 'statusCode': 401})
-      
+    
     @patch.object(ApiToken, 'is_logged_in')
     def test_handler_success(self, mock_is_logged_in):
       mock_is_logged_in.return_value = True
-      event = {"socket": Websocket(client=MockClient(), endpoint_url="test", connection_id="test", ref="test")}
+      event = {"socket": Websocket(client=MockClient(), endpoint_url="test", connection_id="test", ref="test"), "body": '{"question": "Question?"}' }
       self.assertEqual(handler(event, MockContext()), {'statusCode': 200})
     
     @patch.object(ApiToken, 'is_logged_in')
@@ -51,7 +51,7 @@ class TestHandler(TestCase):
       mock_is_superuser.return_value = True
       mock_client = MockClient()
       mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
-      event = {"socket": mock_websocket, "debug": True}
+      event = {"socket": mock_websocket, "debug": True, "body": '{"question": "Question?"}' }
       handler(event, MockContext())
       response = json.loads(mock_client.received_data)
       self.assertEqual(response["type"], "debug")
@@ -65,7 +65,29 @@ class TestHandler(TestCase):
       mock_is_superuser.return_value = False
       mock_client = MockClient()
       mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
-      event = {"socket": mock_websocket, "debug": True}
+      event = {"socket": mock_websocket, "debug": True, "body": '{"question": "Question?"}' }
       handler(event, MockContext())
       response = json.loads(mock_client.received_data)
       self.assertEqual(response["type"], "error")
+
+    @patch.object(ApiToken, 'is_logged_in')
+    def test_handler_question_missing(self, mock_is_logged_in):
+        mock_is_logged_in.return_value = True
+        mock_client = MockClient()
+        mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
+        event = {"socket": mock_websocket}
+        handler(event, MockContext())
+        response = json.loads(mock_client.received_data)
+        self.assertEqual(response["type"], "error")
+        self.assertEqual(response["message"], "Question cannot be blank")
+
+    @patch.object(ApiToken, 'is_logged_in')
+    def test_handler_question_blank(self, mock_is_logged_in):
+        mock_is_logged_in.return_value = True
+        mock_client = MockClient()
+        mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
+        event = {"socket": mock_websocket, "body": '{"quesion": ""}'}
+        handler(event, MockContext())
+        response = json.loads(mock_client.received_data)
+        self.assertEqual(response["type"], "error")
+        self.assertEqual(response["message"], "Question cannot be blank")


### PR DESCRIPTION
Omitting the `question` field (or submitting an empty string) in the chat request payload generates an Opensearch parsing exception and a Honeybadger report.