### PR TITLE
Use selective checkpointer for conversations

### DIFF
--- a/chat/src/core/setup.py
+++ b/chat/src/core/setup.py
@@ -1,4 +1,4 @@
-from persistence.s3_checkpointer import S3Checkpointer
+from persistence.selective_checkpointer import SelectiveCheckpointer
 from search.opensearch_neural_search import OpenSearchNeuralSearch
 from langchain_aws import ChatBedrock
 from langchain_core.language_models.base import BaseModel
@@ -14,7 +14,7 @@ def chat_model(**kwargs) -> BaseModel:
 
 def checkpoint_saver(**kwargs) -> BaseCheckpointSaver:
     checkpoint_bucket: str = os.getenv("CHECKPOINT_BUCKET_NAME")
-    return S3Checkpointer(bucket_name=checkpoint_bucket, **kwargs)
+    return SelectiveCheckpointer(bucket_name=checkpoint_bucket, **kwargs)
 
 def prefix(value):
     env_prefix = os.getenv("ENV_PREFIX")

--- a/chat/src/core/setup.py
+++ b/chat/src/core/setup.py
@@ -14,7 +14,7 @@ def chat_model(**kwargs) -> BaseModel:
 
 def checkpoint_saver(**kwargs) -> BaseCheckpointSaver:
     checkpoint_bucket: str = os.getenv("CHECKPOINT_BUCKET_NAME")
-    return SelectiveCheckpointer(bucket_name=checkpoint_bucket, **kwargs)
+    return SelectiveCheckpointer(bucket_name=checkpoint_bucket, retain_history=False, **kwargs)
 
 def prefix(value):
     env_prefix = os.getenv("ENV_PREFIX")

--- a/chat/src/persistence/selective_checkpointer.py
+++ b/chat/src/persistence/selective_checkpointer.py
@@ -1,0 +1,69 @@
+import os
+from typing import Optional
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.base import (
+    ChannelVersions,
+    Checkpoint,
+    CheckpointMetadata
+)
+from persistence.s3_checkpointer import S3Checkpointer
+
+def _is_tool_message(message):
+    if isinstance(message, ToolMessage):
+        return True
+    if isinstance(message, AIMessage) and message.additional_kwargs.get('stop_reason', '') == 'tool_use':
+        return True
+    return False
+
+def _prune_messages(messages):
+    if messages is None:
+        return messages
+
+    last_human_message = None
+    for i, message in reversed(list(enumerate(messages))):
+        if isinstance(message, HumanMessage):
+            last_human_message = i
+            break
+
+    if last_human_message is not None:
+        return [
+            msg
+            for i, msg in enumerate(messages)
+            if not _is_tool_message(msg) or i > last_human_message
+        ]
+
+    return messages
+
+class SelectiveCheckpointer(S3Checkpointer):
+    """S3 Checkpointer that discards ToolMessages from previous checkpoints."""
+  
+    def __init__(
+        self,
+        bucket_name: str,
+        region_name: str = os.getenv("AWS_REGION"),
+        endpoint_url: Optional[str] = None,
+        compression: Optional[str] = None,
+        retain_history: Optional[bool] = False,
+    ) -> None:
+        super().__init__(bucket_name, region_name, endpoint_url, compression)
+        self.retain_history = retain_history
+
+    def put(
+        self,
+        config: RunnableConfig,
+        checkpoint: Checkpoint,
+        metadata: CheckpointMetadata,
+        new_versions: ChannelVersions,
+    ) -> RunnableConfig:
+        # Remove previous checkpoints
+        thread_id = config["configurable"]["thread_id"]
+        if not self.retain_history:
+            self.delete_checkpoints(thread_id)
+        
+        # Remove all ToolMessages except those related to the most 
+        # recent question (HumanMessage)
+        messages = checkpoint.get("channel_values", {}).get("messages", [])
+        checkpoint["channel_values"]["messages"] = _prune_messages(messages)
+
+        return super().put(config, checkpoint, metadata, new_versions)

