### PR TITLE
Chat conversations add docs to context

### DIFF
--- a/chat/src/agent/callbacks/socket.py
+++ b/chat/src/agent/callbacks/socket.py
@@ -59,6 +59,10 @@ class SocketCallbackHandler(BaseCallbackHandler):
                 result_fields = ("id", "title", "visibility", "work_type", "thumbnail")
                 docs: List[Dict[str, Any]] = [{k: doc.metadata.get(k) for k in result_fields} for doc in output.artifact]
                 self.socket.send({"type": "search_result", "ref": self.ref, "message": docs})
+            case "retrieve_documents":
+                result_fields = ("id", "title", "visibility", "work_type", "thumbnail")
+                docs: List[Dict[str, Any]] = [{k: doc.get(k) for k in result_fields} for doc in output.artifact]
+                self.socket.send({"type": "retrieved_documents", "ref": self.ref, "message": docs})
             case _:
                 print(f"Unhandled tool_end message: {output}")
 

--- a/chat/src/agent/search_agent.py
+++ b/chat/src/agent/search_agent.py
@@ -1,7 +1,6 @@
 from typing import Literal, List
-
-from agent.tools import aggregate, discover_fields, search
 from langchain_core.messages import HumanMessage, ToolMessage
+from agent.tools import aggregate, discover_fields, search, retrieve_documents
 from langchain_core.messages.base import BaseMessage
 from langchain_core.language_models.chat_models import BaseModel
 from langchain_core.callbacks import BaseCallbackHandler
@@ -11,6 +10,7 @@ from langgraph.prebuilt import ToolNode
 from langgraph.errors import GraphRecursionError
 from core.setup import checkpoint_saver
 from agent.callbacks.socket import SocketCallbackHandler
+from typing import Optional
 
 DEFAULT_SYSTEM_MESSAGE = """
 Please provide a brief answer to the question using the tools provided. Include specific details from multiple documents that 
@@ -19,7 +19,7 @@ links using the document's canonical_link field. Do not include intermediate mes
 question is unclear, ask for clarification.
 """
 
-MAX_RECURSION_LIMIT = 10 
+MAX_RECURSION_LIMIT = 8 
 
 class SearchWorkflow:
     def __init__(self, model: BaseModel, system_message: str):
@@ -41,7 +41,6 @@ class SearchWorkflow:
         # We return a list, because this will get added to the existing list
         return {"messages": [response]}
 
-
 class SearchAgent:
     def __init__(
         self,
@@ -50,7 +49,7 @@ class SearchAgent:
         system_message: str = DEFAULT_SYSTEM_MESSAGE,
         **kwargs
     ):
-        tools = [discover_fields, search, aggregate]
+        tools = [discover_fields, search, aggregate, retrieve_documents]
         tool_node = ToolNode(tools)
 
         try:
@@ -79,61 +78,75 @@ class SearchAgent:
         self.checkpointer = checkpoint_saver()
         self.search_agent = workflow.compile(checkpointer=self.checkpointer)
     
-    def invoke(self, question: str, ref: str, *, callbacks: List[BaseCallbackHandler] = [], forget: bool = False, **kwargs):
+    def invoke(self, question: str, ref: str, *, docs: Optional[List[str]] = None,
+callbacks: List[BaseCallbackHandler] = [], forget: bool = False, **kwargs):
         if forget:
             self.checkpointer.delete_checkpoints(ref)
-        
-        try:
+
+        # If documents are provided, skip the search tools and use these docs directly
+        if docs and len(docs) > 0:
+            # Limit to 20 documents
+            docs = docs[:20]
+            # Pass documents in as context for the model
+            doc_lines = [str(doc) for doc in docs]
             return self.search_agent.invoke(
-                {"messages": [HumanMessage(content=question)]},
+                {"messages": [HumanMessage(content=question + "\n" + "\n".join(doc_lines))]},
                 config={
-                    "configurable": {"thread_id": ref},
-                    "callbacks": callbacks,
-                    "recursion_limit": MAX_RECURSION_LIMIT,
-                },
+                    "configurable": {"thread_id": ref}, 
+                    "callbacks": callbacks},
                 **kwargs
             )
-        except GraphRecursionError as e:
-            print(f"Recursion error: {e}")
+        else:  
+            try:
+                return self.search_agent.invoke(
+                    {"messages": [HumanMessage(content=question)]},
+                    config={
+                        "configurable": {"thread_id": ref},
+                        "callbacks": callbacks,
+                        "recursion_limit": MAX_RECURSION_LIMIT,
+                    },
+                    **kwargs
+                )
+            except GraphRecursionError as e:
+                print(f"Recursion error: {e}")
 
