### PR TITLE
Use netid-derived name & email if directory response succeeds but is empty

### DIFF
--- a/node/src/handlers/post-chat-feedback.js
+++ b/node/src/handlers/post-chat-feedback.js
@@ -118,7 +118,6 @@ const sendNotification = async (snsClient, subject, message) => {
     Message: message,
   });
   const response = await snsClient.send(command);
-  console.log(response);
   return response;
 };
 


### PR DESCRIPTION
The auth callback is already creating a username and email from the NetID if the directory search response fails with an error, but not if it succeeds with empty values. This PR makes it do both.