### PR TITLE
Fix problem with search size 0

### DIFF
--- a/api/src/api/request/pipeline.js
+++ b/api/src/api/request/pipeline.js
@@ -19,7 +19,8 @@ function filterFor(query, event) {
 module.exports = class RequestPipeline {
   constructor(searchContext) {
     this.searchContext = { ...searchContext };
-    if (!this.searchContext.size) this.searchContext.size = defaultSearchSize();
+    if (this.searchContext.size === undefined)
+      this.searchContext.size = defaultSearchSize();
     if (!this.searchContext.from) this.searchContext.from = 0;
   }
 

--- a/api/src/handlers/search-runner.js
+++ b/api/src/handlers/search-runner.js
@@ -94,8 +94,11 @@ const constructSearchContext = async (event) => {
 
   const { queryStringParameters = {} } = event;
 
-  searchContext.size =
-    queryStringParameters.size || searchContext.size || defaultSearchSize();
+  if (queryStringParameters.size !== undefined) {
+    searchContext.size = Number(queryStringParameters.size);
+  } else if (searchContext.size === undefined) {
+    searchContext.size = defaultSearchSize();
+  }
   searchContext.from = queryStringParameters.from || searchContext.from || 0;
 
   if (


### PR DESCRIPTION
### Summary

Aggregation queries from DC with `size: 0` were returning the default number of results.

### Steps To Test

Send an agg query like this and make sure it correctly respects the (top level) size param or default if missing.

```
{
    "_source": [
        "id",
        "iiif_manifest",
        "representative_file_set",
        "title",
        "thumbnail",
        "visibility",
        "work_type"
    ],
    "query": {
        "bool": {
            "must": []
        }
    },
    "size": 0,
    "aggs": {
        "subject": {
            "filter": {
                "bool": {
                    "must": []
                }
            },
            "aggs": {
                "subject": {
                    "terms": {
                        "field": "subject.label",
                        "order": {
                            "_count": "desc"
                        },
                        "size": 20
                    }
                }
            }
        }
    },
    "post_filter": {
        "bool": {
            "must": []
        }
    }
}
```