### PR TITLE
Use public-read for av-download links

### DIFF
--- a/av-download/template.yaml
+++ b/av-download/template.yaml
@@ -442,7 +442,7 @@ Resources:
             - Sid: BucketAccess
               Effect: Allow
               Action:
-                - s3:GetObject
+                - s3:PutObjectAcl
               Resource: !Sub "arn:aws:s3:::${MediaConvertDestinationBucket}/*"
   sendTemplatedEmailFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
- Set target of download link to public-read instead of using a signed URL
- Depend on bucket expiration rules to limit access to 3 days