### PR TITLE
Add identifier to IIIF manifests

### DIFF
--- a/node/src/api/response/iiif/presentation-api/metadata.js
+++ b/node/src/api/response/iiif/presentation-api/metadata.js
@@ -46,6 +46,10 @@ function metadataLabelFields(source) {
       value: source.genre.map((item) => item.label),
     },
     {
+      label: "Identifier",
+      value: source.identifier,
+    },
+    {
       label: "Last Modified",
       value: formatSingleValuedField(source.modified_date),
     },

--- a/node/test/unit/api/response/iiif/presentation-api/metadata.test.js
+++ b/node/test/unit/api/response/iiif/presentation-api/metadata.test.js
@@ -24,7 +24,7 @@ describe("IIIF response presentation API metadata helpers", () => {
   it("metadataLabelFields(source)", () => {
     const metadata = metadataLabelFields(source);
     expect(Array.isArray(metadata)).to.be;
-    expect(metadata.length).to.eq(29);
+    expect(metadata.length).to.eq(30);
     metadata.forEach((item) => {
       expect(item.label).to.be.a("string");
       expect(item.value).to.be.an("array");


### PR DESCRIPTION
### Summary

Adds Add identifier to the metadata section of IIIF manifests

### Steps to test

- [Run the API locally](https://github.com/nulib/dc-api-v2?tab=readme-ov-file#running-the-api-locally) (this wasn't working for me right now for some reason)
- Request a work doc with `?as=iiif` parameter and observe that `identifier` is in the metadata