### PR TITLE
Fix target canvas id in content search results

### DIFF
--- a/api/src/api/response/iiif/search.js
+++ b/api/src/api/response/iiif/search.js
@@ -31,13 +31,26 @@ function buildSearchAnnotationBody(annotation, snippet) {
   return body;
 }
 
-async function transform(workId, q, opts = {}) {
+async function transform(workSource, q, opts = {}) {
   const { allowPrivate = false, allowUnpublished = false } = opts;
+  const workId = workSource.id;
 
   const manifestId = `${dcApiEndpoint()}/works/${workId}?as=iiif`;
   const searchId = `${dcApiEndpoint()}/works/${workId}/search?as=iiif&q=${encodeURIComponent(
     q
   )}`;
+
+  // Build canvas index map from the work's file_sets array — same ordering as manifest.js
+  const groupIndexMap = {};
+  let groupIndex = 0;
+  (workSource.file_sets || [])
+    .filter((fs) => fs.role === "Access")
+    .forEach((fs) => {
+      const key = fs.group_with || fs.id;
+      if (!(key in groupIndexMap)) {
+        groupIndexMap[key] = groupIndex++;
+      }
+    });
 
   const response = await getWorkFileSets(workId, {
     allowPrivate,
@@ -45,7 +58,6 @@ async function transform(workId, q, opts = {}) {
     annotationsQuery: q,
     role: "Access",
     source: ["id", "annotations", "group_with"],
-    sortBy: "rank",
   });
 
   const fileSets =
@@ -53,7 +65,6 @@ async function transform(workId, q, opts = {}) {
       ? JSON.parse(response.body).hits.hits.map((h) => h._source)
       : [];
 
-  // Replicate manifest.js grouping: ungrouped file sets use their own id as key
   const fileSetGroups = {};
   fileSets.forEach((fs) => {
     const key = fs.group_with || fs.id;
@@ -63,8 +74,10 @@ async function transform(workId, q, opts = {}) {
 
   const items = [];
 
-  Object.entries(fileSetGroups).forEach(([groupKey, groupFileSets], index) => {
-    const canvasId = `${manifestId}/canvas/${index}`;
+  Object.entries(fileSetGroups).forEach(([groupKey, groupFileSets]) => {
+    const canvasIndex = groupIndexMap[groupKey];
+    if (canvasIndex === undefined) return;
+    const canvasId = `${manifestId}/canvas/${canvasIndex}`;
 
     // Primary file set is the one whose id matches the group key (same as manifest.js)
     const primary =

--- a/api/src/handlers/get-work-search.js
+++ b/api/src/handlers/get-work-search.js
@@ -25,7 +25,8 @@ exports.handler = wrap(async (event) => {
   const workResponse = await getWork(id, { allowPrivate, allowUnpublished });
   if (workResponse.statusCode !== 200) return workResponse;
 
-  return iiifSearchResponse.transform(id, q, {
+  const workSource = JSON.parse(workResponse.body)._source;
+  return iiifSearchResponse.transform(workSource, q, {
     allowPrivate,
     allowUnpublished,
   });

--- a/api/test/integration/get-work-search.test.js
+++ b/api/test/integration/get-work-search.test.js
@@ -6,13 +6,14 @@ chai.use(require("chai-http"));
 
 const ApiToken = requireSource("api/api-token");
 
+// Matches the first Access file set (canvas/0) in mocks/work-1234.json
 const annotatedFileSetsResponse = {
   hits: {
     total: { value: 1 },
     hits: [
       {
         _source: {
-          id: "36a47020-5410-4dda-a7ca-967fe3885bcd",
+          id: "076dcbd8-8c57-40e8-bdf7-dc9153c87a36",
           group_with: null,
           annotations: [
             {
@@ -30,18 +31,35 @@ const annotatedFileSetsResponse = {
   },
 };
 
-const emptyFileSetsResponse = {
+// Matches the second Access file set (canvas/1) in mocks/work-1234.json
+const annotatedSecondFileSetsResponse = {
   hits: {
     total: { value: 1 },
     hits: [
       {
         _source: {
-          id: "36a47020-5410-4dda-a7ca-967fe3885bcd",
+          id: "51862c1c-c024-45dc-ab26-694bd8ebc16c",
           group_with: null,
-          annotations: [],
+          annotations: [
+            {
+              id: "anno-uuid-2",
+              type: "transcription",
+              language: ["en"],
+              content:
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer vitae nisl a leo faucibus consectetur.",
+              model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            },
+          ],
         },
       },
     ],
+  },
+};
+
+const emptyFileSetsResponse = {
+  hits: {
+    total: { value: 0 },
+    hits: [],
   },
 };
 
@@ -85,6 +103,29 @@ describe("IIIF Search 2.0 for a work", () => {
       expect(item.body.format).to.eq("text/plain");
       expect(item.body.language).to.eq("en");
       expect(item.target).to.include("/canvas/0");
+    });
+
+    it("uses the correct canvas index from the manifest ordering, not sequential search result order", async () => {
+      mock
+        .get("/dc-v2-work/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/work-1234.json"));
+      mock
+        .post("/dc-v2-file-set/_search", () => true)
+        .reply(200, annotatedSecondFileSetsResponse);
+
+      const event = helpers
+        .mockEvent("GET", "/works/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+
+      const body = JSON.parse(result.body);
+      expect(body.items).to.have.lengthOf(1);
+      // Second Access file set in work-1234.json must map to canvas/1, not canvas/0
+      expect(body.items[0].target).to.include("/canvas/1");
     });
 
     it("returns an empty items array when no annotations match", async () => {


### PR DESCRIPTION
### Summary

The target canvas ids in the content search results was potentially wrong as they were being added sequentially rather than by figuring out the file set's rank and the correct id of the target canvas

### Changes in this PR

- Retrieve the work document so that the correct file set (canvas) id can be determined from the file set rank
- Tests for the case of a non-sequential result correctly identified