### PR TITLE
Fix search size parameter in collection searches

### DIFF
--- a/node/src/api/response/iiif/collection.js
+++ b/node/src/api/response/iiif/collection.js
@@ -102,11 +102,12 @@ async function buildCollection(responseBody, pageInfo) {
 
 function getItems(hits, pageInfo, isTopCollection) {
   const itemType = isTopCollection ? "Collection" : "Manifest";
-  const items = hits.map((item) => loadItem(item["_source"], itemType));
+  const size = pageInfo.options?.queryStringParameters?.size;
+  const items = hits.map((item) => loadItem(item["_source"], itemType, size));
 
   if (pageInfo?.next_url) {
     items.push({
-      id: pageInfo.next_url,
+      id: size ? `${pageInfo.next_url}&size=${size}` : pageInfo.next_url,
       type: "Collection",
       label: {
         none: ["Next page"],
@@ -161,7 +162,7 @@ function getLinkingPropertyId(pageInfo, baseUrl, queryParam = "q") {
   return result;
 }
 
-function loadItem(item, itemType) {
+function loadItem(item, itemType, size) {
   if (itemType === "Manifest") {
     return {
       id: item.iiif_manifest,
@@ -196,7 +197,9 @@ function loadItem(item, itemType) {
 
   if (itemType === "Collection") {
     return {
-      id: `${item.api_link}?as=iiif`,
+      id: size
+        ? `${item.api_link}?as=iiif&size=${size}`
+        : `${item.api_link}?as=iiif`,
       type: "Collection",
       label: {
         none: [`${item.title}`],


### PR DESCRIPTION
### Summary

- Another attempt - should fix issues described in [`size` param pass through on top-level collection and increase the default value for `collection` `as=iiif`](https://github.com/nulib/repodev_planning_and_docs/issues/5368)

### Steps to Test

- Note for dev testing:  you can update the value of `DEFAULT_SEARCH_SIZE: "100"` in `template.yml` to be a smaller size so it's easier to see what's going on if you don't have very many records in dev.
- Run your dev environment locally with `make serve`
- Make sure the issues outlined in [5368](https://github.com/nulib/repodev_planning_and_docs/issues/5368) are addressed
- Sanity check that size still works as intended in all searches (including non `as=iiif` search) as it's defaults are shared.