### PR TITLE
Add ?as=iiif param to top level collections endpoint.

### DIFF
--- a/docs/docs/spec/openapi.yaml
+++ b/docs/docs/spec/openapi.yaml
@@ -35,6 +35,7 @@ paths:
       tags:
         - Collection
       parameters:
+        - $ref: "./types.yaml#/components/parameters/as"
         - $ref: "./types.yaml#/components/parameters/page"
         - $ref: "./types.yaml#/components/parameters/size"
         - $ref: "./types.yaml#/components/parameters/sort"

--- a/node/src/api/request/models.js
+++ b/node/src/api/request/models.js
@@ -12,7 +12,10 @@ function extractRequestedModels(requestedModels) {
 
 function validModels(models, format) {
   if (format === "iiif") {
-    return models.length == 1 && models.every((model) => model === "works");
+    return (
+      models.length == 1 &&
+      models.every((model) => model === "works" || "collections")
+    );
   }
   return models.every(isAllowed);
 }

--- a/node/src/api/response/iiif/manifest.js
+++ b/node/src/api/response/iiif/manifest.js
@@ -14,6 +14,7 @@ const { metadataLabelFields } = require("./presentation-api/metadata");
 const {
   buildPlaceholderCanvas,
 } = require("./presentation-api/placeholder-canvas");
+const { nulLogo, provider } = require("./presentation-api/provider");
 
 function transform(response) {
   if (response.statusCode === 200) {
@@ -260,37 +261,8 @@ function transform(response) {
       }
     }
 
-    /** Add logo manually (w/o IIIF Builder) */
-    const nulLogo = {
-      id: "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp",
-      type: "Image",
-      format: "image/webp",
-      height: 139,
-      width: 1190,
-    };
-    jsonManifest.logo = [nulLogo];
-
-    /** Add provider manually (w/o IIIF Builder) */
-    const provider = {
-      id: "https://www.library.northwestern.edu/",
-      type: "Agent",
-      label: { none: ["Northwestern University Libraries"] },
-      homepage: [
-        {
-          id: "https://dc.library.northwestern.edu/",
-          type: "Text",
-          label: {
-            none: [
-              "Northwestern University Libraries Digital Collections Homepage",
-            ],
-          },
-          format: "text/html",
-          language: ["en"],
-        },
-      ],
-      logo: [nulLogo],
-    };
     jsonManifest.provider = [provider];
+    jsonManifest.logo = [nulLogo];
 
     return {
       statusCode: 200,

--- a/node/src/api/response/iiif/presentation-api/provider.js
+++ b/node/src/api/response/iiif/presentation-api/provider.js
@@ -1,0 +1,29 @@
+const nulLogo = {
+  id: "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp",
+  type: "Image",
+  format: "image/webp",
+  height: 139,
+  width: 1190,
+};
+
+const provider = {
+  id: "https://www.library.northwestern.edu/",
+  type: "Agent",
+  label: { none: ["Northwestern University Libraries"] },
+  homepage: [
+    {
+      id: "https://dc.library.northwestern.edu/",
+      type: "Text",
+      label: {
+        none: [
+          "Northwestern University Libraries Digital Collections Homepage",
+        ],
+      },
+      format: "text/html",
+      language: ["en"],
+    },
+  ],
+  logo: [nulLogo],
+};
+
+module.exports = { nulLogo, provider };

--- a/node/src/handlers/get-collections.js
+++ b/node/src/handlers/get-collections.js
@@ -1,11 +1,31 @@
 const { doSearch } = require("./search-runner");
 const { wrap } = require("./middleware");
 
+const getCollections = async (event) => {
+  event.pathParameters.models = "collections";
+  event.body = { query: { match_all: {} } };
+  return doSearch(event, { includeToken: false });
+};
+
+const getCollectionsAsIiif = async (event) => {
+  event.pathParameters.models = "collections";
+  event.body = { query: { match_all: {} } };
+  event.queryStringParameters.collectionLabel =
+    "Northwestern University Libraries Digital Collections";
+  event.queryStringParameters.collectionSummary =
+    "Explore digital resources from the Northwestern University Library collections – including letters, photographs, diaries, maps, and audiovisual materials.";
+
+  return doSearch(event, {
+    includeToken: false,
+    parameterOverrides: { as: "iiif" },
+  });
+};
+
 /**
  * A simple function to get Collections
  */
 exports.handler = wrap(async (event) => {
-  event.pathParameters.models = "collections";
-  event.body = { query: { match_all: {} } };
-  return doSearch(event, { includeToken: false });
+  return event.queryStringParameters?.as === "iiif"
+    ? getCollectionsAsIiif(event)
+    : getCollections(event);
 });

--- a/node/test/integration/get-collections.test.js
+++ b/node/test/integration/get-collections.test.js
@@ -71,5 +71,31 @@ describe("Collections route", () => {
       const url = new URL(query_url);
       expect(url.pathname).to.eq("/api/v2/search/collections");
     });
+
+    it("returns top level collection as a IIIF collection", async () => {
+      mock
+        .post("/dc-v2-collection/_search", makeQuery({ size: 10, from: 0 }))
+        .reply(200, helpers.testFixture("mocks/collections.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/collections")
+        .queryParams({ as: "iiif" })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+      expect(result).to.have.header(
+        "content-type",
+        /application\/json;.*charset=UTF-8/
+      );
+      const resultBody = JSON.parse(result.body);
+      expect(resultBody.type).to.eq("Collection");
+      expect(resultBody.label.none[0]).to.eq(
+        "Northwestern University Libraries Digital Collections"
+      );
+      expect(resultBody.summary.none[0]).to.eq(
+        "Explore digital resources from the Northwestern University Library collections – including letters, photographs, diaries, maps, and audiovisual materials."
+      );
+      expect(resultBody.items.length).to.eq(69);
+    });
   });
 });

