### PR TITLE
Uses title instead of all_titles in chat's hybrid query

### DIFF
--- a/chat/src/helpers/hybrid_query.py
+++ b/chat/src/helpers/hybrid_query.py
@@ -20,7 +20,7 @@ def hybrid_query(query: str, model_id: str, vector_field: str = "embedding", k: 
                     filter({
                         "query_string": {
                             "default_operator": "AND",
-                            "fields": ["all_titles^5", "all_controlled_labels", "all_ids^5"], 
+                            "fields": ["title^5", "all_controlled_labels", "all_ids^5"], 
                             "query": query,
                             "analyzer": "english"
                         }


### PR DESCRIPTION
- Will be in sync with DC's hybrid query and `title` seems to be giving better results.