### PR TITLE
Require IAM role to access chat sync function

### DIFF
--- a/chat/template.yaml
+++ b/chat/template.yaml
@@ -254,7 +254,7 @@ Resources:
           METRICS_LOG_GROUP: !Ref ChatMetricsLog
           SECRETS_PATH: !Ref SecretsPath
       FunctionUrlConfig:
-        AuthType: NONE
+        AuthType: AWS_IAM
       Policies:
       - !Ref SecretsPolicy
       - Statement:


### PR DESCRIPTION
- This was triggering NUIT alarms and we only use it for evals, so require logged in user with appropriate role