### PR TITLE
Create file set thumbnail route

### DIFF
--- a/api/src/handlers/get-thumbnail.js
+++ b/api/src/handlers/get-thumbnail.js
@@ -3,7 +3,7 @@ const axios = require("axios").default;
 const cookie = require("cookie");
 const opensearchResponse = require("../api/response/opensearch");
 const { apiTokenName } = require("../environment");
-const { getCollection, getWork } = require("../api/opensearch");
+const { getCollection, getWork, getFileSet } = require("../api/opensearch");
 const { wrap } = require("./middleware");
 
 function getAxiosResponse(url, config) {
@@ -30,6 +30,16 @@ function validateRequest(event) {
   return { id, aspect, size };
 }
 
+function isImageFileSet(doc) {
+  const source = doc._source;
+  return (
+    doc.found &&
+    source.mime_type != null &&
+    source.mime_type.split("/")[0] === "image" &&
+    ["Access", "Auxiliary"].includes(source.role)
+  );
+}
+
 const getThumbnail = async (id, aspect, size, event) => {
   const allowUnpublished =
     event.userToken.isSuperUser() || event.userToken.hasEntitlement(id);
@@ -47,6 +57,22 @@ const getThumbnail = async (id, aspect, size, event) => {
       return { error: await opensearchResponse.transform(esResponse) };
     body = JSON.parse(esResponse.body);
     iiif_base = body?._source?.representative_image?.url;
+  } else if (event.rawPath.match(/\/file-sets\//)) {
+    esResponse = await getFileSet(id, {
+      allowPrivate,
+      allowUnpublished,
+    });
+    if (esResponse.statusCode != 200)
+      return { error: await opensearchResponse.transform(esResponse) };
+    body = JSON.parse(esResponse.body);
+    if (!isImageFileSet(body)) {
+      return {
+        statusCode: 404,
+        headers: { "content-type": "text/plain" },
+        body: "Not Found",
+      };
+    }
+    iiif_base = body?._source?.representative_image_url;
   } else {
     esResponse = await getWork(id, {
       allowPrivate,

--- a/api/template.yaml
+++ b/api/template.yaml
@@ -584,6 +584,18 @@ Resources:
             ApiId: !Ref dcApi
             Path: /works/{id}/thumbnail
             Method: HEAD
+        FileSetApiGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /file-sets/{id}/thumbnail
+            Method: GET
+        FileSetApiHead:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /file-sets/{id}/thumbnail
+            Method: HEAD
   getWorkSearchFunction:
     Type: AWS::Serverless::Function
     Condition: DeployAPI

--- a/api/test/fixtures/mocks/fileset-image-access-1234.json
+++ b/api/test/fixtures/mocks/fileset-image-access-1234.json
@@ -1,0 +1,16 @@
+{
+  "_index": "dev-dc-v2-file-set",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "1234",
+    "api_model": "FileSet",
+    "visibility": "Public",
+    "published": true,
+    "role": "Access",
+    "mime_type": "image/tiff",
+    "representative_image_url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/1234"
+  }
+}

--- a/api/test/fixtures/mocks/fileset-image-auxiliary-1234.json
+++ b/api/test/fixtures/mocks/fileset-image-auxiliary-1234.json
@@ -1,0 +1,16 @@
+{
+  "_index": "dev-dc-v2-file-set",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "1234",
+    "api_model": "FileSet",
+    "visibility": "Public",
+    "published": true,
+    "role": "Auxiliary",
+    "mime_type": "image/jpeg",
+    "representative_image_url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/1234"
+  }
+}

--- a/api/test/fixtures/mocks/fileset-institution-image-1234.json
+++ b/api/test/fixtures/mocks/fileset-institution-image-1234.json
@@ -1,0 +1,16 @@
+{
+  "_index": "dev-dc-v2-file-set",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "1234",
+    "api_model": "FileSet",
+    "visibility": "Institution",
+    "published": true,
+    "role": "Access",
+    "mime_type": "image/tiff",
+    "representative_image_url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/1234"
+  }
+}

--- a/api/test/fixtures/mocks/fileset-private-image-1234.json
+++ b/api/test/fixtures/mocks/fileset-private-image-1234.json
@@ -1,0 +1,16 @@
+{
+  "_index": "dev-dc-v2-file-set",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "1234",
+    "api_model": "FileSet",
+    "visibility": "Private",
+    "published": true,
+    "role": "Access",
+    "mime_type": "image/tiff",
+    "representative_image_url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/1234"
+  }
+}

--- a/api/test/fixtures/mocks/fileset-unpublished-image-1234.json
+++ b/api/test/fixtures/mocks/fileset-unpublished-image-1234.json
@@ -1,0 +1,16 @@
+{
+  "_index": "dev-dc-v2-file-set",
+  "_type": "_doc",
+  "_id": "1234",
+  "_version": 1,
+  "found": true,
+  "_source": {
+    "id": "1234",
+    "api_model": "FileSet",
+    "visibility": "Public",
+    "published": false,
+    "role": "Access",
+    "mime_type": "image/tiff",
+    "representative_image_url": "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/1234"
+  }
+}

--- a/api/test/integration/get-thumbnail.test.js
+++ b/api/test/integration/get-thumbnail.test.js
@@ -198,6 +198,183 @@ describe("Thumbnail routes", () => {
     });
   });
 
