### PR TITLE
Add group_with to OpenAPI schema

### DIFF
--- a/docs/docs/spec/data-types.yaml
+++ b/docs/docs/spec/data-types.yaml
@@ -144,6 +144,9 @@ components:
         duration:
           type: number
           nullable: true
+        group_with:
+          type: string
+          format: uuid
         height:
           type: number
           nullable: true
@@ -183,6 +186,7 @@ components:
         - description
         - download_url
         - duration
+        - group_with
         - height
         - label
         - mime_type

--- a/docs/docs/spec/data-types.yaml
+++ b/docs/docs/spec/data-types.yaml
@@ -147,6 +147,7 @@ components:
         group_with:
           type: string
           format: uuid
+          nullable: true
         height:
           type: number
           nullable: true

--- a/lambdas/package-lock.json
+++ b/lambdas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambdas",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambdas",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fluent-ffmpeg": "2.1.2"

--- a/lambdas/package.json
+++ b/lambdas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambdas",
-  "version": "2.6.0",
+  "version": "2.7.0",  
   "description": "Non-API handler lambdas",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/layers/api_dependencies/package-lock.json
+++ b/layers/api_dependencies/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-api-dependencies",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-api-dependencies",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "^2.0.1",

--- a/layers/api_dependencies/package.json
+++ b/layers/api_dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api-dependencies",
-  "version": "2.6.0",
+  "version": "2.7.0",  
   "description": "NUL Digital Collections API Dependencies",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/node/package-lock.json
+++ b/node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-api-build",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-api-build",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -9964,7 +9964,7 @@
     },
     "src": {
       "name": "dc-api",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-crypto/sha256-browser": "^2.0.1",

--- a/node/package.json
+++ b/node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api-build",
-  "version": "2.6.0",
+  "version": "2.7.0",  
   "description": "NUL Digital Collections API Build Environment",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/node/src/package-lock.json
+++ b/node/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-api",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-api",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@aws-crypto/sha256-browser": "^2.0.1",

--- a/node/src/package.json
+++ b/node/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "NUL Digital Collections API",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",


### PR DESCRIPTION
### Summary 

For issue: https://github.com/nulib/repodev_planning_and_docs/issues/5397, the  `group_with` field was added to file sets

Our OpenAPI docs need to reflect that and https://github.com/nulib/dcapi-types needs to be updated to reflect that

### Steps to test

- Dev deploy the docs site (can't remember if this is currently possible) or run the docs locally
- Make sure you see `group_with` in the OpenAPI documentation
- (Types package publishing happens on merge)