### PR TITLE
Centralize authorization logic via scopes

### DIFF
--- a/api/src/api/abilities.js
+++ b/api/src/api/abilities.js
@@ -1,0 +1,24 @@
+// Add all user abilities to the API Token's entitlements claim
+// The Abilities object maps abilities to functions that check
+// if the user has that ability.
+
+const Abilities = {
+  "read:Public": () => true,
+  "read:Published": () => true,
+  "read:Institution": (user) =>
+    user.isSuperUser() || user.isInstitution() || user.isReadingRoom(),
+  "read:Private": (user) => user.isSuperUser() || user.isReadingRoom(),
+  "read:Unpublished": (user) => user.isSuperUser(),
+  chat: (user) => user.isLoggedIn(),
+};
+
+const addAbilities = (apiToken) => {
+  for (const [ability, fn] of Object.entries(Abilities)) {
+    if (fn(apiToken)) {
+      apiToken.addAbility(ability);
+    }
+  }
+  return apiToken;
+};
+
+module.exports = { addAbilities };

--- a/api/src/api/request/pipeline.js
+++ b/api/src/api/request/pipeline.js
@@ -6,11 +6,14 @@ function filterFor(query, event) {
   const beUnpublished = { term: { published: false } };
   const beRestricted = { term: { visibility: "Private" } };
 
-  let filter = { must: [matchTheQuery] };
-  if (!event.userToken.isSuperUser()) {
-    filter.must_not = event.userToken.isReadingRoom()
-      ? [beUnpublished]
-      : [beUnpublished, beRestricted];
+  let filter = { must: [matchTheQuery], must_not: [] };
+
+  if (!event.userToken.can("read:Unpublished")) {
+    filter.must_not.push(beUnpublished);
+  }
+
+  if (!event.userToken.can("read:Private")) {
+    filter.must_not.push(beRestricted);
   }
 
   return { bool: filter };

--- a/api/src/api/scopes.js
+++ b/api/src/api/scopes.js
@@ -1,8 +1,8 @@
-// Add all user abilities to the API Token's entitlements claim
-// The Abilities object maps abilities to functions that check
-// if the user has that ability.
+// Add all user scopes to the API Token's entitlements claim
+// The Scopes object maps scopes to functions that check
+// if the user has that scope.
 
-const Abilities = {
+const Scopes = {
   "read:Public": () => true,
   "read:Published": () => true,
   "read:Institution": (user) =>
@@ -12,13 +12,13 @@ const Abilities = {
   chat: (user) => user.isLoggedIn(),
 };
 
-const addAbilities = (apiToken) => {
-  for (const [ability, fn] of Object.entries(Abilities)) {
+const addScopes = (apiToken) => {
+  for (const [scope, fn] of Object.entries(Scopes)) {
     if (fn(apiToken)) {
-      apiToken.addAbility(ability);
+      apiToken.addScope(scope);
     }
   }
   return apiToken;
 };
 
-module.exports = { addAbilities };
+module.exports = { addScopes };

--- a/api/src/environment.js
+++ b/api/src/environment.js
@@ -44,7 +44,7 @@ function defaultSearchSize() {
 }
 
 function devTeamNetIds() {
-  return process.env.DEV_TEAM_NET_IDS.split(",");
+  return process.env.DEV_TEAM_NET_IDS?.split(",") || [];
 }
 
 function openSearchEndpoint() {

--- a/api/src/handlers/authorize-document.js
+++ b/api/src/handlers/authorize-document.js
@@ -16,8 +16,8 @@ const authorizeDocument = (event, osResponse) => {
 
   if (!allowed) {
     const publishedState = published ? "Published" : "Unpublished";
-    allowed = [`read:${visibility}`, `read:${publishedState}`].every(
-      (ability) => token.can(ability)
+    allowed = [`read:${visibility}`, `read:${publishedState}`].every((scope) =>
+      token.can(scope)
     );
   }
 

--- a/api/src/handlers/authorize-document.js
+++ b/api/src/handlers/authorize-document.js
@@ -8,18 +8,18 @@ const authorizeDocument = (event, osResponse) => {
 
   const body = JSON.parse(osResponse.body);
   const document = body._source;
-
   const token = event.userToken;
 
-  const visibility = document.visibility;
-  const published = document.published;
-  const readingRoom = token.isReadingRoom();
+  const { published, visibility } = document;
   const workId = document.work_id || document.id;
+  let allowed = token.hasEntitlement(workId);
 
-  const allowed =
-    token.isSuperUser() ||
-    token.hasEntitlement(workId) ||
-    (isAllowedVisibility(token, visibility, readingRoom) && published);
+  if (!allowed) {
+    const publishedState = published ? "Published" : "Unpublished";
+    allowed = [`read:${visibility}`, `read:${publishedState}`].every(
+      (ability) => token.can(ability)
+    );
+  }
 
   return sendResponse(allowed ? 204 : 403);
 };
@@ -28,19 +28,6 @@ function sendResponse(statusCode) {
   return {
     statusCode: statusCode,
   };
-}
-
-function isAllowedVisibility(token, visibility, readingRoom) {
-  switch (visibility) {
-    case "Public":
-      return true;
-    case "Institution":
-      return token.isInstitution() || readingRoom;
-    case "Private":
-      return readingRoom;
-    default:
-      return false;
-  }
 }
 
 module.exports = { authorizeDocument };

--- a/api/src/handlers/get-chat-endpoint.js
+++ b/api/src/handlers/get-chat-endpoint.js
@@ -1,7 +1,7 @@
 const { wrap } = require("./middleware");
 
 const handler = wrap(async (event) => {
-  if (!event.userToken.isLoggedIn()) {
+  if (!event.userToken.can("chat")) {
     return {
       statusCode: 401,
       headers: { "Content-Type": "text/plain" },

--- a/api/test/integration/auth/nusso-login.test.js
+++ b/api/test/integration/auth/nusso-login.test.js
@@ -27,7 +27,6 @@ describe("auth login", function () {
 
     const result = await getAuthLoginHandler.handler(event);
     expect(result.statusCode).to.eq(302);
-    console.log(result);
     expect(result.headers.location).to.eq("https://test-redirect.com");
   });
 

--- a/api/test/integration/get-auth-whoami.test.js
+++ b/api/test/integration/get-auth-whoami.test.js
@@ -34,7 +34,9 @@ describe("auth whoami", function () {
 
     const result = await getAuthWhoamiHandler.handler(event);
     expect(result.statusCode).to.eq(200);
-    expect(JSON.parse(result.body)).to.contain({ name: "Some One" });
+    const response = JSON.parse(result.body);
+    expect(response).to.contain({ name: "Some One" });
+    expect(response).to.have.property("scopes");
   });
 
   it("Doesn't set a new cookie if the token is not updated", async () => {

--- a/api/test/integration/get-chat-endpoint.test.js
+++ b/api/test/integration/get-chat-endpoint.test.js
@@ -10,7 +10,9 @@ describe("GET /chat-endpoint", function () {
   helpers.saveEnvironment();
 
   it("returns the websocket URI and token to a logged in user", async () => {
-    const token = new ApiToken().user({ uid: "abc123" }).sign();
+    let token = new ApiToken().user({ sub: "abc123" });
+    console.log(token.token);
+    token = token.sign();
     const event = helpers
       .mockEvent("GET", "/chat-endpoint")
       .headers({

--- a/api/test/integration/get-chat-endpoint.test.js
+++ b/api/test/integration/get-chat-endpoint.test.js
@@ -11,7 +11,6 @@ describe("GET /chat-endpoint", function () {
 
   it("returns the websocket URI and token to a logged in user", async () => {
     const token = new ApiToken().user({ uid: "abc123" }).sign();
-
     const event = helpers
       .mockEvent("GET", "/chat-endpoint")
       .headers({

--- a/api/test/integration/options-request.test.js
+++ b/api/test/integration/options-request.test.js
@@ -6,6 +6,7 @@ const expect = chai.expect;
 const optionsHandler = requireSource("handlers/options-request");
 
 describe("OPTIONS handler", async () => {
+  helpers.saveEnvironment();
   const event = helpers
     .mockEvent("OPTIONS", "/auth/whoami")
     .headers({
@@ -14,6 +15,7 @@ describe("OPTIONS handler", async () => {
     .render();
 
   it("sends the correct CORS headers", async () => {
+    console.log(process.env.API_TOKEN_SECRET);
     const response = await optionsHandler.handler(event);
     expect(response.headers).to.contain({
       "Access-Control-Allow-Origin":

--- a/api/test/integration/post-chat-feedback.test.js
+++ b/api/test/integration/post-chat-feedback.test.js
@@ -64,7 +64,7 @@ describe("Chat feedback route", () => {
     });
 
     it("should fail if sentiment is invalid", async () => {
-      const token = new ApiToken().user({ uid: "abc123" }).sign();
+      const token = new ApiToken().user({ sub: "abc123" }).sign();
 
       let requestBody = JSON.stringify({
         sentiment: "neutral",
@@ -105,7 +105,7 @@ describe("Chat feedback route", () => {
     });
 
     it("should fail if ref is missing", async () => {
-      const token = new ApiToken().user({ uid: "abc123" }).sign();
+      const token = new ApiToken().user({ sub: "abc123" }).sign();
       let requestBody = JSON.stringify({
         sentiment: "positive",
         timestamp: new Date().toISOString(),
@@ -142,7 +142,7 @@ describe("Chat feedback route", () => {
     });
 
     it("should fail if refIndex is missing", async () => {
-      const token = new ApiToken().user({ uid: "abc123" }).sign();
+      const token = new ApiToken().user({ sub: "abc123" }).sign();
       let requestBody = JSON.stringify({
         sentiment: "positive",
         timestamp: new Date().toISOString(),
@@ -179,7 +179,7 @@ describe("Chat feedback route", () => {
     });
 
     it("should fail if timestamp is missing", async () => {
-      const token = new ApiToken().user({ uid: "abc123" }).sign();
+      const token = new ApiToken().user({ sub: "abc123" }).sign();
       let requestBody = JSON.stringify({
         sentiment: "positive",
         // ... we omit timestamp ...
@@ -217,7 +217,7 @@ describe("Chat feedback route", () => {
 
     describe("Saving feedback", () => {
       it("should upload the response to S3 and return 200", async () => {
-        const token = new ApiToken().user({ uid: "abc123" }).sign();
+        const token = new ApiToken().user({ sub: "abc123" }).sign();
 
         const requestBody = {
           sentiment: "negative",

--- a/api/test/unit/api/api-token.test.js
+++ b/api/test/unit/api/api-token.test.js
@@ -190,43 +190,43 @@ describe("ApiToken", function () {
     });
   });
 
-  describe("abilities", function () {
-    it("has default abilities", async () => {
+  describe("scopes", function () {
+    it("has default scopes", async () => {
       const token = new ApiToken();
-      expect(token.token.abilities.has("read:Public")).to.be.true;
-      expect(token.token.abilities.has("read:Published")).to.be.true;
-      expect(token.token.abilities.has("read:Private")).to.be.false;
-      expect(token.token.abilities.has("read:Unpublished")).to.be.false;
+      expect(token.token.scopes.has("read:Public")).to.be.true;
+      expect(token.token.scopes.has("read:Published")).to.be.true;
+      expect(token.token.scopes.has("read:Private")).to.be.false;
+      expect(token.token.scopes.has("read:Unpublished")).to.be.false;
     });
 
-    it("addAbility() adds an ability", async () => {
+    it("addScope() adds an scope", async () => {
       const token = new ApiToken();
       expect(token.can("read:Public")).to.be.true;
       expect(token.can("read:Published")).to.be.true;
       expect(token.can("read:Private")).to.be.false;
 
-      token.addAbility("read:Private");
+      token.addScope("read:Private");
 
       expect(token.can("read:Public")).to.be.true;
       expect(token.can("read:Published")).to.be.true;
       expect(token.can("read:Private")).to.be.true;
     });
 
-    it("removeAbility() removes an ability", async () => {
+    it("removeScope() removes an scope", async () => {
       const token = new ApiToken();
       expect(token.can("read:Public")).to.be.true;
       expect(token.can("read:Published")).to.be.true;
 
-      token.addAbility("read:Private");
+      token.addScope("read:Private");
       expect(token.can("read:Private")).to.be.true;
 
-      token.removeAbility("read:Private");
+      token.removeScope("read:Private");
       expect(token.can("read:Public")).to.be.true;
       expect(token.can("read:Published")).to.be.true;
       expect(token.can("read:Private")).to.be.false;
     });
 
-    it("imputes abilities from user", async () => {
+    it("imputes scopes from user", async () => {
       const token = new ApiToken();
       token.user({
         sub: "user123",

--- a/api/test/unit/api/api-token.test.js
+++ b/api/test/unit/api/api-token.test.js
@@ -142,51 +142,109 @@ describe("ApiToken", function () {
       expect(token.hasEntitlement("1234")).to.be.true;
       expect(token.hasEntitlement("5678")).to.be.true;
     });
+
+    it("entitlements() replaces entitlements", async () => {
+      const payload = {
+        iss: "https://example.com",
+        sub: "user123",
+        name: "Some One",
+        exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
+        iat: Math.floor(Number(new Date()) / 1000),
+        email: "user@example.com",
+        isLoggedIn: true,
+        entitlements: ["1234"],
+      };
+      const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+
+      const token = new ApiToken(existingToken);
+      expect(token.hasEntitlement("1234")).to.be.true;
+      expect(token.hasEntitlement("5678")).to.be.false;
+
+      token.entitlements(["5678", "9101112"]);
+
+      expect(token.hasEntitlement("1234")).to.be.false;
+      expect(token.hasEntitlement("5678")).to.be.true;
+    });
+
+    it("removeEntitlement() removes an entitlement", async () => {
+      const payload = {
+        iss: "https://example.com",
+        sub: "user123",
+        name: "Some One",
+        exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
+        iat: Math.floor(Number(new Date()) / 1000),
+        email: "user@example.com",
+        isLoggedIn: true,
+        entitlements: ["1234", "5678"],
+      };
+      const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+
+      const token = new ApiToken(existingToken);
+      expect(token.hasEntitlement("1234")).to.be.true;
+      expect(token.hasEntitlement("5678")).to.be.true;
+
+      token.removeEntitlement("5678");
+
+      expect(token.hasEntitlement("1234")).to.be.true;
+      expect(token.hasEntitlement("5678")).to.be.false;
+    });
   });
 
-  it("entitlements() replaces entitlements", async () => {
-    const payload = {
-      iss: "https://example.com",
-      sub: "user123",
-      name: "Some One",
-      exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
-      iat: Math.floor(Number(new Date()) / 1000),
-      email: "user@example.com",
-      isLoggedIn: true,
-      entitlements: ["1234"],
-    };
-    const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+  describe("abilities", function () {
+    it("has default abilities", async () => {
+      const token = new ApiToken();
+      expect(token.token.abilities.has("read:Public")).to.be.true;
+      expect(token.token.abilities.has("read:Published")).to.be.true;
+      expect(token.token.abilities.has("read:Private")).to.be.false;
+      expect(token.token.abilities.has("read:Unpublished")).to.be.false;
+    });
 
-    const token = new ApiToken(existingToken);
-    expect(token.hasEntitlement("1234")).to.be.true;
-    expect(token.hasEntitlement("5678")).to.be.false;
+    it("addAbility() adds an ability", async () => {
+      const token = new ApiToken();
+      expect(token.can("read:Public")).to.be.true;
+      expect(token.can("read:Published")).to.be.true;
+      expect(token.can("read:Private")).to.be.false;
 
-    token.entitlements(["5678", "9101112"]);
+      token.addAbility("read:Private");
 
-    expect(token.hasEntitlement("1234")).to.be.false;
-    expect(token.hasEntitlement("5678")).to.be.true;
-  });
+      expect(token.can("read:Public")).to.be.true;
+      expect(token.can("read:Published")).to.be.true;
+      expect(token.can("read:Private")).to.be.true;
+    });
 
-  it("removeEntitlement() removes an entitlement", async () => {
-    const payload = {
-      iss: "https://example.com",
-      sub: "user123",
-      name: "Some One",
-      exp: Math.floor(Number(new Date()) / 1000) + 12 * 60 * 60,
-      iat: Math.floor(Number(new Date()) / 1000),
-      email: "user@example.com",
-      isLoggedIn: true,
-      entitlements: ["1234", "5678"],
-    };
-    const existingToken = jwt.sign(payload, process.env.API_TOKEN_SECRET);
+    it("removeAbility() removes an ability", async () => {
+      const token = new ApiToken();
+      expect(token.can("read:Public")).to.be.true;
+      expect(token.can("read:Published")).to.be.true;
 
-    const token = new ApiToken(existingToken);
-    expect(token.hasEntitlement("1234")).to.be.true;
-    expect(token.hasEntitlement("5678")).to.be.true;
+      token.addAbility("read:Private");
+      expect(token.can("read:Private")).to.be.true;
 
-    token.removeEntitlement("5678");
+      token.removeAbility("read:Private");
+      expect(token.can("read:Public")).to.be.true;
+      expect(token.can("read:Published")).to.be.true;
+      expect(token.can("read:Private")).to.be.false;
+    });
 
-    expect(token.hasEntitlement("1234")).to.be.true;
-    expect(token.hasEntitlement("5678")).to.be.false;
+    it("imputes abilities from user", async () => {
+      const token = new ApiToken();
+      token.user({
+        sub: "user123",
+        name: "Some One",
+        email: "user123@example.com",
+      });
+      expect(token.can("read:Public")).to.be.true;
+      expect(token.can("read:Published")).to.be.true;
+      expect(token.can("read:Private")).to.be.false;
+      expect(token.can("read:Unpublished")).to.be.false;
+      expect(token.can("chat")).to.be.true;
+
+      token.superUser();
+      expect(token.can("read:Public")).to.be.true;
+      expect(token.can("read:Published")).to.be.true;
+      expect(token.can("read:Private")).to.be.true;
+      expect(token.can("read:Unpublished")).to.be.true;
+      expect(token.can("chat")).to.be.true;
+    });
   });
 });

--- a/api/test/unit/api/helpers.test.js
+++ b/api/test/unit/api/helpers.test.js
@@ -377,7 +377,6 @@ describe("helpers", () => {
     });
     it("adds the reading room flag to the token", () => {
       const token = new ApiToken().user({ sub: "abc123" }).sign();
-
       const event = helpers
         .mockEvent("GET", "/works/{id}/")
         .pathParams({ id: 1234 })

--- a/api/test/unit/api/request/pipeline.test.js
+++ b/api/test/unit/api/request/pipeline.test.js
@@ -105,7 +105,7 @@ describe("RequestPipeline", () => {
       expect(result.searchContext.query.bool.must).to.deep.include(
         requestBody.query
       );
-      expect(result.searchContext.query.bool).not.to.have.any.keys("must_not");
+      expect(result.searchContext.query.bool.must_not).to.be.empty;
     });
   });
 

--- a/chat/README.md
+++ b/chat/README.md
@@ -220,4 +220,4 @@ The chat service implements the following authorization levels:
   - Debug mode
   - Temperature control
   - Unrestricted context window
-  - Ability to override system defaults
+  - Scope to override system defaults

--- a/chat/src/core/apitoken.py
+++ b/chat/src/core/apitoken.py
@@ -2,9 +2,6 @@ from datetime import datetime
 import jwt
 import os
 
-INSTITUTION_PROVIDERS = ["nusso"]
-
-
 class ApiToken:
     @classmethod
     def empty_token(cls):
@@ -13,7 +10,7 @@ class ApiToken:
             "iss": os.getenv("DC_API_ENDPOINT"),
             "exp": datetime.fromtimestamp(time + 12 * 60 * 60).timestamp(),  # 12 hours
             "iat": time,
-            "abilities": [],
+            "scopes": [],
             "entitlements": [],
             "isLoggedIn": False,
             "isDevTeam": False,
@@ -32,8 +29,8 @@ class ApiToken:
     def __str__(self):
         return f"ApiToken(token={self.token})"
 
-    def can(self, ability):
-        return ability in self.token.get("abilities", [])
+    def can(self, scope):
+        return scope in self.token.get("scopes", [])
         
     def is_logged_in(self):
         return self.token.get("isLoggedIn", False)
@@ -45,4 +42,4 @@ class ApiToken:
         return self.token.get("isDevTeam", False)
 
     def is_institution(self):
-        return self.token.get("provider", "none") in INSTITUTION_PROVIDERS
+        return self.token.get("isInstitution", False)

--- a/chat/src/core/apitoken.py
+++ b/chat/src/core/apitoken.py
@@ -13,6 +13,7 @@ class ApiToken:
             "iss": os.getenv("DC_API_ENDPOINT"),
             "exp": datetime.fromtimestamp(time + 12 * 60 * 60).timestamp(),  # 12 hours
             "iat": time,
+            "abilities": [],
             "entitlements": [],
             "isLoggedIn": False,
             "isDevTeam": False,
@@ -31,6 +32,9 @@ class ApiToken:
     def __str__(self):
         return f"ApiToken(token={self.token})"
 
+    def can(self, ability):
+        return ability in self.token.get("abilities", [])
+        
     def is_logged_in(self):
         return self.token.get("isLoggedIn", False)
 

--- a/chat/src/core/event_config.py
+++ b/chat/src/core/event_config.py
@@ -77,8 +77,8 @@ class EventConfig:
         self.text_key = self._get_text_key()
         self.prompt = ChatPromptTemplate.from_template(self.prompt_text)
 
-    def user_can(self, ability):
-        return self.api_token.can(ability)
+    def user_can(self, scope):
+        return self.api_token.can(scope)
 
     def _get_payload_value_with_superuser_check(self, key, default):
         if self.api_token.is_superuser():

--- a/chat/src/core/event_config.py
+++ b/chat/src/core/event_config.py
@@ -77,6 +77,9 @@ class EventConfig:
         self.text_key = self._get_text_key()
         self.prompt = ChatPromptTemplate.from_template(self.prompt_text)
 
+    def user_can(self, ability):
+        return self.api_token.can(ability)
+
     def _get_payload_value_with_superuser_check(self, key, default):
         if self.api_token.is_superuser():
             return self.payload.get(key, default)

--- a/chat/src/handlers.py
+++ b/chat/src/handlers.py
@@ -58,7 +58,7 @@ def chat(event, context):
     socket = event.get("socket", None)
     config.setup_websocket(socket)
 
-    if not (config.is_logged_in or config.is_superuser):
+    if not config.user_can("chat"):
         config.socket.send({"type": "error", "message": "Unauthorized"})
         return {"statusCode": 401, "body": "Unauthorized"}
 

--- a/chat/test/core/test_apitoken.py
+++ b/chat/test/core/test_apitoken.py
@@ -21,6 +21,8 @@ class TestFunction(TestCase):
         self.assertTrue(subject.is_logged_in())
         self.assertFalse(subject.is_superuser())
         self.assertFalse(subject.is_institution())
+        self.assertTrue(subject.can("read:Public"))
+        self.assertFalse(subject.can("read:Private"))
 
     def test_superuser_token(self):
         subject = ApiToken(SUPER_TOKEN)
@@ -28,6 +30,8 @@ class TestFunction(TestCase):
         self.assertTrue(subject.is_logged_in())
         self.assertTrue(subject.is_superuser())
         self.assertTrue(subject.is_institution())
+        self.assertTrue(subject.can("read:Public"))
+        self.assertTrue(subject.can("read:Private"))
 
     def test_devteam_token(self):
         subject = ApiToken(DEV_TEAM_TOKEN)

--- a/chat/test/core/test_event_config.py
+++ b/chat/test/core/test_event_config.py
@@ -128,7 +128,7 @@ class TestEventConfigWebsocket(unittest.TestCase):
         self.assertEqual(returned_socket, mock_socket)
         self.assertEqual(config.socket, mock_socket)
         
-class TestEventConfigAbility(unittest.TestCase):
+class TestEventConfigScope(unittest.TestCase):
     def setUp(self):
         self.event = {
             "body": json.dumps({

--- a/chat/test/core/test_event_config.py
+++ b/chat/test/core/test_event_config.py
@@ -127,3 +127,23 @@ class TestEventConfigWebsocket(unittest.TestCase):
         returned_socket = config.setup_websocket(socket=mock_socket)
         self.assertEqual(returned_socket, mock_socket)
         self.assertEqual(config.socket, mock_socket)
+        
+class TestEventConfigAbility(unittest.TestCase):
+    def setUp(self):
+        self.event = {
+            "body": json.dumps({
+                "auth": "some_token",
+                "question": "What is the capital of France?"
+            })
+        }
+        self.config = EventConfig(event=self.event)
+
+    @patch.object(ApiToken, 'can', return_value=True)
+    def test_can_method(self, mock_can):
+        self.assertTrue(self.config.user_can("chat"))
+        mock_can.assert_called_once_with("chat")
+
+    @patch.object(ApiToken, 'can', return_value=False)
+    def test_can_method_false(self, mock_can):
+        self.assertFalse(self.config.user_can("chat"))
+        mock_can.assert_called_once_with("chat")

--- a/chat/test/fixtures/apitoken.py
+++ b/chat/test/fixtures/apitoken.py
@@ -1,21 +1,19 @@
 TEST_SECRET = "TEST_SECRET"
 TEST_TOKEN_NAME = "dcTestToken"
-SUPER_TOKEN = (
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4NDM1NzU2ODg5MTIs"
-    "ImlhdCI6MTY4Nzg4MDI0NywiaXNMb2dnZWRJbiI6dHJ1ZSwic3ViIjoiYXBpVGVzd"
-    "FN1cGVyVXNlciIsImlzU3VwZXJVc2VyIjp0cnVlLCJlbnRpdGxlbWVudHMiOltdLC"
-    "Jwcm92aWRlciI6Im51c3NvIn0.bhEOBeza7yQNjFe_1gfRgynTrGwhdmAAUdsfV9HTck4"
-)
-TEST_TOKEN = (
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4NDM1ODY2MDYxNjUsI"
-    "mlhdCI6MTY4Nzg5MTM2OSwiZW50aXRsZW1lbnRzIjpbXSwiaXNMb2dnZWRJbiI6dHJ"
-    "1ZSwic3ViIjoidGVzdFVzZXIiLCJwcm92aWRlciI6InRlc3QifQ.QaE6ekwTDvcBcIW"
-    "kJ1Bo1Ou3DQMBWsRGxtpMCDUrGbU"
-)
-DEV_TEAM_TOKEN = (
-    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjI1MjY1OTQ2MDcsIn"
-    "N1YiI6ImFiYzEyMyIsImlzcyI6Im1lYWRvdyIsImlhdCI6MTcyNDk1OTUyNiwiZ"
-    "W50aXRsZW1lbnRzIjpbXSwiaXNMb2dnZWRJbiI6dHJ1ZSwiaXNTdXBlclVzZXIi"
-    "OmZhbHNlLCJpc0RldlRlYW0iOnRydWUsInByb3ZpZGVyIjoibnVzc28ifQ.fuSO"
-    "aWVVRq6fw0liNaWW9OGaEf4LbK3ZlMaw5HMYkzQ"
-)
+SUPER_TOKEN = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4NDM1NzU2ODg5MTIsI'
+               'mlhdCI6MTY4Nzg4MDI0NywiaXNMb2dnZWRJbiI6dHJ1ZSwic3ViIjoiYXBpVGVzdFN'
+               '1cGVyVXNlciIsImlzU3VwZXJVc2VyIjp0cnVlLCJlbnRpdGxlbWVudHMiOltdLCJwc'
+               'm92aWRlciI6Im51c3NvIiwiYWJpbGl0aWVzIjpbInJlYWQ6UHVibGljIiwicmVhZDp'
+               'QdWJsaXNoZWQiLCJyZWFkOlByaXZhdGUiLCJyZWFkOlVucHVibGlzaGVkIiwiY2hhd'
+               'CJdfQ.iVPfB_BUHk1hxV67YMiCQ6TWNHNTC1Vm4kmscDl7FYI')
+TEST_TOKEN = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4NDM1ODY2MDYxNjUsIml'
+              'hdCI6MTY4Nzg5MTM2OSwiZW50aXRsZW1lbnRzIjpbXSwiaXNMb2dnZWRJbiI6dHJ1ZSw'
+              'ic3ViIjoidGVzdFVzZXIiLCJwcm92aWRlciI6InRlc3QiLCJhYmlsaXRpZXMiOlsicmV'
+              'hZDpQdWJsaWMiLCJyZWFkOlB1Ymxpc2hlZCIsImNoYXQiXX0.KCH-2thBdlO9wJ7keNL_'
+              'OKv0HG6ecTljH7oYPkqBtbM')
+DEV_TEAM_TOKEN = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjI1MjY1OTQ2MDcsIn'
+                  'N1YiI6ImFiYzEyMyIsImlzcyI6Im1lYWRvdyIsImlhdCI6MTcyNDk1OTUyNiwiZ'
+                  'W50aXRsZW1lbnRzIjpbXSwiaXNMb2dnZWRJbiI6dHJ1ZSwiaXNTdXBlclVzZXIi'
+                  'OmZhbHNlLCJpc0RldlRlYW0iOnRydWUsInByb3ZpZGVyIjoibnVzc28iLCJhYml'
+                  'saXRpZXMiOlsicmVhZDpQdWJsaWMiLCJyZWFkOlB1Ymxpc2hlZCIsImNoYXQiXX0'
+                  '.YbnWn0y-OkYM9aukGLCFulOUnhOUN-ZIwBt8mNfw64g')

--- a/chat/test/fixtures/apitoken.py
+++ b/chat/test/fixtures/apitoken.py
@@ -1,19 +1,19 @@
 TEST_SECRET = "TEST_SECRET"
 TEST_TOKEN_NAME = "dcTestToken"
-SUPER_TOKEN = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4NDM1NzU2ODg5MTIsI'
-               'mlhdCI6MTY4Nzg4MDI0NywiaXNMb2dnZWRJbiI6dHJ1ZSwic3ViIjoiYXBpVGVzdFN'
-               '1cGVyVXNlciIsImlzU3VwZXJVc2VyIjp0cnVlLCJlbnRpdGxlbWVudHMiOltdLCJwc'
-               'm92aWRlciI6Im51c3NvIiwiYWJpbGl0aWVzIjpbInJlYWQ6UHVibGljIiwicmVhZDp'
-               'QdWJsaXNoZWQiLCJyZWFkOlByaXZhdGUiLCJyZWFkOlVucHVibGlzaGVkIiwiY2hhd'
-               'CJdfQ.iVPfB_BUHk1hxV67YMiCQ6TWNHNTC1Vm4kmscDl7FYI')
+SUPER_TOKEN = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4NDM1NzU2ODg5MTIsIm'
+               'lhdCI6MTY4Nzg4MDI0NywiaXNMb2dnZWRJbiI6dHJ1ZSwic3ViIjoiYXBpVGVzdFN1c'
+               'GVyVXNlciIsImlzU3VwZXJVc2VyIjp0cnVlLCJlbnRpdGxlbWVudHMiOltdLCJwcm92'
+               'aWRlciI6Im51c3NvIiwic2NvcGVzIjpbInJlYWQ6UHVibGljIiwicmVhZDpQdWJsaXN'
+               'oZWQiLCJyZWFkOlByaXZhdGUiLCJyZWFkOlVucHVibGlzaGVkIiwiY2hhdCJdLCJpc0'
+               'luc3RpdHV0aW9uIjp0cnVlfQ.TYuYUvAamOqvBnixTbOq7QiHvDbnycwLdAcPf_R4S2o')
 TEST_TOKEN = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjQ4NDM1ODY2MDYxNjUsIml'
               'hdCI6MTY4Nzg5MTM2OSwiZW50aXRsZW1lbnRzIjpbXSwiaXNMb2dnZWRJbiI6dHJ1ZSw'
-              'ic3ViIjoidGVzdFVzZXIiLCJwcm92aWRlciI6InRlc3QiLCJhYmlsaXRpZXMiOlsicmV'
-              'hZDpQdWJsaWMiLCJyZWFkOlB1Ymxpc2hlZCIsImNoYXQiXX0.KCH-2thBdlO9wJ7keNL_'
-              'OKv0HG6ecTljH7oYPkqBtbM')
-DEV_TEAM_TOKEN = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjI1MjY1OTQ2MDcsIn'
-                  'N1YiI6ImFiYzEyMyIsImlzcyI6Im1lYWRvdyIsImlhdCI6MTcyNDk1OTUyNiwiZ'
-                  'W50aXRsZW1lbnRzIjpbXSwiaXNMb2dnZWRJbiI6dHJ1ZSwiaXNTdXBlclVzZXIi'
-                  'OmZhbHNlLCJpc0RldlRlYW0iOnRydWUsInByb3ZpZGVyIjoibnVzc28iLCJhYml'
-                  'saXRpZXMiOlsicmVhZDpQdWJsaWMiLCJyZWFkOlB1Ymxpc2hlZCIsImNoYXQiXX0'
-                  '.YbnWn0y-OkYM9aukGLCFulOUnhOUN-ZIwBt8mNfw64g')
+              'ic3ViIjoidGVzdFVzZXIiLCJwcm92aWRlciI6InRlc3QiLCJzY29wZXMiOlsicmVhZDp'
+              'QdWJsaWMiLCJyZWFkOlB1Ymxpc2hlZCIsImNoYXQiXSwiaXNJbnN0aXR1dGlvbiI6ZmF'
+              'sc2V9.WHHlVPVMs2OD4WvDpRYc8gNSDiOFJOibjKdds_fxGNA')
+DEV_TEAM_TOKEN = ('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjI1MjY1OTQ2MDcsInN'
+                  '1YiI6ImFiYzEyMyIsImlzcyI6Im1lYWRvdyIsImlhdCI6MTcyNDk1OTUyNiwiZW5'
+                  '0aXRsZW1lbnRzIjpbXSwiaXNMb2dnZWRJbiI6dHJ1ZSwiaXNTdXBlclVzZXIiOmZ'
+                  'hbHNlLCJpc0RldlRlYW0iOnRydWUsInByb3ZpZGVyIjoibnVzc28iLCJzY29wZXM'
+                  'iOlsicmVhZDpQdWJsaWMiLCJyZWFkOlB1Ymxpc2hlZCIsImNoYXQiXSwiaXNJbnN'
+                  '0aXR1dGlvbiI6dHJ1ZX0.Ew3y9acVHjbI2tzx5lMiaWBUNVmX8-g9mF1LPXL0ytU')

--- a/chat/test/handlers/test_chat.py
+++ b/chat/test/handlers/test_chat.py
@@ -5,14 +5,15 @@ import json
 import os
 import pytest
 from unittest import TestCase
-from unittest.mock import patch, MagicMock
+from unittest.mock import patch
 from moto import mock_aws
 
 from handlers import chat
+from core.apitoken import ApiToken
 from core.websocket import Websocket
 from langchain_core.language_models.fake_chat_models import FakeListChatModel
 from langgraph.checkpoint.memory import MemorySaver
-
+from test.fixtures.apitoken import TEST_SECRET, TEST_TOKEN
 
 class MockClient:
     def __init__(self):
@@ -22,80 +23,26 @@ class MockClient:
         self.received_data = Data
         return Data
 
-
 class MockContext:
     def __init__(self):
-        self.log_stream_name = "test_log_stream"
-
-
-class MockApiToken:
-    def __init__(self, logged_in=True, sub="test-user-123"):
-        self.token = {
-            "sub": sub,
-            "isLoggedIn": logged_in,
-            "isDevTeam": False,
-            "isSuperUser": False,
-            "provider": "none",
-        }
-
-    def is_logged_in(self):
-        return self.token.get("isLoggedIn", False)
-
-    def is_superuser(self):
-        return self.token.get("isSuperUser", False)
-
-    def is_dev_team(self):
-        return self.token.get("isDevTeam", False)
-
+        self.log_stream_name = 'test_log_stream'
 
 @mock_aws
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 class TestHandler(TestCase):
-    @patch("handlers.EventConfig")
-    @patch("agent.search_agent.checkpoint_saver", return_value=MemorySaver())
-    def test_handler_unauthorized(self, mock_create_saver, mock_event_config):
-        # Configure the mock to simulate unauthorized user
-        mock_config = MagicMock()
-        mock_config.is_logged_in = False
-        mock_config.is_superuser = False
-        mock_config.api_token = MockApiToken(logged_in=False, sub=None)
-        mock_event_config.return_value = mock_config
 
-        event = {
-            "socket": Websocket(
-                client=MockClient(),
-                endpoint_url="test",
-                connection_id="test",
-                ref="test",
-            )
-        }
-        self.assertEqual(
-            chat(event, MockContext()), {"statusCode": 401, "body": "Unauthorized"}
-        )
+    @patch.object(ApiToken, 'is_logged_in', return_value=False)
+    @patch('agent.search_agent.checkpoint_saver', return_value=MemorySaver())
+    def test_handler_unauthorized(self, mock_create_saver, mock_is_logged_in):
+        event = {"socket": Websocket(client=MockClient(), endpoint_url="test", connection_id="test", ref="test")}
+        self.assertEqual(chat(event, MockContext()), {'statusCode': 401, 'body': 'Unauthorized'})
 
-    @patch("handlers.EventConfig")
-    @patch("agent.search_agent.checkpoint_saver", return_value=MemorySaver())
-    @patch(
-        "handlers.chat_model",
-        return_value=FakeListChatModel(responses=["fake response"]),
-    )
-    def test_handler_success(
-        self, mock_chat_model, mock_create_saver, mock_event_config
-    ):
-        # Configure the mock to simulate authorized user
-        mock_config = MagicMock()
-        mock_config.is_logged_in = True
-        mock_config.is_superuser = False
-        mock_config.api_token = MockApiToken(logged_in=True)
-        mock_config.question = "Question?"
-        mock_config.stream_response = False
-        mock_config.forget = False
-        mock_config.docs = None
-        mock_config.ref = "test"
-        mock_config.k = 40
-        mock_config.model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
-        mock_event_config.return_value = mock_config
-
+    @patch.dict(os.environ, {"API_TOKEN_SECRET": TEST_SECRET})
+    @patch.object(ApiToken, "can", return_value=True)
+    @patch.object(ApiToken, 'is_logged_in', return_value=True)
+    @patch('agent.search_agent.checkpoint_saver', return_value=MemorySaver())
+    @patch('handlers.chat_model', return_value=FakeListChatModel(responses=["fake response"]))
+    def test_handler_success(self, mock_chat_model, mock_create_saver, mock_is_logged_in, mock_can):
         event = {
             "socket": Websocket(
                 client=MockClient(),
@@ -103,83 +50,48 @@ class TestHandler(TestCase):
                 connection_id="test",
                 ref="test",
             ),
-            "body": '{"question": "Question?"}',
+            "body": '{"question": "Question?", "auth": "%s"}' % TEST_TOKEN,
         }
-        self.assertEqual(chat(event, MockContext()), {"statusCode": 200})
+        response = chat(event, MockContext())
+        self.assertEqual(response, {'statusCode': 200})
+        mock_can.assert_called_once_with("chat")
 
-    @patch("handlers.EventConfig")
-    @patch("agent.search_agent.checkpoint_saver", return_value=MemorySaver())
-    def test_handler_question_missing(self, mock_create_saver, mock_event_config):
+    @patch.object(ApiToken, 'can', return_value=True)
+    @patch.object(ApiToken, 'is_logged_in', return_value=True)
+    @patch('agent.search_agent.checkpoint_saver', return_value=MemorySaver())
+    def test_handler_question_missing(self, mock_create_saver, mock_is_logged_in, mock_can):
         mock_client = MockClient()
-        mock_websocket = Websocket(
-            client=mock_client, endpoint_url="test", connection_id="test", ref="test"
-        )
-
-        # Configure the mock
-        mock_config = MagicMock()
-        mock_config.is_logged_in = True
-        mock_config.is_superuser = False
-        mock_config.api_token = MockApiToken()
-        mock_config.socket = mock_websocket
-        mock_config.question = None
-        mock_event_config.return_value = mock_config
-
+        mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
         event = {"socket": mock_websocket}
         chat(event, MockContext())
+        mock_can.assert_called_once_with("chat")
         response = json.loads(mock_client.received_data)
         self.assertEqual(response["type"], "error")
         self.assertEqual(response["message"], "Question cannot be blank")
 
-    @patch("handlers.EventConfig")
-    @patch("agent.search_agent.checkpoint_saver", return_value=MemorySaver())
-    def test_handler_question_typo(self, mock_create_saver, mock_event_config):
+    @patch.object(ApiToken, "can", return_value=True)
+    @patch.object(ApiToken, 'is_logged_in', return_value=True)
+    @patch('agent.search_agent.checkpoint_saver', return_value=MemorySaver())
+    def test_handler_question_typo(self, mock_create_saver, mock_is_logged_in, mock_can):
         mock_client = MockClient()
-        mock_websocket = Websocket(
-            client=mock_client, endpoint_url="test", connection_id="test", ref="test"
-        )
-
-        # Configure the mock
-        mock_config = MagicMock()
-        mock_config.is_logged_in = True
-        mock_config.is_superuser = False
-        mock_config.api_token = MockApiToken()
-        mock_config.socket = mock_websocket
-        mock_config.question = ""
-        mock_event_config.return_value = mock_config
-
+        mock_websocket = Websocket(client=mock_client, endpoint_url="test", connection_id="test", ref="test")
         event = {"socket": mock_websocket, "body": '{"quesion": ""}'}
         chat(event, MockContext())
+        mock_can.assert_called_once_with("chat")
         response = json.loads(mock_client.received_data)
         self.assertEqual(response["type"], "error")
         self.assertEqual(response["message"], "Question cannot be blank")
 
+    @patch.dict(os.environ, {"API_TOKEN_SECRET": TEST_SECRET})
     @patch.dict(os.environ, {"METRICS_LOG_GROUP": "/nul/test/metrics/log/group"})
-    @patch("handlers.EventConfig")
-    @patch("agent.search_agent.checkpoint_saver", return_value=MemorySaver())
-    @patch(
-        "handlers.chat_model",
-        return_value=FakeListChatModel(responses=["fake response"]),
-    )
-    def test_handler_with_metrics(
-        self, mock_model, mock_create_saver, mock_event_config
-    ):
+    @patch.object(ApiToken, "can", return_value=True)
+    @patch.object(ApiToken, 'is_logged_in', return_value=True)
+    @patch('agent.search_agent.checkpoint_saver', return_value=MemorySaver())
+    @patch('handlers.chat_model', return_value=FakeListChatModel(responses=["fake response"]))
+    def test_handler_with_metrics(self, mock_model, mock_create_saver, mock_is_logged_in, mock_can):
         client = boto3.client("logs", region_name="us-east-1")
         client.create_log_group(logGroupName=os.getenv("METRICS_LOG_GROUP"))
-
-        # Configure the mock
-        mock_config = MagicMock()
-        mock_config.is_logged_in = True
-        mock_config.is_superuser = False
-        mock_config.api_token = MockApiToken()
-        mock_config.question = "Question?"
-        mock_config.stream_response = False
-        mock_config.forget = False
-        mock_config.docs = None
-        mock_config.ref = "test"
-        mock_config.k = 40
-        mock_config.model = "us.anthropic.claude-3-5-sonnet-20241022-v2:0"
-        mock_event_config.return_value = mock_config
-
+        
         event = {
             "socket": Websocket(
                 client=MockClient(),
@@ -187,19 +99,20 @@ class TestHandler(TestCase):
                 connection_id="test",
                 ref="test",
             ),
-            "body": '{"question": "Question?", "ref": "test"}',
+            "body": '{"question": "Question?", "ref": "test", "auth": "%s"}' % TEST_TOKEN,
         }
         chat(event, MockContext())
-        chat(event, MockContext())  # Second call to test if log stream already exists
+        chat(event, MockContext()) # Second call to test if log stream already exists
 
         response = client.get_log_events(
-            logGroupName="/nul/test/metrics/log/group", logStreamName="test_log_stream"
+            logGroupName="/nul/test/metrics/log/group",
+            logStreamName="test_log_stream"
         )
         expected = {
             "answer": ["fake response"],
             "artifacts": [],
             "user": {
-                "auth_provider": "none",
+                "auth_provider": "test",
                 "is_dev_team": False,
                 "is_superuser": False,
             },
@@ -207,7 +120,7 @@ class TestHandler(TestCase):
             "model": "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
             "question": "Question?",
             "ref": "test",
-            "token_counts": {},
+            "token_counts": {}
         }
         log_events = response["events"]
         self.assertEqual(len(log_events), 2)

--- a/chat/test/handlers/test_chat_sync.py
+++ b/chat/test/handlers/test_chat_sync.py
@@ -63,10 +63,8 @@ class TestHandler(TestCase):
             "artifacts": [],
             "token_counts": {},
         }
-        response = chat_sync(
-            {"body": '{"question": "Question?", "ref": "test_ref"}'}, MockContext()
-        )
-
+        response = chat_sync({"body": '{"question": "Question?", "ref": "test_ref"}'}, MockContext())
+        
         self.assertEqual(json.loads(response.get("body")), expected_body)
         self.assertEqual(response.get("statusCode"), 200)
         self.assertEqual(

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -8,7 +8,7 @@ Check out the [OpenAPI specification page](./spec.md) for detailed descriptions 
 
 ### Application Programming Interfaces (APIs)
 
-An API allows end users to interact with the data stored in the Digital Collections in a structured and programmatic way, which makes it possible to integrate the data into own applications and workflows. Most programming languages and frameworks provide the ability to send and receive information using HTTP requests. The Northwestern University Libraries Digital Collections API is designed with flexibility in mind and works with a wide range of programming languages and frameworks.
+An API allows end users to interact with the data stored in the Digital Collections in a structured and programmatic way, which makes it possible to integrate the data into own applications and workflows. Most programming languages and frameworks provide the scope to send and receive information using HTTP requests. The Northwestern University Libraries Digital Collections API is designed with flexibility in mind and works with a wide range of programming languages and frameworks.
 
 Our API allows developers to access the data in the Digital Collections API by sending HTTP requests and receiving responses in a format that can be parsed and processed by the application. This makes it simple to fetch and process data, reshaping the data if necessary for integration into your application or project. The API also allows developers to authenticate and authorize their requests using standard protocols such as OAuth, but for now this feature is internal (check back for future updates on authentication/authorization!).
 
@@ -78,7 +78,7 @@ Working with a REST (Representational State Transfer) API is a common method for
 
 ## OpenSearch
 
-We use [OpenSearch](https://opensearch.org) to provide the search functionality behind our API. One of the key advantages of using a tool like OpenSearch is the ability to perform advanced searches using tokenization, custom queries, and aggregations. Tokenization allows for the search engine to break down text into smaller units, or tokens, for more precise searching. This allows users to search for specific words or phrases within the digital collections. Custom queries allow users to create more complex searches using Boolean operators and other advanced search features. Aggregations provide the ability to group results by specific fields, such as by creator or subject, allowing users to quickly filter and analyze large sets of data. With range queries, users can perform searches based on specific numerical or date ranges, such as finding all resources that were created between two specific dates. This is particularly useful when searching large datasets. See the [OpenSearch documentation](https://opensearch.org/docs/latest/) for more information about using OpenSearch's many features.
+We use [OpenSearch](https://opensearch.org) to provide the search functionality behind our API. One of the key advantages of using a tool like OpenSearch is the scope to perform advanced searches using tokenization, custom queries, and aggregations. Tokenization allows for the search engine to break down text into smaller units, or tokens, for more precise searching. This allows users to search for specific words or phrases within the digital collections. Custom queries allow users to create more complex searches using Boolean operators and other advanced search features. Aggregations provide the scope to group results by specific fields, such as by creator or subject, allowing users to quickly filter and analyze large sets of data. With range queries, users can perform searches based on specific numerical or date ranges, such as finding all resources that were created between two specific dates. This is particularly useful when searching large datasets. See the [OpenSearch documentation](https://opensearch.org/docs/latest/) for more information about using OpenSearch's many features.
 
 ### Example
 
@@ -342,7 +342,7 @@ The `?as=iiif` parameter in the API allows users to retrieve resources as IIIF m
 
 Additionally, IIIF manifests provide a rich set of metadata that can be used to improve the user experience, such as captions, translations, and descriptions. This metadata can be displayed in the front-end interface to provide users with more context and information about the images they are viewing.
 
-One of the primary benefits of using IIIF is the ability to easily access and manipulate images and other multimedia resources solely making HTTP requests. The IIIF specification makes allowances for cropping, rotation, and zooming in a standardized way. This allows users to easily access, manipulate, and display images in a consistent way across different applications that implement the specification.
+One of the primary benefits of using IIIF is the scope to easily access and manipulate images and other multimedia resources solely making HTTP requests. The IIIF specification makes allowances for cropping, rotation, and zooming in a standardized way. This allows users to easily access, manipulate, and display images in a consistent way across different applications that implement the specification.
 
 ### Example
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -27,7 +27,7 @@ plugins:
   - render_swagger:
       allow_arbitrary_locations : true
 markdown_extensions:
-  - admonition #adds ability to have custom highlight boxes with !!!
+  - admonition #adds scope to have custom highlight boxes with !!!
   - codehilite:
       guess_lang: false
   - def_list


### PR DESCRIPTION
In order to make sure authorization logic is consistent across the entire codebase (including between the NodeJS and Python parts), I moved all of the decisionmaking to a new `scopes` module, which adds scopes to the token depending on what the current user can and cannot do. The parts of the code that used to do their own logic (`authorize-document`, `pipeline`, and the chat handlers) now just need to make a call like `token.can("read:Private")` or `token.can("chat")`. And since the abilities travel with the token, the python side of the code and the front end don't need to replicate any of the logic about who can or cannot use the chat.