### PR TITLE
Fix bug in neural query auth filter

### DIFF
--- a/api/src/api/request/pipeline.js
+++ b/api/src/api/request/pipeline.js
@@ -34,10 +34,10 @@ function addFilter(query, filter) {
     result.bool.filter.push(...filter);
   } else if (result.neural) {
     const boolFilter = { bool: { filter: filter } };
-    if (result.neural.filter) {
-      boolFilter.bool.filter.push(result.neural.filter);
-    }
     const neuralField = Object.keys(result.neural)[0];
+    if (result.neural[neuralField].filter) {
+      boolFilter.bool.filter.push(result.neural[neuralField].filter);
+    }
     result.neural[neuralField].filter = boolFilter;
   } else if (result.hybrid) {
     result.hybrid.queries = result.hybrid.queries.map((subQuery) =>

--- a/api/test/unit/api/request/pipeline.test.js
+++ b/api/test/unit/api/request/pipeline.test.js
@@ -114,6 +114,57 @@ describe("RequestPipeline", () => {
     });
   });
 
+  describe("neural", () => {
+    it("applies the filter to a neural query", () => {
+      event.userToken = new ApiToken();
+      requestBody.query = {
+        neural: {
+          embedding: {
+            query_text:
+              "Do you have any materials related to testing the request pipeline?",
+            model_id: "MODEL_ID",
+            k: 5,
+          },
+        },
+      };
+      pipeline = new RequestPipeline(requestBody);
+      const result = pipeline.authFilter(event);
+      expect(result.searchContext.size).to.eq(50);
+      expect(result.searchContext.query.neural.embedding).to.deep.include(
+        requestBody.query.neural.embedding
+      );
+      expect(
+        result.searchContext.query.neural.embedding.filter.bool.filter.length
+      ).to.eq(2);
+    });
+
+    it("adds to an existing neural query filter", () => {
+      event.userToken = new ApiToken();
+      requestBody.query = {
+        neural: {
+          embedding: {
+            filter: {
+              term: { "visibility.keyword": "Public" },
+            },
+            query_text:
+              "Do you have any materials related to testing the request pipeline?",
+            model_id: "MODEL_ID",
+            k: 5,
+          },
+        },
+      };
+      pipeline = new RequestPipeline(requestBody);
+      const result = pipeline.authFilter(event);
+      expect(result.searchContext.size).to.eq(50);
+      expect(result.searchContext.query.neural.embedding).to.deep.include(
+        requestBody.query.neural.embedding
+      );
+      expect(
+        result.searchContext.query.neural.embedding.filter.bool.filter.length
+      ).to.eq(3);
+    });
+  });
+
   describe("hybrid", () => {
     it("applies the filter to all subqueries", () => {
       event.userToken = new ApiToken();


### PR DESCRIPTION
Add the neural query filter to the neural[field] (e.g., `{"neural": {"embedding": {"filter": {...}}}`) instead of at the top level (`{"neural": {"filter": {...}}`)