### PR TITLE
Restore ES access policy for file set download

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -387,6 +387,11 @@ Resources:
               Action:
                 - s3:GetObject
               Resource: !Sub "arn:aws:s3:::${PyramidBucket}/*"
+            - Sid: ESHTTPPolicy
+              Effect: Allow
+              Action:
+                - es:ESHttp*
+              Resource: "*"
       Events:
         ApiGet:
           Type: HttpApi


### PR DESCRIPTION
### Summary

AV download is currently failing and returning a `403`.

### Changes in this PR

- Restore ES access policy to SAM template