### PR TITLE
SearchAgentState manages facets for LLM context awareness

### DIFF
--- a/chat/test/agent/test_search_workflow.py
+++ b/chat/test/agent/test_search_workflow.py
@@ -3,7 +3,7 @@ from langchain_core.messages.base import BaseMessage
 from langchain_core.messages.system import SystemMessage
 from langgraph.graph import END
 
-from agent.search_agent import SearchWorkflow
+from agent.search_agent import SearchWorkflow, SearchAgentState
 
 
 class FakeMessage(BaseMessage):
@@ -26,28 +26,50 @@ class TestSearchWorkflow(unittest.TestCase):
         )
 
     def test_should_continue_with_tool_calls(self):
-        state = {
-            "messages": [
-                FakeMessage(content="Hello"),
-                FakeMessage(content="Calling tool", tool_calls=["test_tool"]),
-            ]
-        }
+        state = SearchAgentState(messages=[
+            FakeMessage(content="Hello"),
+            FakeMessage(content="Calling tool", tool_calls=["test_tool"]),
+        ])
         result = self.workflow.should_continue(state)
         self.assertEqual(result, "tools")
 
     def test_should_continue_without_tool_calls(self):
-        state = {
-            "messages": [
-                FakeMessage(content="Hello"),
-                FakeMessage(content="No tool calls here"),
-            ]
-        }
+        state = SearchAgentState(messages=[
+            FakeMessage(content="Hello"),
+            FakeMessage(content="No tool calls here"),
+        ])
         result = self.workflow.should_continue(state)
         self.assertEqual(result, END)
 
     def test_call_model(self):
-        state = {"messages": [FakeMessage(content="User input")]}
+        state = SearchAgentState(messages=[FakeMessage(content="User input")])
         result = self.workflow.call_model(state)
         self.assertIn("messages", result)
         self.assertEqual(len(result["messages"]), 1)
         self.assertEqual(result["messages"][0].content, "Mock Response")
+
+    def test_call_model_with_facets(self):
+        facets = [{"subject.label": "Nigeria"}, {"collection.title.keyword": "Test Collection"}]
+        state = SearchAgentState(
+            messages=[FakeMessage(content="User input")],
+            facets=facets
+        )
+        result = self.workflow.call_model(state)
+        self.assertIn("messages", result)
+        self.assertEqual(len(result["messages"]), 1)
+        self.assertEqual(result["messages"][0].content, "Mock Response")
+
+    def test_create_facets_context(self):
+        facets = [
+            {"subject.label": ["Nigeria", "Ghana"]},
+            {"collection.title.keyword": "E. H. Duckworth Photograph Collection"},
+            {"work_type.keyword": "Image"}
+        ]
+        
+        context = self.workflow._create_facets_context(facets)
+        
+        self.assertIn("IMPORTANT CONTEXT", context)
+        self.assertIn("Subject: Nigeria, Ghana", context)
+        self.assertIn("Collection.Title: E. H. Duckworth Photograph Collection", context)
+        self.assertIn("Work Type: Image", context)
+        self.assertIn("Do NOT attempt to broaden", context)


### PR DESCRIPTION
- `SearchAgent` becomes facets-aware state management via `SearchAgentState` extension
- Facets context added to prompt templates for LLM awareness of applied filters

Example connecting to the `dc-api-prototype` stack via WebSockets for testing :

```json
{
  "message": "{{DEFAULT_MESSAGE}}",
  "auth":
    "{{FOREVER_USER_TOKEN}}",
  "ref": "abc123",
  "forget": true,
  "question": "What are the current facets in the search context?",
  "facets": [
    {"subject.label": "Nigeria"},
    {"collection.title.keyword": "E. H. Duckworth Photograph Collection"},
    {"work_type.keyword": "Image"}
  ]
}

```

```json
{
    "type": "answer",
    "ref": "abc123",
    "message": "According to the provided context, the search is currently filtered with these facets:\n\n1. Subject: \"Nigeria\"\n2. Collection Title: \"E. H. Duckworth Photograph Collection\"\n3. Work Type: \"Image\"\n\nThese filters are actively scoping all search results to show only photographic images from the E. H. Duckworth collection that are related to Nigeria."
}
```