### PR TITLE
Deploy v2.9.5 to production

### DIFF
--- a/api/dependencies/package-lock.json
+++ b/api/dependencies/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-api-dependencies",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-api-dependencies",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "^2.0.1",

--- a/api/dependencies/package.json
+++ b/api/dependencies/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api-dependencies",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "NUL Digital Collections API Dependencies",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-api-build",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-api-build",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api-build",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "NUL Digital Collections API Build Environment",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/api/src/api/request/pipeline.js
+++ b/api/src/api/request/pipeline.js
@@ -34,10 +34,10 @@ function addFilter(query, filter) {
     result.bool.filter.push(...filter);
   } else if (result.neural) {
     const boolFilter = { bool: { filter: filter } };
-    if (result.neural.filter) {
-      boolFilter.bool.filter.push(result.neural.filter);
-    }
     const neuralField = Object.keys(result.neural)[0];
+    if (result.neural[neuralField].filter) {
+      boolFilter.bool.filter.push(result.neural[neuralField].filter);
+    }
     result.neural[neuralField].filter = boolFilter;
   } else if (result.hybrid) {
     result.hybrid.queries = result.hybrid.queries.map((subQuery) =>

--- a/api/src/handlers/search-runner.js
+++ b/api/src/handlers/search-runner.js
@@ -65,10 +65,24 @@ const doSearch = async (event, searchParams = {}) => {
     .authFilter(event)
     .toJson();
 
+  const searchModels = modelsToTargets(models);
+  const searchQuery = sanitizeQueryString(event.queryStringParameters);
+
+  if (format === "_explain") {
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        models: searchModels,
+        body: JSON.parse(filteredSearchContext),
+        query: searchQuery,
+      }),
+    };
+  }
+
   const esResponse = await search(
-    modelsToTargets(models),
+    searchModels,
     filteredSearchContext,
-    sanitizeQueryString(event.queryStringParameters)
+    searchQuery
   );
 
   return await responseTransformer.transformSearchResult(esResponse, pager);

--- a/api/src/package-lock.json
+++ b/api/src/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dc-api",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dc-api",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "^2.0.1",

--- a/api/src/package.json
+++ b/api/src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dc-api",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "NUL Digital Collections API",
   "repository": "https://github.com/nulib/dc-api-v2",
   "author": "nulib",

--- a/api/test/integration/search.test.js
+++ b/api/test/integration/search.test.js
@@ -262,5 +262,25 @@ describe("Search routes", () => {
         "?_source_includes=title%2Caccession_number"
       );
     });
+
+    it("returns the query when as=_explain is specified", async () => {
+      const originalQuery = {
+        query: { query_string: { query: "*" } },
+      };
+      const event = helpers
+        .mockEvent("GET", "/search")
+        .queryParams({ as: "_explain" })
+        .render();
+      const authQuery = new RequestPipeline(originalQuery)
+        .authFilter(helpers.preprocess(event))
+        .toJson();
+      const expectedQuery = JSON.parse(authQuery);
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+      const resultBody = JSON.parse(result.body);
+      expect(resultBody.models).to.eq("dc-v2-work");
+      expect(resultBody.body).to.deep.equal(expectedQuery);
+    });
   });
 });

--- a/api/test/unit/api/request/pipeline.test.js
+++ b/api/test/unit/api/request/pipeline.test.js
@@ -114,6 +114,57 @@ describe("RequestPipeline", () => {
     });
   });
 
+  describe("neural", () => {
+    it("applies the filter to a neural query", () => {
+      event.userToken = new ApiToken();
+      requestBody.query = {
+        neural: {
+          embedding: {
+            query_text:
+              "Do you have any materials related to testing the request pipeline?",
+            model_id: "MODEL_ID",
+            k: 5,
+          },
+        },
+      };
+      pipeline = new RequestPipeline(requestBody);
+      const result = pipeline.authFilter(event);
+      expect(result.searchContext.size).to.eq(50);
+      expect(result.searchContext.query.neural.embedding).to.deep.include(
+        requestBody.query.neural.embedding
+      );
+      expect(
+        result.searchContext.query.neural.embedding.filter.bool.filter.length
+      ).to.eq(2);
+    });
+
+    it("adds to an existing neural query filter", () => {
+      event.userToken = new ApiToken();
+      requestBody.query = {
+        neural: {
+          embedding: {
+            filter: {
+              term: { "visibility.keyword": "Public" },
+            },
+            query_text:
+              "Do you have any materials related to testing the request pipeline?",
+            model_id: "MODEL_ID",
+            k: 5,
+          },
+        },
+      };
+      pipeline = new RequestPipeline(requestBody);
+      const result = pipeline.authFilter(event);
+      expect(result.searchContext.size).to.eq(50);
+      expect(result.searchContext.query.neural.embedding).to.deep.include(
+        requestBody.query.neural.embedding
+      );
+      expect(
+        result.searchContext.query.neural.embedding.filter.bool.filter.length
+      ).to.eq(3);
+    });
+  });
+
   describe("hybrid", () => {
     it("applies the filter to all subqueries", () => {
       event.userToken = new ApiToken();

--- a/av-download/lambdas/package-lock.json
+++ b/av-download/lambdas/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "lambdas",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "lambdas",
-      "version": "2.9.4",
+      "version": "2.9.5",
       "license": "Apache-2.0",
       "dependencies": {
         "fluent-ffmpeg": "2.1.3"

--- a/av-download/lambdas/package.json
+++ b/av-download/lambdas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lambdas",
-  "version": "2.9.4",
+  "version": "2.9.5",
   "description": "Non-API handler lambdas",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/chat/pyproject.toml
+++ b/chat/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dc-api-v2-chat"
-version = "2.9.4"
+version = "2.9.5"
 requires-python = ">=3.12"
 dependencies = [
   "boto3~=1.34",

--- a/chat/uv.lock
+++ b/chat/uv.lock
@@ -302,7 +302,7 @@ wheels = [
 
 [[package]]
 name = "dc-api-v2-chat"
-version = "2.9.4"
+version = "2.9.5"
 source = { virtual = "." }
 dependencies = [
     { name = "boto3" },

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dc-api-v2-docs"
-version = "2.9.4"
+version = "2.9.5"
 requires-python = ">=3.12"
 dependencies = [
   "mkdocs>=1.1.2,<2.0.0",

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -123,7 +123,7 @@ wheels = [
 
 [[package]]
 name = "dc-api-v2-docs"
-version = "2.9.4"
+version = "2.9.5"
 source = { virtual = "." }
 dependencies = [
     { name = "diagrams" },


### PR DESCRIPTION
# :open_book: Changelog

- Add undocumented `as=_explain` response format
- Add the neural query filter to the neural[field] instead of at the top level

# Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

# :rocket: Deployment Notes

- Backward compatible API changes
  - [x] REST API
  - [ ] Chat Websocket API
- Backwards-incompatible API changes
  - [ ] REST API
  - [ ] Chat Websocket API
- [ ] Specific deployment synchronization instructions with other apps/API's
- [ ] Other specific instructions/tasks