### PR TITLE
Reduce token usage in conversation search

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,16 @@ env.json:
 samconfig.%.yaml:
 	DEV_PREFIX=$* ./bin/make_deploy_config.sh
 deploy: build samconfig.$(DEV_PREFIX).yaml
+	if ! aws sts get-caller-identity --query 'Arn' --output text | grep AWSReservedSSO_AWSAdministratorAccess > /dev/null; then \
+		echo "You must be logged in as an admin to deploy"; \
+		exit 1; \
+	fi
 	sam deploy --config-file samconfig.$(DEV_PREFIX).yaml --stack-name dc-api-$(DEV_PREFIX)
 sync: samconfig.$(DEV_PREFIX).yaml
+	if ! aws sts get-caller-identity --query 'Arn' --output text | grep AWSReservedSSO_AWSAdministratorAccess > /dev/null; then \
+		echo "You must be logged in as an admin to sync"; \
+		exit 1; \
+	fi
 	sam sync --config-file samconfig.$(DEV_PREFIX).yaml --stack-name dc-api-$(DEV_PREFIX) --watch $(ARGS)
 sync-code: ARGS=--code
 sync-code: sync

--- a/chat/src/agent/callbacks/metrics.py
+++ b/chat/src/agent/callbacks/metrics.py
@@ -1,51 +1,109 @@
+from datetime import datetime
 from typing import Any, Dict
 from langchain_core.callbacks import BaseCallbackHandler
 from langchain_core.outputs import LLMResult
 from langchain_core.messages.tool import ToolMessage
+import boto3
 import json
+import os
 
 class MetricsCallbackHandler(BaseCallbackHandler):
-  def __init__(self, *args, **kwargs):
-    self.accumulator = {}
-    self.answers = []
-    self.artifacts = []
-    super().__init__(*args, **kwargs)
+    def __init__(self, log_stream = None, *args, extra_data = {}, **kwargs):
+        self.accumulator = {}
+        self.answers = []
+        self.artifacts = []
+        self.log_stream = log_stream
+        self.extra_data = extra_data
+        super().__init__(*args, **kwargs)
 
-  def on_llm_end(self, response: LLMResult, **kwargs: Dict[str, Any]):
-    if response is None:
-        return
+    def on_llm_end(self, response: LLMResult, **kwargs: Dict[str, Any]):
+        if response is None:
+            return
 
-    if not response.generations or not response.generations[0]:
-        return
-        
-    for generation in response.generations[0]:
-      if generation.text != "":
-        self.answers.append(generation.text)
+        if not response.generations or not response.generations[0]:
+            return
 
-      if not hasattr(generation, 'message') or generation.message is None:
-          continue
-          
-      metadata = getattr(generation.message, 'usage_metadata', None)
-      if metadata is None:
-          continue
-          
-      for k, v in metadata.items():
-          self.accumulator[k] = self.accumulator.get(k, 0) + v
+        for generation in response.generations[0]:
+            if generation.text != "":
+                self.answers.append(generation.text)
 
-  def on_tool_end(self, output: ToolMessage, **kwargs: Dict[str, Any]):
+            if not hasattr(generation, "message") or generation.message is None:
+                continue
+
+            metadata = getattr(generation.message, "usage_metadata", None)
+            if metadata is None:
+                continue
+
+            for k, v in metadata.items():
+                self.accumulator[k] = self.accumulator.get(k, 0) + v
+
+    def on_tool_end(self, output: ToolMessage, **kwargs: Dict[str, Any]):
         content = output.content
         if isinstance(content, str):
             try:
                 content = json.loads(content)
             except json.decoder.JSONDecodeError as e:
-                print(f"Invalid json ({e}) returned from {output.name} tool: {output.content}")
+                print(
+                    f"Invalid json ({e}) returned from {output.name} tool: {output.content}"
+                )
                 return
-                
+
         match output.name:
             case "aggregate":
