### PR TITLE
Add "No title" string for Manifests with title as `null`.

### DIFF
--- a/api/src/api/response/iiif/collection.js
+++ b/api/src/api/response/iiif/collection.js
@@ -178,7 +178,7 @@ function loadItem(item, itemType, size) {
         },
       ],
       label: {
-        none: [`${item.title}`],
+        none: [`${item.title || "No title"}`],
       },
       summary: {
         none: [`${item.work_type}`],

--- a/api/src/api/response/iiif/manifest.js
+++ b/api/src/api/response/iiif/manifest.js
@@ -68,7 +68,7 @@ function transform(response) {
         }
 
         /** Build out manifest descriptive properties */
-        manifest.addLabel(source.title, "none");
+        manifest.addLabel(source.title || "No title", "none");
         source.description.length > 0 &&
           manifest.addSummary(source.description, "none");
 


### PR DESCRIPTION
## What does this do?

Adds an OR to determine Work `title` is falsy (`null`) and return the fallback value of "No title" for Manifests labels. This occurs on both Manifest resources and the Collection items listing.

https://mat.dev.rdc.library.northwestern.edu:3002/search?q=%2280b4b209-88d3-4e07-9890-9a4fdaef5c46%22&as=iiif