### PR TITLE
Add provider capability check for login when delegating to auth module

### DIFF
--- a/api/src/handlers/auth/magic-login.js
+++ b/api/src/handlers/auth/magic-login.js
@@ -1,4 +1,4 @@
-const { dcApiEndpoint, dcUrl } = require("../../environment");
+const { dcApiEndpoint } = require("../../environment");
 const { createMagicToken } = require("./magic-link");
 const { SESClient, SendTemplatedEmailCommand } = require("@aws-sdk/client-ses");
 

--- a/api/src/handlers/auth/nusso-callback.js
+++ b/api/src/handlers/auth/nusso-callback.js
@@ -1,5 +1,6 @@
 const axios = require("axios").default;
 const cookie = require("cookie");
+const { dcApiEndpoint } = require("../../environment");
 const ApiToken = require("../../api/api-token");
 const Honeybadger = require("../../honeybadger-setup");
 
@@ -10,10 +11,14 @@ const BAD_DIRECTORY_SEARCH_FAULT =
  * NUSSO auth callback
  */
 exports.handler = async (event) => {
-  const returnPath = Buffer.from(
-    decodeURIComponent(event.cookieObject.redirectUrl),
-    "base64"
-  ).toString("utf8");
+  let returnPath = `${dcApiEndpoint()}/auth/whoami`;
+  const redirectUrl = event.cookieObject.redirectUrl;
+  if (redirectUrl) {
+    returnPath = Buffer.from(
+      decodeURIComponent(event.cookieObject.redirectUrl),
+      "base64"
+    ).toString("utf8");
+  }
 
   const user = await redeemSsoToken(event);
   if (user) {

--- a/api/src/handlers/get-auth-stage.js
+++ b/api/src/handlers/get-auth-stage.js
@@ -1,10 +1,31 @@
 const { wrap } = require("./middleware");
+const { ProviderCapabilities } = require("../environment");
 
 const DEFAULT_PROVIDER = "nusso";
 
 exports.handler = wrap(async (event, context) => {
   const provider = event.pathParameters.provider || DEFAULT_PROVIDER;
   const stage = event.pathParameters.stage || "login";
+
+  const capabilities = ProviderCapabilities();
+  if (!capabilities[provider]) {
+    return {
+      statusCode: 404,
+      body: JSON.stringify({
+        error: `Unknown provider: '${provider}'`,
+      }),
+    };
+  }
+
+  if (!capabilities[provider].includes("login")) {
+    return {
+      statusCode: 404,
+      body: JSON.stringify({
+        error: `Login not enabled for provider '${provider}'`,
+      }),
+    };
+  }
+
   try {
     const providerModule = `./auth/${provider}-${stage}`;
     console.info("Delegating to provider module:", providerModule);

--- a/api/test/integration/auth/magic.test.js
+++ b/api/test/integration/auth/magic.test.js
@@ -120,3 +120,22 @@ describe("Magic link callback", () => {
     expect(body).to.have.property("error", "Token expired");
   });
 });
+
+describe("auth login with Magic Link disabled", function () {
+  helpers.saveEnvironment();
+
+  beforeEach(() => {
+    process.env.PROVIDER_CAPABILITIES =
+      '{"magic":[],"nusso":["chat", "login"]}';
+  });
+
+  it("returns a 404 when Magic Link is disabled", async () => {
+    const event = helpers
+      .mockEvent("GET", "/auth/login/magic")
+      .pathParams({ provider: "magic", stage: "login" })
+      .render();
+
+    const result = await handler(event);
+    expect(result.statusCode).to.eq(404);
+  });
+});

--- a/api/test/test-helpers/index.js
+++ b/api/test/test-helpers/index.js
@@ -18,7 +18,8 @@ const TestEnvironment = {
   WEBSOCKET_URI: "wss://thisisafakewebsocketapiurl",
   CHAT_FEEDBACK_BUCKET: "test-chat-feedback-bucket",
   DEFAULT_SEARCH_SIZE: "10",
-  PROVIDER_CAPABILITIES: '{"magic":["chat"],"nusso":["chat"]}',
+  PROVIDER_CAPABILITIES:
+    '{"magic":["chat", "login"],"nusso":["chat", "login"]}',
 };
 
 for (const v in TestEnvironment) delete process.env[v];

--- a/bin/make_deploy_config.sh
+++ b/bin/make_deploy_config.sh
@@ -79,6 +79,7 @@ for section in deploy sync; do
         MediaConvertRoleArn="arn:aws:iam::${aws_account_id}:role/service-role/MediaConvert_Default_Role"
         NussoApiKey="$(jq -r '.api_key' <<< $nusso_config)"
         NussoBaseUrl="$(jq -r '.base_url' <<< $nusso_config)"
+        ProviderCapabilities='{"magic":["chat", "login"],"nusso":["chat", "login"]}'
         PyramidBucket="${DEV_PREFIX}-${DEV_ENV}-pyramids"
         ReadingRoomIPs=""
         RepositoryEmail="repository@northwestern.edu"


### PR DESCRIPTION
- Check to make sure provider is configured to login in auth login and callback handlers
- Properly handle callback when there's no redirect URL (which has been resulting in the redirect URL ending in `�w^~)�`)
- Add `ProviderCapabilities` variable to `make samconfig.*.toml` helper
- Fix some linter style complaints

To test:
- Add a `PROVIDER_CAPABILITIES` config to your `env.json`
- Run `make serve`