### PR TITLE
Implement IIIF Content Search 2.0 at `/works/{id}/search`

### DIFF
--- a/api/src/api/opensearch.js
+++ b/api/src/api/opensearch.js
@@ -27,6 +27,7 @@ async function getWorkFileSets(workId, opts = {}) {
   const {
     allowPrivate = false,
     allowUnpublished = false,
+    annotationsQuery = null,
     role = null,
     source = null,
     sortBy = null,
@@ -51,6 +52,9 @@ async function getWorkFileSets(workId, opts = {}) {
   const mustClauses = [{ term: { work_id: workId } }];
   if (role) {
     mustClauses.push({ term: { role: role } });
+  }
+  if (annotationsQuery) {
+    mustClauses.push({ match: { "annotations.content": annotationsQuery } });
   }
 
   const searchBody = {

--- a/api/src/api/response/iiif/manifest.js
+++ b/api/src/api/response/iiif/manifest.js
@@ -368,6 +368,12 @@ async function transform(response, options = {}) {
       }
     }
 
+    jsonManifest.service = [
+      {
+        id: `${dcApiEndpoint()}/works/${source.id}/search?as=iiif`,
+        type: "SearchService2",
+      },
+    ];
     jsonManifest.provider = [provider];
     jsonManifest.logo = [nulLogo];
     const navPlace = buildNavPlace(source);

--- a/api/src/api/response/iiif/presentation-api/items.js
+++ b/api/src/api/response/iiif/presentation-api/items.js
@@ -157,8 +157,10 @@ module.exports = {
   buildImageService,
   buildSupplementingAnnotation,
   buildTranscriptionAnnotation,
+  getTranscriptionContent,
   isAltFormat,
   isAudioVideo,
   isImage,
   isPDF,
+  normalizeLanguages,
 };

--- a/api/src/api/response/iiif/search.js
+++ b/api/src/api/response/iiif/search.js
@@ -1,0 +1,103 @@
+const { dcApiEndpoint } = require("../../../environment");
+const { getWorkFileSets } = require("../../opensearch");
+const {
+  getTranscriptionContent,
+  normalizeLanguages,
+} = require("./presentation-api/items");
+
+function extractSnippet(content, q, contextChars = 100) {
+  const idx = content.toLowerCase().indexOf(q.toLowerCase());
+  if (idx === -1) return null;
+  const start = Math.max(0, idx - contextChars);
+  const end = Math.min(content.length, idx + q.length + contextChars);
+  let snippet = content.slice(start, end).trim();
+  if (start > 0) snippet = "..." + snippet;
+  if (end < content.length) snippet = snippet + "...";
+  return snippet;
+}
+
+function buildSearchAnnotationBody(annotation, snippet) {
+  const body = {
+    type: "TextualBody",
+    value: snippet,
+    format: "text/plain",
+  };
+  const languages = normalizeLanguages(annotation.language);
+  if (languages.length === 1) {
+    body.language = languages[0];
+  } else if (languages.length > 1) {
+    body.language = languages;
+  }
+  return body;
+}
+
+async function transform(workId, q, opts = {}) {
+  const { allowPrivate = false, allowUnpublished = false } = opts;
+
+  const manifestId = `${dcApiEndpoint()}/works/${workId}?as=iiif`;
+  const searchId = `${dcApiEndpoint()}/works/${workId}/search?as=iiif&q=${encodeURIComponent(
+    q
+  )}`;
+
+  const response = await getWorkFileSets(workId, {
+    allowPrivate,
+    allowUnpublished,
+    annotationsQuery: q,
+    role: "Access",
+    source: ["id", "annotations", "group_with"],
+    sortBy: "rank",
+  });
+
+  const fileSets =
+    response.statusCode === 200
+      ? JSON.parse(response.body).hits.hits.map((h) => h._source)
+      : [];
+
+  // Replicate manifest.js grouping: ungrouped file sets use their own id as key
+  const fileSetGroups = {};
+  fileSets.forEach((fs) => {
+    const key = fs.group_with || fs.id;
+    if (!fileSetGroups[key]) fileSetGroups[key] = [];
+    fileSetGroups[key].push(fs);
+  });
+
+  const items = [];
+
+  Object.entries(fileSetGroups).forEach(([groupKey, groupFileSets], index) => {
+    const canvasId = `${manifestId}/canvas/${index}`;
+
+    // Primary file set is the one whose id matches the group key (same as manifest.js)
+    const primary =
+      groupFileSets.find((fs) => fs.id === groupKey) || groupFileSets[0];
+    if (!primary?.annotations) return;
+
+    primary.annotations
+      .filter((ann) => ann.type === "transcription")
+      .forEach((ann) => {
+        const content = getTranscriptionContent(ann);
+        const snippet = extractSnippet(content, q);
+        if (!snippet) return;
+
+        items.push({
+          id: `${canvasId}/annotation/${ann.id}`,
+          type: "Annotation",
+          motivation: "supplementing",
+          body: buildSearchAnnotationBody(ann, snippet),
+          target: canvasId,
+        });
+      });
+  });
+
+  return {
+    statusCode: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      "@context": "http://iiif.io/api/search/2/context.json",
+      id: searchId,
+      type: "AnnotationPage",
+      items,
+    }),
+  };
+}
+
+module.exports = { transform };

--- a/api/src/handlers/get-work-search.js
+++ b/api/src/handlers/get-work-search.js
@@ -1,0 +1,32 @@
+const { getWork } = require("../api/opensearch");
+const iiifSearchResponse = require("../api/response/iiif/search");
+const { wrap } = require("./middleware");
+
+exports.handler = wrap(async (event) => {
+  const id = event.pathParameters.id;
+  const { as, q } = event.queryStringParameters;
+
+  const allowPrivate =
+    event.userToken.isSuperUser() ||
+    event.userToken.isReadingRoom() ||
+    event.userToken.hasEntitlement(id);
+  const allowUnpublished =
+    event.userToken.isSuperUser() || event.userToken.hasEntitlement(id);
+
+  if (as !== "iiif" || !q?.trim()) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Request must include ?as=iiif&q={query}",
+      }),
+    };
+  }
+
+  const workResponse = await getWork(id, { allowPrivate, allowUnpublished });
+  if (workResponse.statusCode !== 200) return workResponse;
+
+  return iiifSearchResponse.transform(id, q, {
+    allowPrivate,
+    allowUnpublished,
+  });
+});