-                self.artifacts.append({"type": "aggregation", "artifact": content.get("aggregation_result", {})})
+                self.artifacts.append(
+                    {
+                        "type": "aggregation",
+                        "artifact": content.get("aggregation_result", {}),
+                    }
+                )
             case "search":
                 source_urls = [doc.get("api_link") for doc in content]
                 self.artifacts.append({"type": "source_urls", "artifact": source_urls})
             case "summarize":
                 print(output)
+
+    def log_metrics(self):
+        if self.log_stream is None:
+            return
+        
+        log_group = os.getenv("METRICS_LOG_GROUP")
+        if log_group and ensure_log_stream_exists(log_group, self.log_stream):
+            client = log_client()
+            message = {
+                "answer": self.answers,
+                "artifacts": self.artifacts,
+                "token_counts": self.accumulator,
+            }
+            message.update(self.extra_data)
+
+            log_events = [
+                {
+                    "timestamp": timestamp(),
+                    "message": json.dumps(message),
+                }
+            ]
+            client.put_log_events(
+                logGroupName=log_group, logStreamName=self.log_stream, logEvents=log_events
+            )
+
+
+def ensure_log_stream_exists(log_group, log_stream):
+    client = log_client()
+    try:
+        print(
+            client.create_log_stream(logGroupName=log_group, logStreamName=log_stream)
+        )
+        return True
+    except client.exceptions.ResourceAlreadyExistsException:
+        return True
+    except Exception:
+        print(f"Could not create log stream: {log_group}:{log_stream}")
+        return False
+
+
+def log_client():
+    return boto3.client("logs", region_name=os.getenv("AWS_REGION", "us-east-1"))
+
+
+def timestamp():
+    return round(datetime.timestamp(datetime.now()) * 1000)

--- a/chat/src/agent/tools.py
+++ b/chat/src/agent/tools.py
@@ -1,7 +1,5 @@
 import json
 
-from langchain_core.language_models.chat_models import BaseModel
-from langchain_core.messages import HumanMessage
 from langchain_core.tools import tool
 from core.setup import opensearch_vector_store
 from typing import List