+  describe("FileSet", () => {
+    const event = helpers
+      .mockEvent("GET", "/file-sets/{id}/thumbnail")
+      .headers({ origin: "https://test.example.edu/" })
+      .pathParams({ id: 1234 });
+
+    it("retrieves a thumbnail for an Access image file set", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/fileset-image-access-1234.json")
+        );
+      mock
+        .get("/iiif/2/mbk-dev/1234/full/!300,300/0/default.jpg")
+        .reply(200, helpers.testFixture("mocks/thumbnail_full.jpg"), {
+          "Content-Type": "image/jpeg",
+        });
+
+      const result = await handler(event.render());
+      expect(result.statusCode).to.eq(200);
+      expect(result.headers["content-type"]).to.eq("image/jpeg");
+      expectCorsHeaders(result);
+    });
+
+    it("retrieves a thumbnail for an Auxiliary image file set", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/fileset-image-auxiliary-1234.json")
+        );
+      mock
+        .get("/iiif/2/mbk-dev/1234/full/!300,300/0/default.jpg")
+        .reply(200, helpers.testFixture("mocks/thumbnail_full.jpg"), {
+          "Content-Type": "image/jpeg",
+        });
+
+      const result = await handler(event.render());
+      expect(result.statusCode).to.eq(200);
+      expectCorsHeaders(result);
+    });
+
+    it("returns 404 for a non-image (audio) file set", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/fileset-audio-1234.json"));
+
+      const result = await handler(event.render());
+      expect(result.statusCode).to.eq(404);
+      expectCorsHeaders(result);
+    });
+
+    it("returns 404 for a non-image (video) file set", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/fileset-video-1234.json"));
+
+      const result = await handler(event.render());
+      expect(result.statusCode).to.eq(404);
+      expectCorsHeaders(result);
+    });
+
+    it("returns 404 if the file set doc can't be found", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/missing-fileset-1234.json"));
+
+      const result = await handler(event.render());
+      expect(result.error.statusCode).to.eq(404);
+      expectCorsHeaders(result);
+    });
+
+    it("returns 403 if the file set is private", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/fileset-private-image-1234.json")
+        );
+
+      const result = await handler(event.render());
+      expect(result.error.statusCode).to.eq(403);
+      expectCorsHeaders(result);
+    });
+
+    it("returns 200 if the file set is private and the user is in the reading room", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/fileset-private-image-1234.json")
+        );
+      mock
+        .get("/iiif/2/mbk-dev/1234/full/!300,300/0/default.jpg")
+        .reply(200, helpers.testFixture("mocks/thumbnail_full.jpg"), {
+          "Content-Type": "image/jpeg",
+        });
+
+      const renderedEvent = event.render();
+      process.env.READING_ROOM_IPS = renderedEvent.requestContext.http.sourceIp;
+      const result = await handler(renderedEvent);
+      expect(result.statusCode).to.eq(200);
+    });
+
+    it("returns 200 for an institution file set", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/fileset-institution-image-1234.json")
+        );
+      mock
+        .get("/iiif/2/mbk-dev/1234/full/!300,300/0/default.jpg")
+        .reply(200, helpers.testFixture("mocks/thumbnail_full.jpg"), {
+          "Content-Type": "image/jpeg",
+        });
+
+      const result = await handler(event.render());
+      expect(result.statusCode).to.eq(200);
+      expectCorsHeaders(result);
+    });
+
+    it("returns 404 if the file set is unpublished", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/fileset-unpublished-image-1234.json")
+        );
+
+      const result = await handler(event.render());
+      expect(result.error.statusCode).to.eq(404);
+      expectCorsHeaders(result);
+    });
+
+    it("returns 200 for an unpublished file set if the user is a superuser", async () => {
+      const token = new ApiToken().superUser().sign();
+      const superEvent = helpers
+        .mockEvent("GET", "/file-sets/{id}/thumbnail")
+        .headers({ authorization: `Bearer ${token}` })
+        .pathParams({ id: 1234 });
+
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/fileset-unpublished-image-1234.json")
+        );
+      mock
+        .get("/iiif/2/mbk-dev/1234/full/!300,300/0/default.jpg")
+        .reply(200, helpers.testFixture("mocks/thumbnail_full.jpg"), {
+          "Content-Type": "image/jpeg",
+        });
+
+      const result = await handler(superEvent.render());
+      expect(result.statusCode).to.eq(200);
+    });
+
+    it("returns an error from the IIIF server", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(
+          200,
+          helpers.testFixture("mocks/fileset-image-access-1234.json")
+        );
+      mock
+        .get("/iiif/2/mbk-dev/1234/full/!300,300/0/default.jpg")
+        .reply(403, "Forbidden", { "Content-Type": "text/plain" });
+
+      const result = await handler(event.render());
+      expect(result.statusCode).to.eq(403);
+      expect(result.body).to.eq("Forbidden");
+      expectCorsHeaders(result);
+    });
+  });
+
   describe("Superuser", () => {
     let event;
 


### PR DESCRIPTION
### Summary

Create a `file-sets/{id}/thumbnail` route to support requests for thumbnails of institution level images under 300px when not logged in.

### Changes in this PR

- `api/src/handlers/get-thumbnail.js`- Added a `/file-sets/` branch to the existing `getThumbnail()` function, plus a new `isImageFileSet()` helper that gates thumbnail access to file sets with `Access` or `Auxiliary` role and an image mime_type. Auth is identical to the works/collections pattern.                                                           
- `api/template.yaml` — Added `FileSetApiGet` and `FileSetApiHead` events to the existing `getThumbnailFunction`.