--- a/node/test/unit/api/response/iiif/presentation-api/provider.test.js
+++ b/node/test/unit/api/response/iiif/presentation-api/provider.test.js
@@ -1,0 +1,40 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+
+const { provider, nulLogo } = requireSource(
+  "api/response/iiif/presentation-api/provider"
+);
+
+describe("IIIF response presentation API provider and logo", () => {
+  it("outputs a IIIF provider property", async () => {
+    expect(provider.id).to.contain("https://www.library.northwestern.edu");
+    expect(provider.type).to.eq("Agent");
+    expect(provider.label.none[0]).to.eq("Northwestern University Libraries");
+    expect(provider.homepage[0].id).to.contain(
+      "https://dc.library.northwestern.edu"
+    );
+    expect(provider.homepage[0].label.none[0]).to.eq(
+      "Northwestern University Libraries Digital Collections Homepage"
+    );
+    expect(provider.logo).to.be.an("array");
+    expect(provider.logo[0].id).to.contain(
+      "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp"
+    );
+    expect(provider.logo[0].type).to.eq("Image");
+    expect(provider.logo[0].format).to.eq("image/webp");
+    expect(provider.logo[0].height).to.be.a("number");
+    expect(provider.logo[0].width).to.be.a("number");
+  });
+
+  it("outputs a IIIF logo property", async () => {
+    expect(nulLogo.id).to.contain(
+      "https://iiif.dc.library.northwestern.edu/iiif/2/00000000-0000-0000-0000-000000000003/full/pct:50/0/default.webp"
+    );
+    expect(nulLogo.type).to.eq("Image");
+    expect(nulLogo.format).to.eq("image/webp");
+    expect(nulLogo.height).to.be.a("number");
+    expect(nulLogo.width).to.be.a("number");
+  });
+});


### PR DESCRIPTION
This work adds a `?as=iiif` param to create a IIIF resource for the top level collection of collections. In the process, we have also extended out Presentation API properties across all collections.

To review, navigate to the your dev API endpoint, ex:
https://mat.dev.rdc.library.northwestern.edu:3002/collections?as=iiif

If you really wanna see these Collections in action, check it out in:
https://theseus-viewer.netlify.app/?iiif-content=https://mat.dev.rdc.library.northwestern.edu:3002/collections?as=iiif

- This _top_ collection should be a IIIF resource with the type `Collection` and have a list of Collections under `items`.
- `requiredStatement`, `seeAlso`, `provider`, `logo`, and `homepage` should be present in this collection
- Individual Collections should output as before, ex: https://mat.dev.rdc.library.northwestern.edu:3002/collections/3e38c22d-de6e-4827-9097-96d0da968746?as=iiif
- Search result Collections should output as before, ex: https://mat.dev.rdc.library.northwestern.edu:3002/search?as=iiif&collectionLabel=Pug&collectionSummary=1+result&query=pug

