### PR TITLE
Removes prompt to suggest NUL catalog searches, based on chat responses.

### DIFF
--- a/chat/src/helpers/prompts.py
+++ b/chat/src/helpers/prompts.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 
 def prompt_template() -> str:
-    return """Please provide a brief answer to the question based on the documents provided. Include specific details from the documents that support your answer. Keep your answer concise and keep reading time under 45 seconds. Each document is identified by a 'title' and a unique 'source' UUID. If the documents do not answer the question, please respond that you can't seem to find enough information about [keyword] that in the Digital Collection and suggest they search NUL's catalog and construct a search link using this format: https://search.library.northwestern.edu/discovery/search?field=any&query=any,contains,keyword&institution=01NWU&vid=01NWU_INST:NULVNEW&search_scope=MyInst_and_CI&tab=Everything&mode=Basic&displayMode=full&bulkSize=10&highlight=true&dum=true&displayField=all&pcAvailabiltyMode=true&facet=rtype,exclude,reviews,lk:
+    return """Please provide a brief answer to the question based on the documents provided. Include specific details from the documents that support your answer. Keep your answer concise and keep reading time under 45 seconds. Each document is identified by a 'title' and a unique 'source' UUID.
 
     Documents:
     {context}

--- a/chat/test/helpers/test_metrics.py
+++ b/chat/test/helpers/test_metrics.py
@@ -99,10 +99,10 @@ class TestMetrics(TestCase):
 
         expected_result = {
             "answer": 12,
-            "prompt": 462,
+            "prompt": 322,
             "question": 5,
             "source_documents": 527,
-            "total": 1006
+            "total": 866
         }
 
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
## Steps to test:

Th easiest way to see the change without deploying anything is to fire up Postman and add the following prompt override (the following text matches the change in the PR, but makes it easier to copy/paste):
```
"prompt": "Please provide a brief answer to the question based on the documents provided. Include specific details from the documents that support your answer. Keep your answer concise and keep reading time under 45 seconds. Each document is identified by a 'title' and a unique 'source' UUID.\n\n    Documents:\n    {context}\n    Answer in raw markdown. When referencing a document by title, link to it using its UUID like this: [title](https://dc.library.northwestern.edu/items/UUID). For example: [Judy Collins, Jackson Hole Folk Festival](https://dc.library.northwestern.edu/items/f1ca513b-7d13-4af6-ad7b-8c7ffd1d3a37). Suggest keyword searches using this format: [keyword](https://dc.library.northwestern.edu/search?q=keyword). Offer a variety of search terms that cover different aspects of the topic. Include as many direct links to Digital Collections searches as necessary for a thorough study. The `collection` field contains information about the collection the document belongs to. In the summary, mention the top 1 or 2 collections, explain why they are relevant and link to them using the collection title and id: [collection['title']](https://dc.library.northwestern.edu/collections/collection['id']), for example [World War II Poster Collection](https://dc.library.northwestern.edu/collections/faf4f60e-78e0-4fbf-96ce-4ca8b4df597a):\n\n    Question:\n    {question}\n    "
```