@@ -29,7 +27,8 @@ def filter_results(results):
     Filters out the embeddings from the results
     """
     filtered = []
-    for doc in results:
+    for result in results:
+        doc = result.metadata
         if 'embedding' in doc:
             doc.pop('embedding')
         filtered.append(doc)
@@ -101,33 +100,3 @@ def retrieve_documents(doc_ids: List[str]):
         return filter_results(response)
     except Exception as e:
         return {"error": str(e)}
-    
-@tool(response_format="content")
-def summarize(content, model: BaseModel):
-    """
-    Summarize content. If content is a list of documents, each document will
-    be replaced with a summary to reduce the amount of content passed to the agent's
-    model at each turn. Otherwise, the content will be summarized as a whole.
-    
-    Args:
-        content: The content to summarize.
-        model (BaseModel): The summarization model to use.
-    
-    Returns:
-        A new list of documents, pared down.
-    """
-
-    summary_prompt = f"""
-    Summarize the following content. If the content is a list of documents
-    with IDs, replace each document with a new dict with the shape
-    {'id': doc.id, 'title': doc.title 'content': summary}, where summary is a 
-    concise but semantically meaningful summary of the document content for the
-    agent to use on subsequent turns. Otherwise, produce a summary of the content
-    as a whole.
-    
-    {content}
-    """
-    print(f"Summarizing content: {content}")
-    summary = model.invoke([HumanMessage(content=summary_prompt)])
-    print(f"Summarized content: {summary.content}")
-    return summary.content

--- a/chat/src/core/document.py
+++ b/chat/src/core/document.py
@@ -1,0 +1,47 @@
+def minimize_documents(docs):
+    return [minimize_document(doc) for doc in docs]
+
+def minimize_document(doc):
+    return {
+        'id': doc.get('id'),
+        'title': minimize(doc.get('title')),
+        'alternate_title': minimize(doc.get('alternate_title')),
+        'description': minimize(doc.get('description')),
+        'abstract': minimize(doc.get('abstract')),
+        'subject': labels_only(doc.get('subject')),
+        'date_created': minimize(doc.get('date_created')),
+        'provenance': minimize(doc.get('provenance')),
+        'collection': minimize(doc.get('collection', {}).get('title')),
+        'creator': labels_only(doc.get('creator')),
+        'contributor': labels_only(doc.get('contributor')),
+        
+        'work_type': minimize(doc.get('work_type')),
+        'genre': labels_only(doc.get('genre')),
+        'scope_and_contents': minimize(doc.get('scope_and_contents')),
+        'table_of_contents': minimize(doc.get('table_of_contents')),
+        'cultural_context': minimize(doc.get('cultural_context')),
+        'notes': minimize(doc.get('notes')),
+        'keywords': minimize(doc.get('keywords')),
+        'visibility': minimize(doc.get('visibility')),
+        'canonical_link': minimize(doc.get('canonical_link')),
+        
+        'rights_statement': label_only(doc.get('rights_statement')),
+    }
+
+def labels_only(list_of_fields):
+    return minimize([label_only(field) for field in list_of_fields])
+    
+def label_only(field):
+    if field is None:
+        return None
+    return field.get('label_with_role', field.get('label', None))
+
+def minimize(field):
+    try:
+        if field is None:
+            return None
+        if len(field) == 0:
+            return None
+        return field
+    except TypeError:
+        return field

--- a/chat/src/handlers.py
+++ b/chat/src/handlers.py
@@ -1,9 +1,6 @@
-import boto3
 import json
 import logging
-import os
 from core.secrets import load_secrets
-from datetime import datetime
 from core.event_config import EventConfig
 from honeybadger import honeybadger
 from agent.search_agent import SearchAgent
@@ -63,14 +60,22 @@ def chat(event, context):
         config.socket.send({"type": "error", "message": "Question cannot be blank"})
         return {"statusCode": 400, "body": "Question cannot be blank"}
 
-    metrics = MetricsCallbackHandler()
+    log_info = {
+        "is_dev_team": config.api_token.is_dev_team(),
+        "is_superuser": config.api_token.is_superuser(),
+        "k": config.k,
+        "model": config.model,
+        "question": config.question,
+        "ref": config.ref,
+    }
+    metrics = MetricsCallbackHandler(context.log_stream_name, extra_data=log_info)
     callbacks = [SocketCallbackHandler(config.socket, config.ref), metrics]
     model = chat_model(model=config.model, streaming=config.stream_response)
-    search_agent = SearchAgent(model=model)
-
+    search_agent = SearchAgent(model=model, metrics=metrics)
+    
     try:
         search_agent.invoke(config.question, config.ref, forget=config.forget, docs=config.docs, callbacks=callbacks)
-        log_metrics(context, metrics, config)
+        metrics.log_metrics()
     except Exception as e:
         error_response = {"type": "error", "message": "An unexpected error occurred. Please try again later."}
         if config.socket:
@@ -78,44 +83,3 @@ def chat(event, context):
         raise e
 
     return {"statusCode": 200}
-
-
-def log_metrics(context, metrics, config):
-    log_group = os.getenv("METRICS_LOG_GROUP")
-    log_stream = context.log_stream_name
-    if log_group and ensure_log_stream_exists(log_group, log_stream):
-        client = log_client()
-        log_events = [{
-            "timestamp": timestamp(), 
-            "message": json.dumps({
-                "answer": metrics.answers,
-                "is_dev_team": config.api_token.is_dev_team(),
-                "is_superuser": config.api_token.is_superuser(),
-                "k": config.k,
-                "model": config.model,
-                "question": config.question,
-                "ref": config.ref,
-                "artifacts": metrics.artifacts,
-                "token_counts": metrics.accumulator,
-            })
-        }]
-        client.put_log_events(
-                logGroupName=log_group, logStreamName=log_stream, logEvents=log_events
-            )
-    
-def ensure_log_stream_exists(log_group, log_stream):
-    client = log_client()
-    try:
-        print(client.create_log_stream(logGroupName=log_group, logStreamName=log_stream))
-        return True
-    except client.exceptions.ResourceAlreadyExistsException:
-        return True
-    except Exception:
-        print(f"Could not create log stream: {log_group}:{log_stream}")
-        return False
-
-def log_client():
-    return boto3.client("logs", region_name=os.getenv("AWS_REGION", "us-east-1"))
-
-def timestamp():
-    return round(datetime.timestamp(datetime.now()) * 1000)

--- a/chat/template.yaml
+++ b/chat/template.yaml
@@ -53,7 +53,7 @@ Resources:
   ChatWebSocket:
     Type: AWS::ApiGatewayV2::Api
     Properties:
-      Name: ChatWebSocket
+      Name: !Sub "${AWS::StackName}-Api"
       ProtocolType: WEBSOCKET
       RouteSelectionExpression: "$request.body.message"
   CheckpointBucket:

--- a/chat/test/agent/callbacks/test_socket.py
+++ b/chat/test/agent/callbacks/test_socket.py
@@ -85,21 +85,17 @@ class TestSocketCallbackHandler(TestCase):
 
     def test_on_tool_end_search(self):
         # Mock tool output
-        class MockDoc:
-            def __init__(self, metadata):
-                self.metadata = metadata
-
         class MockToolMessage:
-            def __init__(self, name, artifact):
+            def __init__(self, name, content):
                 self.name = name
-                self.artifact = artifact
+                self.content = content
 
-        artifact = [
-            MockDoc({"id": 1, "title": "Result 1", "visibility": "public", "work_type": "article", "thumbnail": "img1"}),
-            MockDoc({"id": 2, "title": "Result 2", "visibility": "private", "work_type": "document", "thumbnail": "img2"})
+        content = [
+            {"id": 1, "title": "Result 1", "visibility": "public", "work_type": "article", "thumbnail": "img1"},
+            {"id": 2, "title": "Result 2", "visibility": "private", "work_type": "document", "thumbnail": "img2"}
         ]
 
-        output = MockToolMessage("search", artifact)
+        output = MockToolMessage("search", content)
         self.handler.on_tool_end(output)
 
         # Verify search_result message was sent
@@ -116,9 +112,9 @@ class TestSocketCallbackHandler(TestCase):
     
     def test_on_tool_end_aggregate(self):
         class MockToolMessage:
-            def __init__(self, name, artifact):
+            def __init__(self, name, content):
                 self.name = name
-                self.artifact = artifact
+                self.content = content
 
         output = MockToolMessage("aggregate", {"aggregation_result": {"count": 10}})
         self.handler.on_tool_end(output)
@@ -132,9 +128,9 @@ class TestSocketCallbackHandler(TestCase):
         
     def test_on_tool_end_discover_fields(self):
         class MockToolMessage:
-            def __init__(self, name, artifact):
+            def __init__(self, name, content):
                 self.name = name
-                self.artifact = artifact
+                self.content = content
 
         output = MockToolMessage("discover_fields", {})
         self.handler.on_tool_end(output)
@@ -143,9 +139,9 @@ class TestSocketCallbackHandler(TestCase):
 
     def test_on_tool_end_unknown(self):
         class MockToolMessage:
-            def __init__(self, name, artifact):
+            def __init__(self, name, content):
                 self.name = name
-                self.artifact = artifact
+                self.content = content
 
         output = MockToolMessage("unknown", {})
         self.handler.on_tool_end(output)

--- a/chat/test/agent/test_tools.py
+++ b/chat/test/agent/test_tools.py
@@ -33,11 +33,17 @@ class TestTools(TestCase):
 
     @patch('agent.tools.opensearch_vector_store')
     def test_search(self, mock_opensearch):
-        mock_results = [{"id": "doc1", "text": "example result"}]
+        class MockDoc:
+            def __init__(self, content, metadata):
+                self.content = content
+                self.metadata = metadata
+
+        expected_results = [{"id": "doc1", "text": "example result"}]
+        mock_results = [MockDoc(content=doc["id"], metadata=doc) for doc in expected_results]
         mock_opensearch.return_value.similarity_search.return_value = mock_results
         
         response = search.invoke("test query")
-        self.assertEqual(response, mock_results)
+        self.assertEqual(response, expected_results)
 
     @patch('agent.tools.opensearch_vector_store')
     def test_aggregate(self, mock_opensearch):

--- a/chat/test/agent/test_tools.py
+++ b/chat/test/agent/test_tools.py
@@ -29,9 +29,7 @@ class TestTools(TestCase):
         
         # Pass required parameters based on the tool's schema
         response = discover_fields.invoke({"query": ""})  # Assuming query is the required parameter
-        self.assertIsInstance(response, str)
-        parsed_response = json.loads(response)
-        self.assertEqual(parsed_response, ["field1", "field3.subfield1"])
+        self.assertEqual(response, ["field1", "field3.subfield1"])
 
     @patch('agent.tools.opensearch_vector_store')
     def test_search(self, mock_opensearch):
@@ -39,19 +37,17 @@ class TestTools(TestCase):
         mock_opensearch.return_value.similarity_search.return_value = mock_results
         
         response = search.invoke("test query")
-        self.assertIsInstance(response, str)  # Remove .content check
-        parsed_response = json.loads(response)
-        self.assertEqual(parsed_response, mock_results)
+        self.assertEqual(response, mock_results)
 
     @patch('agent.tools.opensearch_vector_store')
     def test_aggregate(self, mock_opensearch):
-        mock_response = {
+        mock_response = json.dumps({
             "aggregations": {
                 "example_agg": {
                     "buckets": []
                 }
             }
-        }
+        })
         mock_opensearch.return_value.aggregations_search.return_value = mock_response
         
         # Pass parameters directly instead of as JSON string
@@ -61,18 +57,17 @@ class TestTools(TestCase):
             "term": "term"
         })
         self.assertIsInstance(response, str)
-        parsed_response = json.loads(response)
-        self.assertEqual(parsed_response, mock_response)
+        self.assertEqual(json.loads(response), json.loads(mock_response))
 
     @patch('agent.tools.opensearch_vector_store')
     def test_aggregate_no_term(self, mock_opensearch):
-        mock_response = {
+        mock_response = json.dumps({
             "aggregations": {
                 "all_docs": {
                     "buckets": []
                 }
             }
-        }
+        })
         mock_opensearch.return_value.aggregations_search.return_value = mock_response
 
         response = aggregate.invoke({
@@ -81,8 +76,7 @@ class TestTools(TestCase):
             "term": ""
         })
         self.assertIsInstance(response, str)
-        parsed_response = json.loads(response)
-        self.assertEqual(parsed_response, mock_response)
+        self.assertEqual(json.loads(response), json.loads(mock_response))
 
     def test_get_keyword_fields(self):
         properties = {


### PR DESCRIPTION
Building on PR #296, which reduced cumulative token usage across multiple interactions by removing all non-current ToolMessages, this PR reduces token counts within a _single_ interaction by:

- Reducing redundancy in tool results (by returning only content instead of content and artifact containing the same data in different forms)
- Filtering fields in the documents returned from the index

On average, this reduces tool content byte size by about 90%, and token counts per interaction by about 80%. This allows complex questions to succeed by keeping tool recursion from overwhelming the LLM's max token count.

The PR also adds language to the system prompt to cap tool usage at 6 per interaction, with instructions to summarize results and ask for clarification if it still can't answer the question.