### PR TITLE
Return source documents for context in chat sync for testing

### DIFF
--- a/chat/src/handlers/chat_sync.py
+++ b/chat/src/handlers/chat_sync.py
@@ -10,8 +10,8 @@ honeybadger.configure()
 logging.getLogger('honeybadger').addHandler(logging.StreamHandler())
 
 RESPONSE_TYPES = {
-    "base": ["answer", "ref"],
-    "debug": ["answer", "attributes", "azure_endpoint", "deployment_name", "is_superuser", "k", "openai_api_version", "prompt", "question", "ref", "temperature", "text_key", "token_counts"],
+    "base": ["answer", "ref", "context"],
+    "debug": ["answer", "attributes", "azure_endpoint", "deployment_name", "is_superuser", "k", "openai_api_version", "prompt", "question", "ref", "temperature", "text_key", "token_counts", "context"],
     "log": ["answer", "deployment_name", "is_superuser", "k", "openai_api_version", "prompt", "question", "ref", "size", "source_documents", "temperature", "token_counts"],
     "error": ["question", "error", "source_documents"]
 }

--- a/chat/src/helpers/http_response.py
+++ b/chat/src/helpers/http_response.py
@@ -27,6 +27,8 @@ class HTTPResponse:
                 source_document["content"] = doc.page_content
                 source_documents.append(source_document)
                 
+            self.context = source_documents
+
             original_question = {
                 "question": self.config.question,
                 "source_documents": source_documents,
@@ -49,6 +51,7 @@ class HTTPResponse:
                 | self.debug_response_passthrough()
             )
             response = chain.invoke(self.config.question)
+            response["context"] = self.context
         except Exception as err:
             response = {
                 "question": self.config.question,


### PR DESCRIPTION
- Adding to chat sync endpoint only
- Some of the Azure evaluations can take context as part of input so we want to send it the source documents. 