--- a/api/template.yaml
+++ b/api/template.yaml
@@ -584,6 +584,30 @@ Resources:
             ApiId: !Ref dcApi
             Path: /works/{id}/thumbnail
             Method: HEAD
+  getWorkSearchFunction:
+    Type: AWS::Serverless::Function
+    Condition: DeployAPI
+    Properties:
+      Handler: handlers/get-work-search.handler
+      Description: IIIF Search 2.0 for a Work's transcription annotations.
+      #* Layers:
+      #*   - !Ref apiDependencies
+      Policies:
+        - !Ref SecretsPolicy
+        - !Ref readIndexPolicy
+      Events:
+        WorkApiGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /works/{id}/search
+            Method: GET
+        WorkApiHead:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /works/{id}/search
+            Method: HEAD
   getSimilarFunction:
     Type: AWS::Serverless::Function
     Condition: DeployAPI

--- a/api/test/integration/get-work-by-id.test.js
+++ b/api/test/integration/get-work-by-id.test.js
@@ -91,6 +91,10 @@ describe("Retrieve work by id", () => {
         "http://iiif.io/api/presentation/3/context.json"
       );
       expect(resultBody.label.none[0]).to.eq("Canary Record TEST 1");
+      expect(resultBody.service).to.deep.include({
+        id: `${process.env.DC_API_ENDPOINT}/works/1234/search?as=iiif`,
+        type: "SearchService2",
+      });
     });
 
     it("will retrieve a private, unpublished work document with an entitlement", async () => {

--- a/api/test/integration/get-work-search.test.js
+++ b/api/test/integration/get-work-search.test.js
@@ -1,0 +1,187 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+chai.use(require("chai-http"));
+
+const ApiToken = requireSource("api/api-token");
+
+const annotatedFileSetsResponse = {
+  hits: {
+    total: { value: 1 },
+    hits: [
+      {
+        _source: {
+          id: "36a47020-5410-4dda-a7ca-967fe3885bcd",
+          group_with: null,
+          annotations: [
+            {
+              id: "anno-uuid-1",
+              type: "transcription",
+              language: ["en"],
+              content:
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae nisl a leo faucibus consectetur.",
+              model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            },
+          ],
+        },
+      },
+    ],
+  },
+};
+
+const emptyFileSetsResponse = {
+  hits: {
+    total: { value: 1 },
+    hits: [
+      {
+        _source: {
+          id: "36a47020-5410-4dda-a7ca-967fe3885bcd",
+          group_with: null,
+          annotations: [],
+        },
+      },
+    ],
+  },
+};
+
+describe("IIIF Search 2.0 for a work", () => {
+  helpers.saveEnvironment();
+  const mock = helpers.mockIndex();
+
+  describe("GET /works/{id}/search", () => {
+    const { handler } = requireSource("handlers/get-work-search");
+
+    it("returns a IIIF Search 2.0 AnnotationPage with matching items", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-1234.json"));
+      mock
+        .post("/dc-v2-file-set/_search", () => true)
+        .reply(200, annotatedFileSetsResponse);
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+
+      const body = JSON.parse(result.body);
+      expect(body["@context"]).to.eq(
+        "http://iiif.io/api/search/2/context.json"
+      );
+      expect(body.type).to.eq("AnnotationPage");
+      expect(body.id).to.include("?as=iiif&q=Lorem");
+      expect(body.items).to.have.lengthOf(1);
+
+      const item = body.items[0];
+      expect(item.type).to.eq("Annotation");
+      expect(item.motivation).to.eq("supplementing");
+      expect(item.body.type).to.eq("TextualBody");
+      expect(item.body.value).to.include("Lorem");
+      expect(item.body.format).to.eq("text/plain");
+      expect(item.body.language).to.eq("en");
+      expect(item.target).to.include("/canvas/0");
+    });
+
+    it("returns an empty items array when no annotations match", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-1234.json"));
+      mock
+        .post("/dc-v2-file-set/_search", () => true)
+        .reply(200, annotatedFileSetsResponse);
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "zzznomatch" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+
+      const body = JSON.parse(result.body);
+      expect(body.type).to.eq("AnnotationPage");
+      expect(body.items).to.deep.eq([]);
+    });
+
+    it("returns 400 when q parameter is missing", async () => {
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(400);
+    });
+
+    it("returns 400 when as parameter is not iiif", async () => {
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(400);
+    });
+
+    it("returns 404 when the work does not exist", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/missing-work-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(404);
+    });
+
+    it("returns 403 when the work is private and no token is provided", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/private-work-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(403);
+    });
+
+    it("returns results for a private work with a valid entitlement token", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/private-work-1234.json"));
+      mock
+        .post("/dc-v2-file-set/_search", () => true)
+        .reply(200, emptyFileSetsResponse);
+
+      const token = new ApiToken().addEntitlement("1234").sign();
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "Lorem" })
+        .headers({ Cookie: `${process.env.API_TOKEN_NAME}=${token};` })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+
+      const body = JSON.parse(result.body);
+      expect(body.type).to.eq("AnnotationPage");
+    });
+  });
+});


### PR DESCRIPTION
 ## Summary
                                                                                                          
  Adds a [IIIF Content Search 2.0](https://iiif.io/api/search/2.0/) endpoint that lets viewers like Clover IIIF search within a work's transcription annotations and navigate to matching canvases.  


## What changed:                                                                                           
                  
  - `GET /works/{id}/search?as=iiif&q={query}` - new endpoint that queries OpenSearch for Access file
   sets whose `annotations.content` matches the search term, then returns a IIIF AnnotationPage with one
  item per match. Each item targets the canvas URI and includes a ~100-character snippet around   
  the matched text for sidebar highlighting in the viewer.
  - IIIF manifests now include a `SearchService2` service entry pointing to the search endpoint so Clover
  can auto-discover it.                                                                                   


<img width="1116" height="605" alt="Screenshot 2026-04-24 at 12 19 06 PM" src="https://github.com/user-attachments/assets/3e9fe7b1-44fb-4f7f-8704-b01ad418eb65" />

                                                                                                          
