### PR TITLE
Add undocumented `as=_explain` to inspect the filtered query

### DIFF
--- a/api/src/handlers/search-runner.js
+++ b/api/src/handlers/search-runner.js
@@ -65,10 +65,24 @@ const doSearch = async (event, searchParams = {}) => {
     .authFilter(event)
     .toJson();
 
+  const searchModels = modelsToTargets(models);
+  const searchQuery = sanitizeQueryString(event.queryStringParameters);
+
+  if (format === "_explain") {
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        models: searchModels,
+        body: JSON.parse(filteredSearchContext),
+        query: searchQuery,
+      }),
+    };
+  }
+
   const esResponse = await search(
-    modelsToTargets(models),
+    searchModels,
     filteredSearchContext,
-    sanitizeQueryString(event.queryStringParameters)
+    searchQuery
   );
 
   return await responseTransformer.transformSearchResult(esResponse, pager);

--- a/api/test/integration/search.test.js
+++ b/api/test/integration/search.test.js
@@ -262,5 +262,25 @@ describe("Search routes", () => {
         "?_source_includes=title%2Caccession_number"
       );
     });
+
+    it("returns the query when as=_explain is specified", async () => {
+      const originalQuery = {
+        query: { query_string: { query: "*" } },
+      };
+      const event = helpers
+        .mockEvent("GET", "/search")
+        .queryParams({ as: "_explain" })
+        .render();
+      const authQuery = new RequestPipeline(originalQuery)
+        .authFilter(helpers.preprocess(event))
+        .toJson();
+      const expectedQuery = JSON.parse(authQuery);
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+      const resultBody = JSON.parse(result.body);
+      expect(resultBody.models).to.eq("dc-v2-work");
+      expect(resultBody.body).to.deep.equal(expectedQuery);
+    });
   });
 });


### PR DESCRIPTION
Adds `_explain` as a valid response format to return the query with auth filters added instead of executing the query and returning results.

Example:
```
POST /search/works?as=_explain
Content-Type: application/json

{
  "query": {
    "neural": {
      "embedding": {
        "query_text": "baseball negatives",
        "k": 10
      }
    }
  }
}
```

```json
{
  "models": "mbk-dev-dc-v2-work",
  "body": {
    "from": 0,
    "query": {
      "neural": {
        "embedding": {
          "filter": {
            "bool": {
              "filter": [
                {
                  "terms": {
                    "published": [
                      true
                    ]
                  }
                },
                {
                  "terms": {
                    "visibility": [
                      "Institution",
                      "Public"
                    ]
                  }
                }
              ]
            }
          },
          "k": 10,
          "model_id": "TJqjgZUBz6P6wl85sCAv",
          "query_text": "baseball negatives"
        }
      }
    },
    "size": 10,
    "track_total_hits": true
  }
}
```