-            # Retrieve the messages processed so far
-            checkpoint_tuple = self.checkpointer.get_tuple({"configurable": {"thread_id": ref}})
-            state = checkpoint_tuple.checkpoint if checkpoint_tuple else None
-            messages = state.get("channel_values", {}).get("messages", []) if state else []
+                # Retrieve the messages processed so far
+                checkpoint_tuple = self.checkpointer.get_tuple({"configurable": {"thread_id": ref}})
+                state = checkpoint_tuple.checkpoint if checkpoint_tuple else None
+                messages = state.get("channel_values", {}).get("messages", []) if state else []
 
-            # Extract relevant responses including tool outputs
-            responses = []
-            for msg in messages:
-                if isinstance(msg, (BaseMessage, ToolMessage)):
-                    responses.append(msg.content)
+                # Extract relevant responses including tool outputs
+                responses = []
+                for msg in messages:
+                    if isinstance(msg, (BaseMessage, ToolMessage)):
+                        responses.append(msg.content)
 
-            if responses:
-                # Summarize the responses so far
-                summary_prompt = f"""
-                The following is what I have discovered so far based on multiple sources. 
-                Summarize the key points concisely for the user:
+                if responses:
+                    # Summarize the responses so far
+                    summary_prompt = f"""
+                    The following is what I have discovered so far based on multiple sources. 
+                    Summarize the key points concisely for the user:
+                    
+                    {responses[-5:]}  # Take the last few responses
+                    """
                 
-                {responses[-5:]}  # Take the last few responses
-                """
-            
-                # Generate a summary using the LLM
-                summary = self.workflow_logic.model.invoke([HumanMessage(content=summary_prompt)])
-                summary_text = summary.content
+                    # Generate a summary using the LLM
+                    summary = self.workflow_logic.model.invoke([HumanMessage(content=summary_prompt)])
+                    summary_text = summary.content
 
-                # Send summary as an "answer" message before finalizing
+                    # Send summary as an "answer" message before finalizing
+                    for cb in callbacks:
+                        if isinstance(cb, SocketCallbackHandler):
+                            cb.socket.send({"type": "answer", "ref": ref, "message": summary_text})
+
+                else:
+                    # Send a fallback message
+                    fallback_message = "I reached my recursion limit but couldn't retrieve enough useful information."
+                    for cb in callbacks:
+                        if isinstance(cb, SocketCallbackHandler):
+                            cb.socket.send({"type": "answer", "ref": ref, "message": fallback_message})
+                
                 for cb in callbacks:
-                    if isinstance(cb, SocketCallbackHandler):
-                        cb.socket.send({"type": "answer", "ref": ref, "message": summary_text})
-
-            else:
-                # Send a fallback message
-                fallback_message = "I reached my recursion limit but couldn't retrieve enough useful information."
-                for cb in callbacks:
-                    if isinstance(cb, SocketCallbackHandler):
-                        cb.socket.send({"type": "answer", "ref": ref, "message": fallback_message})
-
-            
-            for cb in callbacks:
-                if hasattr(cb, "on_agent_finish"):
-                    cb.on_agent_finish(finish=None, run_id=ref, **kwargs)
-            return {"type": "final", "ref": ref, "message": "Finished"}
+                    if hasattr(cb, "on_agent_finish"):
+                        cb.on_agent_finish(finish=None, run_id=ref, **kwargs)
+                return {"type": "final", "ref": ref, "message": "Finished"}

--- a/chat/src/core/event_config.py
+++ b/chat/src/core/event_config.py
@@ -8,6 +8,7 @@ from core.apitoken import ApiToken
 from core.prompts import prompt_template
 from core.websocket import Websocket
 from uuid import uuid4
+from typing import Optional, List
 
 CHAIN_TYPE = "stuff"
 DOCUMENT_VARIABLE_NAME = "context"
@@ -29,6 +30,7 @@ class EventConfig:
 
     api_token: ApiToken = field(init=False)
     debug_mode: bool = field(init=False)
+    docs: Optional[List[str]] = field(init=False, default=None)
     event: dict = field(default_factory=dict)
     forget: bool = field(init=False)
     is_dev_team: bool = field(init=False)
@@ -53,6 +55,7 @@ class EventConfig:
         self.payload = json.loads(self.event.get("body", "{}"))
         self.api_token = ApiToken(signed_token=self.payload.get("auth"))
         self.debug_mode = self._is_debug_mode_enabled()
+        self.docs = self.payload.get("docs", None)
         self.forget = self.payload.get("forget", False)
         self.is_dev_team = self.api_token.is_dev_team()
         self.is_logged_in = self.api_token.is_logged_in()