--- a/chat/test/core/test_setup.py
+++ b/chat/test/core/test_setup.py
@@ -16,16 +16,16 @@ class TestChatModel(unittest.TestCase):
 
 class TestCheckpointSaver(unittest.TestCase):
     @patch.dict(os.environ, {"CHECKPOINT_BUCKET_NAME": "test-bucket"})
-    @patch("core.setup.S3Checkpointer")
-    def test_checkpoint_saver_initialization(self, mock_s3_checkpointer):
+    @patch("core.setup.SelectiveCheckpointer")
+    def test_checkpoint_saver_initialization(self, mock_checkpointer):
         kwargs = {"prefix": "test"}
         result = checkpoint_saver(**kwargs)
         
-        mock_s3_checkpointer.assert_called_once_with(
+        mock_checkpointer.assert_called_once_with(
             bucket_name="test-bucket",
             **kwargs
         )
-        self.assertEqual(result, mock_s3_checkpointer.return_value)
+        self.assertEqual(result, mock_checkpointer.return_value)
 
 class TestPrefix(unittest.TestCase):
     def test_prefix_with_env_prefix(self):

--- a/chat/test/core/test_setup.py
+++ b/chat/test/core/test_setup.py
@@ -23,6 +23,7 @@ class TestCheckpointSaver(unittest.TestCase):
         
         mock_checkpointer.assert_called_once_with(
             bucket_name="test-bucket",
+            retain_history=False,
             **kwargs
         )
         self.assertEqual(result, mock_checkpointer.return_value)


### PR DESCRIPTION
## Overview

By default, the entire conversation history is saved with every checkpoint, including tool use nodes and responses. Since the document retrieval tool produces some large results, this quickly leads to exponential bloat.

For comparison, consider the following prompt and follow-ups:

1. Tell me a little bit about Barry Olivier. Keep it short.
2. What can you tell me about how he handled expenses?
3. Do you know if he was friends with any of the artists, or was it strictly a business relationship?

Here are the messages (abbreviated, with total length displayed) in the final checkpoint after all three questions in the currently deployed branch:

```
HumanMessage content='Tell me a little bit about Barry Olivier. ...	[163 B]
AIMessage content=[{'type': 'tool_use', 'id': 'toolu_bdrk_01Nu2H...	[586 B]
ToolMessage content='["page_content=\'ba0ec012-a9ef-422e-96cc-1f...	[221.2 kB]
AIMessage content=[{'type': 'text', 'text': "\n\nBarry Olivier (...	[1.2 kB]
HumanMessage content='What can you tell me about how he handled ...	[158 B]
AIMessage content=[{'type': 'tool_use', 'id': 'toolu_bdrk_01KDGJ...	[633 B]
ToolMessage content='["page_content=\'ba0d31cb-bd61-4787-a81b-3f...	[180.3 kB]
AIMessage content=[{'type': 'text', 'text': "\n\nBased on the ar...	[1.5 kB]
HumanMessage content='Do you know if he was friends with any of ...	[205 B]
AIMessage content=[{'type': 'tool_use', 'id': 'toolu_bdrk_01Upng...	[671 B]
ToolMessage content='["page_content=\'ad01277d-26da-429d-a09c-04...	[321.4 kB]
AIMessage content=[{'type': 'tool_use', 'id': 'toolu_bdrk_01MSrN...	[679 B]
ToolMessage content='["page_content=\'55ed7eda-09ec-4b6e-984f-c8...	[156.6 kB]
AIMessage content=[{'type': 'text', 'text': '\n\nBased on the ex...	[1.4 kB]
```

That's about 880kB of tool messages in one checkpoint, and a total checkpoint size of 886.6kB. Since the most recent checkpoint is sent to every tool on each followup question, the input token counts spiral out of control, and the request takes much longer to process.

## Solution

This PR introduces a new `SelectiveCheckpointer` (built on top of the `S3Checkpointer`) that removes all `ToolMessage`s (and their associated `AIMessage stop_reason='tool_use'` messages) from the checkpoint before saving, except for those generated by the most recent interaction. It also deletes all but the most recent checkpoint to save space, since we don't have any features that require us to rewind. Here is the final checkpoint from this branch using the same questions and data.

```
HumanMessage content='Tell me a little bit about Barry Olivier. ...	[163 B]
AIMessage content="Barry Olivier (1935-) was a folk musician and...	[1.2 kB]
HumanMessage content='What can you tell me about how he handled ...	[158 B]
AIMessage content="Based on the archival records, Barry Olivier ...	[1.8 kB]
HumanMessage content='Do you know if he was friends with any of ...	[205 B]
AIMessage content="Let me search for information about Barry Oli...	[863 B]
ToolMessage content='["page_content=\'a852b087-0868-46be-b6df-30...	[148.5 kB]
AIMessage content='Based on the correspondence records, Barry Ol...	[2.1 kB]
```

Only 148.5kb of `ToolMessage`s, and a total checkpoint size of 154.96kB.

### Input Token Counts

|       | Tool Use Before | LLM Prompt Before | Tool Use After | LLM Prompt After |
|-------|-----------------|-------------------|----------------|------------------|
| Q1     | 999             | 45,482             | 999            | 29,805            |
| Q2     | 45,764           | 77,621             | 30,042          | 63,940            |
| Q3     | 147,235          | 175,485            | 35,521          | 62,085            |

This doesn't account for the differences in search strategy between the two runs. Obviously there's no reason for the existing branch to use more input tokens for the LLM invocation on the first question. But the results are pretty drastic. The LLM token count even _decreased_ between questions 2 and 3.

## Responses

The quality of the responses doesn't seem to have suffered at all from the removal of the intermediary tool messages. As with the input token count, the only major difference is in the first question, where the checkpoint didn't even exist yet.

### Q1.
#### Before
Barry Olivier (b. 1935) was the founder and director of the Berkeley Folk Music Festival, which he ran from 1958 to 1970. He was both an organizer and performer, regularly playing guitar and singing at festival events. According to his own [account of Berkeley's folk music scene](https://dc.rdc-staging.library.northwestern.edu/items/ba0ec012-a9ef-422e-96cc-1f476d78cbb5), he helped shape the folk revival in Berkeley from 1956-1970. In 1957, he began performing folk music sessions at [KPFA radio in Berkeley](https://dc.rdc-staging.library.northwestern.edu/items/8e70a434-a877-4709-97f3-0863b5d1abd6). His activities ranged from performing at noon concerts in UC Berkeley's Faculty Glade to handling the complex logistics of organizing the [annual festival](https://dc.rdc-staging.library.northwestern.edu/items/e58690fd-707e-4971-97ab-7d0da56abb79), which grew into a major folk music event.

#### After
Barry Olivier (1935-) was a folk musician and performer active in Berkeley, California in the 1950s and 1960s. He regularly performed at [Cooper's Northgate folk song jam sessions](https://dc.rdc-staging.library.northwestern.edu/items/1ea95caa-2cbd-4e38-95f0-27cd4431012d) in Berkeley and appeared on [KPFA radio's folk music programs](https://dc.rdc-staging.library.northwestern.edu/items/72b0e5a4-edf5-432e-8cc1-2e6cb72994f9) in 1957. He later performed at events like the [Richmond Festival of the Arts folk song concert](https://dc.rdc-staging.library.northwestern.edu/items/f7f84a43-c156-4dee-ade8-03b97b5a1438) in May 1965.

### Q2
#### Before
Based on the archival records, Barry Olivier maintained detailed financial records for the Berkeley Folk Music Festival throughout its run from 1958-1970. He kept careful track of expenses through [various financial statements, budgets, and records](https://dc.rdc-staging.library.northwestern.edu/items/ba0d31cb-bd61-4787-a81b-3f4f82f636da), starting with the very first festival in 1958. He regularly prepared [preliminary expense and income reports](https://dc.rdc-staging.library.northwestern.edu/items/909d4120-2d3d-4ef3-9586-77e4b0447422) as well as final financial statements for each festival. The festival operated under the auspices of the University of California Berkeley's Associated Students (ASUC), and Olivier handled reimbursements and expenditures through their system, submitting [detailed expense statements and requisition forms](https://dc.rdc-staging.library.northwestern.edu/items/98589b50-8158-4bb4-8bcb-27ad4b777e1e). He kept meticulous records of even small expenses, maintaining [receipts, adding machine calculations, and handwritten notes](https://dc.rdc-staging.library.northwestern.edu/items/596d322f-c406-4f13-a8dd-7cabb7e96178) to document festival costs.

#### After
Based on the archival records, Barry Olivier handled expenses meticulously, particularly in his role managing the Berkeley Folk Music Festival. He kept detailed financial records including:

1. Festival budgets and expense statements, sending regular [financial updates and memos](https://dc.rdc-staging.library.northwestern.edu/items/a5b3383d-5a09-466b-a99d-dd8d33da5bf9) to festival staff and committee members

2. Careful tracking of [personal expenses and reimbursements](https://dc.rdc-staging.library.northwestern.edu/items/c2921335-7495-4f16-b10b-ca836f148ba3) for travel and activities related to the festival, including mileage records

3. Documentation of [printing costs](https://dc.rdc-staging.library.northwestern.edu/items/c1869a5d-9aa1-4493-a4bc-a3b2fc164d94) and other operational expenses

4. Management of [ticket sales revenue](https://dc.rdc-staging.library.northwestern.edu/items/1a89fb86-e940-416d-b771-6537e4d09c33) and accounts

5. Personal responsibility for festival finances - there's evidence he sometimes [covered outstanding festival debts](https://dc.rdc-staging.library.northwestern.edu/items/2656b4fd-28b1-4cbe-af32-0c04b5656cfb) to the University of California Berkeley Associated Students organization from his own funds.

### Q3
#### Before
Based on the extensive correspondence preserved in the archives, Barry Olivier maintained both professional and personal relationships with many folk musicians and artists. His letters show ongoing friendships with several performers: He exchanged warm personal letters with Mark Levine about [their friendship and careers](https://dc.rdc-staging.library.northwestern.edu/items/16060905-4075-439c-9cca-60e116dac1e2), wrote supportively to Vern & Ray [expressing how much he enjoyed their work](https://dc.rdc-staging.library.northwestern.edu/items/8ac6f797-1154-4089-a2db-406efaf5e631), and maintained an ongoing correspondence with Billy Faier that included discussions of both business and personal matters, with Olivier [expressing interest in helping Faier personally](https://dc.rdc-staging.library.northwestern.edu/items/fab1087a-82db-4baa-b94a-21c78e3e8cc2). These letters reflect that while he was a professional festival organizer, he also developed genuine friendships and mentoring relationships with many of the artists he worked with over the years.

#### After
Based on the correspondence records, Barry Olivier maintained both professional and personal relationships with many folk artists. Here are some examples:

1. He had an especially supportive relationship with [Alice Stuart](https://dc.rdc-staging.library.northwestern.edu/items/92470eb5-b630-44e5-aa6e-4acc3ab00856), offering career advice and emotional support. He wrote her multiple personal letters, including advice about her mental health and congratulations on her marriage.

2. His correspondence with artists often mixed business and personal matters. For example, in his [letter to Janet Smith](https://dc.rdc-staging.library.northwestern.edu/items/a972edef-5112-4683-8f24-49b3ccea2a08), he shared family news alongside discussion of potential performances.

3. He would share personal opinions and experiences with artists, as shown in his [letter to Alice Stuart](https://dc.rdc-staging.library.northwestern.edu/items/a134aef8-cf40-47ae-be63-ab091670a1c4) where he discussed his thoughts about Bob Dylan concerts he had attended.

4. He appeared to go above and beyond business relationships, such as helping [Billy Faier](https://dc.rdc-staging.library.northwestern.edu/items/fab1087a-82db-4baa-b94a-21c78e3e8cc2) with various issues including financial matters, showing personal interest in helping artists beyond just their performances.

The tone and content of his correspondence suggests he developed genuine friendships with many of the artists while maintaining professional relationships to organize the Berkeley Folk Music Festival and other events.