### PR TITLE
Allow _source_includes and _source_excludes for GET search requests

### DIFF
--- a/docs/docs/spec/types.yaml
+++ b/docs/docs/spec/types.yaml
@@ -60,6 +60,20 @@ components:
       description: Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc")
       schema:
         type: string
+    _source_excludes:
+      name: _source_excludes
+      in: query
+      required: false
+      description: Comma-delimited list of fields to exclude from search results (e.g. "embedding,embedding_text_length")
+      schema:
+        type: string
+    _source_includes:
+      name: _source_includes
+      in: query
+      required: false
+      description: Comma-delimited list of fields to include in search results (e.g. "title,accession_number")
+      schema:
+        type: string
     as:
       name: as
       in: query

--- a/node/src/handlers/search-runner.js
+++ b/node/src/handlers/search-runner.js
@@ -96,6 +96,26 @@ const constructSearchContext = async (event) => {
   searchContext.size = queryStringParameters.size || searchContext.size || 10;
   searchContext.from = queryStringParameters.from || searchContext.from || 0;
 
+  if (
+    queryStringParameters?._source_excludes ||
+    searchContext._source?.exclude
+  ) {
+    searchContext._source = searchContext._source || {};
+    searchContext._source.exclude =
+      queryStringParameters?._source_excludes.split(",") ||
+      searchContext._source.exclude;
+  }
+
+  if (
+    queryStringParameters?._source_includes ||
+    searchContext._source?.include
+  ) {
+    searchContext._source = searchContext._source || {};
+    searchContext._source.include =
+      queryStringParameters?._source_includes.split(",") ||
+      searchContext._source.include;
+  }
+
   if (queryStringParameters?.sort || searchContext.sort)
     searchContext.sort =
       parseSortParameter(queryStringParameters) || searchContext.sort;
@@ -104,7 +124,6 @@ const constructSearchContext = async (event) => {
     const page = Number(queryStringParameters.page || 1);
     searchContext.from = (page - 1) * searchContext.size;
   }
-
   return searchContext;
 };
 


### PR DESCRIPTION
### Summary 

- Allow consumers to specify fields for include and exclude in GET /search requests. 
- Ex: `_source_includes=title,date_created,accesssion_number` and `_source_excludes=embedding`