### PR TITLE
Update av download lambda to node 22.x and AWS SDK v3

### DIFF
--- a/lambdas/start-audio-transcode.js
+++ b/lambdas/start-audio-transcode.js
@@ -1,41 +1,39 @@
-const AWS = require('aws-sdk');
+const { S3Client, PutObjectCommand } = require('@aws-sdk/client-s3');
 const ffmpeg = require('fluent-ffmpeg');
 const stream = require('stream');
 
 module.exports.handler = async (event) => {
-  
-  const s3 = new AWS.S3();
-  const url = event.streamingUrl;
-  const referer = event.referer || null;
-  const inputOptions = referer ? ["-referer", referer] : [];
-  const bucket = event.destinationBucket;
-  const key = event.destinationKey;
-  const pass = new stream.PassThrough();
+ const s3Client = new S3Client();
+ const url = event.streamingUrl;
+ const referer = event.referer || null;
+ const inputOptions = referer ? ["-referer", referer] : [];
+ const bucket = event.destinationBucket;
+ const key = event.destinationKey;
+ const pass = new stream.PassThrough();
 
-  return new Promise((resolve, reject) => {
-    ffmpeg()
-      .input(url)
-      .inputOptions(inputOptions)
-      .format('mp3')
-      .output(pass, { end: true })
-      .on('start', () => {
-        s3.upload({
-          Bucket: bucket,
-          Key: key,
-          Body: pass,
-        }, (error, _data) => {
-          if (error) {
-            console.error('upload failed', error);
-            reject(error);
-          } else {
-            resolve({ success: true });
-          }
-        });
-      })
-      .on('error', (error) => {
-        console.error('ffmpeg error', error);
-        reject(error);
-      })
-      .run();
-  });
+ return new Promise((resolve, reject) => {
+   ffmpeg()
+     .input(url)
+     .inputOptions(inputOptions)
+     .format('mp3')
+     .output(pass, { end: true })
+     .on('start', async () => {
+       try {
+         await s3Client.send(new PutObjectCommand({
+           Bucket: bucket,
+           Key: key,
+           Body: pass
+         }));
+         resolve({ success: true });
+       } catch (error) {
+         console.error('upload failed', error);
+         reject(error);
+       }
+     })
+     .on('error', (error) => {
+       console.error('ffmpeg error', error);
+       reject(error);
+     })
+     .run();
+ });
 }

--- a/template.yaml
+++ b/template.yaml
@@ -965,7 +965,7 @@ Resources:
   startAudioTranscodeFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs16.x
+      Runtime: nodejs22.x
       CodeUri: ./lambdas
       Handler: start-audio-transcode.handler
       Description: Performs audio transcode job with ffmpeg


### PR DESCRIPTION
### Summary

- Update av download lambda to node 22.x and AWS SDK v3

### How to test

- Run your API with step function: https://github.com/nulib/dc-api-v2?tab=readme-ov-file#running-the-api-locally-with-state-machine--lambdas-needed-for-av-download-route
- Run Meadow locally
- Download an AV file set from Meadow and confirm it still works