--- a/chat/src/handlers.py
+++ b/chat/src/handlers.py
@@ -69,7 +69,7 @@ def chat(event, context):
     search_agent = SearchAgent(model=model)
 
     try:
-        search_agent.invoke(config.question, config.ref, forget=config.forget, callbacks=callbacks)
+        search_agent.invoke(config.question, config.ref, forget=config.forget, docs=config.docs, callbacks=callbacks)
         log_metrics(context, metrics, config)
     except Exception as e:
         error_response = {"type": "error", "message": "An unexpected error occurred. Please try again later."}

--- a/chat/src/search/opensearch_neural_search.py
+++ b/chat/src/search/opensearch_neural_search.py
@@ -77,6 +77,21 @@ class OpenSearchNeuralSearch(VectorStore):
         )
 
         return response.get("aggregations", {})
+
+    def retrieve_documents(self, doc_ids: List[str]) -> List[Document]:
+        """Retrieve documents from the OpenSearch index based on a list of document IDs."""
+        query = {
+            "query": {
+                "ids": {
+                    "values": doc_ids
+                }
+            }
+        }
+
+        response = self.client.search(index=self.index, body=query, size=len(doc_ids))
+        documents = [Document(page_content=hit["_source"][self.text_field], metadata=hit["_source"]) for hit in response["hits"]["hits"]]
+        return documents
+
     
     def add_texts(self, texts: List[str], metadatas: List[dict], **kwargs: Any) -> None:
        pass


### PR DESCRIPTION
## Summary

In order to handle our conversations flow, the API needs to be able to accept a list of `docs` and add those to the context if provided.

## Steps to Test

- Sync/deploy the PR branch.  https://github.com/nulib/dc-api-v2/blob/deploy/staging/chat/README.md#deploy-a-development-stack
- Pass in queries with `docs` (like below for example), and ask questions (what are the docs about, can I see more like these, etc...)
  - Note that it seems you can provide as little metadata as this (or more or less), the agent will perform a search to get more info about these docs if needed. 
- Make sure existing functionality without docs works.

```
{
  "message": "{{DEFAULT_MESSAGE}}",
  "auth":
    "{{FOREVER_SUPERUSER_TOKEN}}",
  "ref": "abc123",
  "forget": true,
  "question": "I'm looking for more works from this location and timeframe",
   "docs": [
        {
            "id": "82a6eb08-5541-4038-ac29-13321a9dd4ed",
            "title": "Basketball-NU player #4 with basketball-\"Smith 1937\"",
            "visibility": "Institution",
            "work_type": "Image",
            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/82a6eb08-5541-4038-ac29-13321a9dd4ed/thumbnail"
        },
        {
            "id": "74a4620a-cc2c-45a2-aa4d-4e1ef417952b",
            "title": "Basketball (c. 1973)-players jumping for ball (\"Jon Saunders\" written on back)",
            "visibility": "Institution",
            "work_type": "Image",
            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/74a4620a-cc2c-45a2-aa4d-4e1ef417952b/thumbnail"
        },
        {
            "id": "a52e49ea-bfe7-432b-aee3-3b7c9ca706b0",
            "title": "Basketball-c. 1977-three players looking up (figure to the right)",
            "visibility": "Institution",
            "work_type": "Image",
            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/a52e49ea-bfe7-432b-aee3-3b7c9ca706b0/thumbnail"
        },
        {
            "id": "59a8f7ce-b3d3-43a3-a9a5-49456e2dd1a2",
            "title": "Basketball-NU player #44 with ball, being guarded by opponent #45",
            "visibility": "Institution",
            "work_type": "Image",
            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/59a8f7ce-b3d3-43a3-a9a5-49456e2dd1a2/thumbnail"
        },
        {
            "id": "e5a6f3cc-ee84-49be-98fe-cf2c0a1cb6da",
            "title": "Basketball-c. 1983-Gaddis Rathel-NU player #33 (Rathel) dribbling the ball",
            "visibility": "Institution",
            "work_type": "Image",
            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/e5a6f3cc-ee84-49be-98fe-cf2c0a1cb6da/thumbnail"
        },
        {
            "id": "1c8d8158-dd3e-44cb-b7f5-ab9d01965645",
            "title": "Basketball-NU player with opponent and basketball behind him (Left: Bryan Ashbaugh. Right: Jim Wallace)",
            "visibility": "Institution",
            "work_type": "Image",
            "thumbnail": "https://dcapi.rdc-staging.library.northwestern.edu/api/v2/works/1c8d8158-dd3e-44cb-b7f5-ab9d01965645/thumbnail"
        }
   ]
```

