### PR TITLE
Don't list default search size as parameter in SAM template

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -57,9 +57,6 @@ Parameters:
   DcUrl:
     Type: String
     Description: URL of Digital Collections website
-  DefaultSearchSize:
-    Type: String
-    Description: Default number of search results per page
   DevTeamNetIds:
     Type: String
     Description: Northwestern NetIDs of the development team


### PR DESCRIPTION
### Summary

My deploy of the default search size is failing: https://github.com/nulib/dc-api-v2/actions/runs/13499963262/job/37727803431#step:13:128

I think this is because I listed it in the parameters section of the template even though I hard coded the variable value.