### PR TITLE
Tweak prompt for length and no relevant results found

### DIFF
--- a/chat/src/helpers/prompts.py
+++ b/chat/src/helpers/prompts.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 
 def prompt_template() -> str:
-    return """Please provide a brief answer to the question based on the documents provided. Include specific details from the documents that support your answer. Keep your answer concise. Each document is identified by a 'title' and a unique 'source' UUID:
+    return """Please provide a brief answer to the question based on the documents provided. Include specific details from the documents that support your answer. Keep your answer concise and keep reading time under 45 seconds. Each document is identified by a 'title' and a unique 'source' UUID. If the documents do not answer the question, please respond that you can't seem to find enough information about [keyword] that in the Digital Collection and suggest they search NUL's catalog and construct a search link using this format: https://search.library.northwestern.edu/discovery/search?field=any&query=any,contains,keyword&institution=01NWU&vid=01NWU_INST:NULVNEW&search_scope=MyInst_and_CI&tab=Everything&mode=Basic&displayMode=full&bulkSize=10&highlight=true&dum=true&displayField=all&pcAvailabiltyMode=true&facet=rtype,exclude,reviews,lk:
 
     Documents:
     {context}

--- a/chat/test/helpers/test_metrics.py
+++ b/chat/test/helpers/test_metrics.py
@@ -99,10 +99,10 @@ class TestMetrics(TestCase):
 
         expected_result = {
             "answer": 12,
-            "prompt": 314,
+            "prompt": 462,
             "question": 5,
             "source_documents": 527,
-            "total": 858
+            "total": 1006
         }
 
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
## Summary

- Instructs prompt to keep reading time of answers under 45 seconds
- Instructs prompt to suggest searching NUL's catalog if no relevant results are found in DC
- Handles error flow where `response.py`'s `prepare_response` was constructing and returning an error object but `chat.py` was not accounting for the error shape. (Example: https://github.com/nulib/repodev_planning_and_docs/issues/5071)
  - Now error will be logged in default lambda log (not metrics) and a generic `Internal Server Error` returned 