### PR TITLE
Add IIIF content search for file sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@ View and edit information about a specific Work in the Index.
 3. View JSON response at `https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002/works/[WORK_ID]`
 4. View IIIF Manifest JSON response at `https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002/works/[WORK_ID]?as=iiif`
 
+### IIIF content search
+
+IIIF Presentation responses expose [IIIF Content Search 2.0](https://iiif.io/api/search/2.0/) services for transcription annotations:
+
+- Work manifests include a `SearchService2` entry for `https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002/works/[WORK_ID]/search?as=iiif`
+- File set canvases include a `SearchService2` entry for `https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002/file-sets/[FILE_SET_ID]/search?as=iiif`
+
+To search transcription text, include a non-empty `q` parameter:
+
+```shell
+curl "https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002/works/[WORK_ID]/search?as=iiif&q=[QUERY]"
+curl "https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002/file-sets/[FILE_SET_ID]/search?as=iiif&q=[QUERY]"
+```
+
+Both endpoints return a IIIF `AnnotationPage` whose `items` target the matching work canvas or file set canvas. Requests without `as=iiif` or a non-empty `q` return `400`.
+
 For help debugging/inspecting, JavaScript `console` messages are written to: `dc-api-v2/dc-api.log`
 
 ### DC

--- a/api/src/api/response/iiif/annotations.js
+++ b/api/src/api/response/iiif/annotations.js
@@ -1,16 +1,11 @@
 const { dcApiEndpoint } = require("../../../environment");
-const { getWorkFileSets } = require("../../opensearch");
 
-async function transform(response, options = {}) {
+async function transform(response) {
   const body = JSON.parse(response.body);
   const fileSet = body._source;
   const annotations = fileSet?.annotations ?? [];
 
-  const workId = fileSet.work_id;
-  const fileSetId = body._id;
-  const fileSetIndex = await getFileSetIndex(workId, fileSetId, options);
-
-  const canvasId = `${dcApiEndpoint()}/works/${workId}?as=iiif/canvas/${fileSetIndex}`;
+  const canvasId = `${dcApiEndpoint()}/file-sets/${fileSet.id}?as=iiif`;
   const annotationPageId = `${dcApiEndpoint()}/file-sets/${
     fileSet.id
   }/annotations?as=iiif`;
@@ -51,19 +46,4 @@ async function transform(response, options = {}) {
   };
 }
 
-async function getFileSetIndex(workId, fileSetId, options) {
-  const fileSetsResponse = await getWorkFileSets(workId, {
-    allowPrivate: options.allowPrivate,
-    allowUnpublished: options.allowUnpublished,
-    role: "Access",
-    sortBy: "rank",
-  });
-
-  const fileSetBody = JSON.parse(fileSetsResponse.body);
-  const hits = fileSetBody?.hits?.hits || [];
-
-  const index = hits.findIndex((hit) => hit._source.id === fileSetId);
-
-  return index;
-}
 module.exports = { transform };

--- a/api/src/api/response/iiif/canvas.js
+++ b/api/src/api/response/iiif/canvas.js
@@ -26,6 +26,12 @@ async function transform(response, options = {}) {
     height,
     label: { none: [label(fileSet)] },
     items: [annotationPage(canvasId, fileSet, { width, height })],
+    service: [
+      {
+        id: `${dcApiEndpoint()}/file-sets/${fileSet.id}/search?as=iiif`,
+        type: "SearchService2",
+      },
+    ],
   };
 
   if (fileSet.description) {

--- a/api/src/api/response/iiif/file-set-search.js
+++ b/api/src/api/response/iiif/file-set-search.js
@@ -1,0 +1,35 @@
+const { dcApiEndpoint } = require("../../../environment");
+const {
+  buildSearchAnnotationBody,
+  transcriptionAnnotationsMatching,
+} = require("./search-helpers");
+
+async function transform(fileSet, q) {
+  const canvasId = `${dcApiEndpoint()}/file-sets/${fileSet.id}?as=iiif`;
+  const searchId = `${dcApiEndpoint()}/file-sets/${
+    fileSet.id
+  }/search?as=iiif&q=${encodeURIComponent(q)}`;
+
+  const items = transcriptionAnnotationsMatching(fileSet.annotations, q).map(
+    (ann) => ({
+      id: `${canvasId}/annotation/${ann.id}`,
+      type: "Annotation",
+      motivation: "supplementing",
+      body: buildSearchAnnotationBody(ann),
+      target: canvasId,
+    })
+  );
+
+  return {
+    statusCode: 200,
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      "@context": "http://iiif.io/api/search/2/context.json",
+      id: searchId,
+      type: "AnnotationPage",
+      items,
+    }),
+  };
+}
+
+module.exports = { transform };

--- a/api/src/api/response/iiif/manifest.js
+++ b/api/src/api/response/iiif/manifest.js
@@ -45,7 +45,7 @@ async function transform(response, options = {}) {
          * @param {boolean} isAuxiliary
          */
         function buildCanvasFromFileSet(fileSet, index, isAuxiliary) {
-          const canvasId = `${manifestId}/canvas/${fileSet.role.toLowerCase()}/${index}`;
+          const canvasId = fileSetCanvasId(fileSet);
           manifest.createCanvas(canvasId, (canvas) => {
             if (isAudioVideo(source.work_type))
               canvas.duration = fileSet.duration || 1;
@@ -241,81 +241,76 @@ async function transform(response, options = {}) {
           });
 
         /** Process grouped file sets */
-        Object.entries(fileSetGroups).forEach(
-          ([currentGroupKey, fileSets], index) => {
-            const canvasId = `${manifestId}/canvas/${index}`;
-            manifest.createCanvas(canvasId, (canvas) => {
-              // Find the file set with ID matching the currentGroupKey and make it primary
-              let matchingFileSetIndex = -1;
-              for (let i = 0; i < fileSets.length; i++) {
-                if (fileSets[i].id === currentGroupKey) {
-                  matchingFileSetIndex = i;
-                  break;
-                }
-              }
-              if (matchingFileSetIndex > -1) {
-                // Remove the matching fileSet and place it at the beginning
-                const matchingFileSet = fileSets.splice(
-                  matchingFileSetIndex,
-                  1
-                )[0];
-                fileSets.unshift(matchingFileSet);
-              }
-              const primaryFileSet = fileSets[0];
-
-              if (isAudioVideo(source.work_type)) {
-                canvas.duration = primaryFileSet.duration || 1;
-              }
-              canvas.height = primaryFileSet.height || 100;
-              canvas.width = primaryFileSet.width || 100;
-              canvas.addLabel(primaryFileSet.label, "none");
-              addThumbnailToCanvas(canvas, primaryFileSet);
-
-              /** Build "Choice" annotation if there are alternates */
-              const annotationId = `${canvasId}/annotation/0`;
-              const choiceBody =
-                fileSets.length > 1
-                  ? {
-                      type: "Choice",
-                      items: fileSets.map((fileSet) =>
-                        buildAnnotationBody(fileSet, source.work_type)
-                      ),
-                    }
-                  : buildAnnotationBody(primaryFileSet, source.work_type);
-
-              canvas.createAnnotation(annotationId, {
-                id: annotationId,
-                type: "Annotation",
-                motivation: "painting",
-                body: choiceBody,
-              });
-
-              /** Add "supplementing" annotation */
-              if (primaryFileSet.webvtt) {
-                addSupplementingAnnotationToCanvas(
-                  canvas,
-                  canvasId,
-                  primaryFileSet
-                );
-              }
-
-              /** Add transcription annotations */
-              const transcriptions = transcriptionMap[primaryFileSet.id];
-              if (
-                source.work_type === "Image" &&
-                primaryFileSet.role === "Access" &&
-                transcriptions?.length
-              ) {
-                canvasAnnotations[canvasId] = {
-                  id: `${dcApiEndpoint()}/file-sets/${
-                    primaryFileSet.id
-                  }/annotations?as=iiif`,
-                  type: "AnnotationPage",
-                };
-              }
-            });
+        Object.entries(fileSetGroups).forEach(([currentGroupKey, fileSets]) => {
+          // Find the file set with ID matching the currentGroupKey and make it primary
+          let matchingFileSetIndex = -1;
+          for (let i = 0; i < fileSets.length; i++) {
+            if (fileSets[i].id === currentGroupKey) {
+              matchingFileSetIndex = i;
+              break;
+            }
           }
-        );
+          if (matchingFileSetIndex > -1) {
+            // Remove the matching fileSet and place it at the beginning
+            const matchingFileSet = fileSets.splice(matchingFileSetIndex, 1)[0];
+            fileSets.unshift(matchingFileSet);
+          }
+          const primaryFileSet = fileSets[0];
+          const canvasId = fileSetCanvasId(primaryFileSet);
+
+          manifest.createCanvas(canvasId, (canvas) => {
+            if (isAudioVideo(source.work_type)) {
+              canvas.duration = primaryFileSet.duration || 1;
+            }
+            canvas.height = primaryFileSet.height || 100;
+            canvas.width = primaryFileSet.width || 100;
+            canvas.addLabel(primaryFileSet.label, "none");
+            addThumbnailToCanvas(canvas, primaryFileSet);
+
+            /** Build "Choice" annotation if there are alternates */
+            const annotationId = `${canvasId}/annotation/0`;
+            const choiceBody =
+              fileSets.length > 1
+                ? {
+                    type: "Choice",
+                    items: fileSets.map((fileSet) =>
+                      buildAnnotationBody(fileSet, source.work_type)
+                    ),
+                  }
+                : buildAnnotationBody(primaryFileSet, source.work_type);
+
+            canvas.createAnnotation(annotationId, {
+              id: annotationId,
+              type: "Annotation",
+              motivation: "painting",
+              body: choiceBody,
+            });
+
+            /** Add "supplementing" annotation */
+            if (primaryFileSet.webvtt) {
+              addSupplementingAnnotationToCanvas(
+                canvas,
+                canvasId,
+                primaryFileSet
+              );
+            }
+
+            /** Add transcription annotations */
+            const transcriptions = transcriptionMap[primaryFileSet.id];
+            if (
+              source.work_type === "Image" &&
+              primaryFileSet.role === "Access" &&
+              transcriptions?.length
+            ) {
+              canvasAnnotations[canvasId] = {
+                id: `${dcApiEndpoint()}/file-sets/${
+                  primaryFileSet.id
+                }/annotations?as=iiif`,
+                type: "AnnotationPage",
+              };
+            }
+          });
+        });
 
         source.file_sets
           .filter((fileSet) => fileSet.role === "Auxiliary")
@@ -392,6 +387,10 @@ async function transform(response, options = {}) {
     };
   }
   return transformError(response);
+}
+
+function fileSetCanvasId(fileSet) {
+  return `${dcApiEndpoint()}/file-sets/${fileSet.id}?as=iiif`;
 }
 
 async function fetchFileSetTranscriptions(source, options) {

--- a/api/src/api/response/iiif/search-helpers.js
+++ b/api/src/api/response/iiif/search-helpers.js
@@ -1,0 +1,36 @@
+const {
+  getTranscriptionContent,
+  normalizeLanguages,
+} = require("./presentation-api/items");
+
+function annotationMatches(annotation, q) {
+  return getTranscriptionContent(annotation)
+    .toLowerCase()
+    .includes(q.toLowerCase());
+}
+
+function buildSearchAnnotationBody(annotation) {
+  const body = {
+    type: "TextualBody",
+    value: getTranscriptionContent(annotation),
+    format: "text/plain",
+  };
+  const languages = normalizeLanguages(annotation.language);
+  if (languages.length === 1) {
+    body.language = languages[0];
+  } else if (languages.length > 1) {
+    body.language = languages;
+  }
+  return body;
+}
+
+function transcriptionAnnotationsMatching(annotations = [], q) {
+  return annotations
+    .filter((annotation) => annotation.type === "transcription")
+    .filter((annotation) => annotationMatches(annotation, q));
+}
+
+module.exports = {
+  buildSearchAnnotationBody,
+  transcriptionAnnotationsMatching,
+};

--- a/api/src/api/response/iiif/search.js
+++ b/api/src/api/response/iiif/search.js
@@ -1,45 +1,37 @@
 const { dcApiEndpoint } = require("../../../environment");
 const { getWorkFileSets } = require("../../opensearch");
 const {
-  getTranscriptionContent,
-  normalizeLanguages,
-} = require("./presentation-api/items");
-
-function buildSearchAnnotationBody(annotation, content) {
-  const body = {
-    type: "TextualBody",
-    value: content,
-    format: "text/plain",
-  };
-  const languages = normalizeLanguages(annotation.language);
-  if (languages.length === 1) {
-    body.language = languages[0];
-  } else if (languages.length > 1) {
-    body.language = languages;
-  }
-  return body;
-}
+  buildSearchAnnotationBody,
+  transcriptionAnnotationsMatching,
+} = require("./search-helpers");
 
 async function transform(workSource, q, opts = {}) {
   const { allowPrivate = false, allowUnpublished = false } = opts;
   const workId = workSource.id;
 
-  const manifestId = `${dcApiEndpoint()}/works/${workId}?as=iiif`;
   const searchId = `${dcApiEndpoint()}/works/${workId}/search?as=iiif&q=${encodeURIComponent(
     q
   )}`;
 
-  // Build canvas index map from the work's file_sets array — same ordering as manifest.js
-  const groupIndexMap = {};
-  let groupIndex = 0;
+  // Build canvas ID map from the work's file_sets array using the same grouping
+  // and primary-file-set selection as manifest.js.
+  const groupFileSetMap = {};
   (workSource.file_sets || [])
     .filter((fs) => fs.role === "Access")
     .forEach((fs) => {
       const key = fs.group_with || fs.id;
-      if (!(key in groupIndexMap)) {
-        groupIndexMap[key] = groupIndex++;
+      if (!groupFileSetMap[key]) {
+        groupFileSetMap[key] = [];
       }
+      groupFileSetMap[key].push(fs);
     });
+  const groupCanvasIdMap = Object.fromEntries(
+    Object.entries(groupFileSetMap).map(([key, groupFileSets]) => {
+      const primary =
+        groupFileSets.find((fs) => fs.id === key) || groupFileSets[0];
+      return [key, `${dcApiEndpoint()}/file-sets/${primary.id}?as=iiif`];
+    })
+  );
 
   const response = await getWorkFileSets(workId, {
     allowPrivate,
@@ -64,29 +56,23 @@ async function transform(workSource, q, opts = {}) {
   const items = [];
 
   Object.entries(fileSetGroups).forEach(([groupKey, groupFileSets]) => {
-    const canvasIndex = groupIndexMap[groupKey];
-    if (canvasIndex === undefined) return;
-    const canvasId = `${manifestId}/canvas/${canvasIndex}`;
+    const canvasId = groupCanvasIdMap[groupKey];
+    if (canvasId === undefined) return;
 
     // Primary file set is the one whose id matches the group key (same as manifest.js)
     const primary =
       groupFileSets.find((fs) => fs.id === groupKey) || groupFileSets[0];
     if (!primary?.annotations) return;
 
-    primary.annotations
-      .filter((ann) => ann.type === "transcription")
-      .forEach((ann) => {
-        const content = getTranscriptionContent(ann);
-        if (!content.toLowerCase().includes(q.toLowerCase())) return;
-
-        items.push({
-          id: `${canvasId}/annotation/${ann.id}`,
-          type: "Annotation",
-          motivation: "supplementing",
-          body: buildSearchAnnotationBody(ann, content),
-          target: canvasId,
-        });
+    transcriptionAnnotationsMatching(primary.annotations, q).forEach((ann) => {
+      items.push({
+        id: `${canvasId}/annotation/${ann.id}`,
+        type: "Annotation",
+        motivation: "supplementing",
+        body: buildSearchAnnotationBody(ann),
+        target: canvasId,
       });
+    });
   });
 
   return {

--- a/api/src/handlers/get-file-set-search.js
+++ b/api/src/handlers/get-file-set-search.js
@@ -1,0 +1,30 @@
+const { getFileSet } = require("../api/opensearch");
+const iiifSearchResponse = require("../api/response/iiif/file-set-search");
+const { wrap } = require("./middleware");
+
+exports.handler = wrap(async (event) => {
+  const id = event.pathParameters.id;
+  const { as, q } = event.queryStringParameters ?? {};
+
+  const allowPrivate =
+    event.userToken.isSuperUser() || event.userToken.isReadingRoom();
+  const allowUnpublished = event.userToken.isSuperUser();
+
+  if (as !== "iiif" || !q?.trim()) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({
+        message: "Request must include ?as=iiif&q={query}",
+      }),
+    };
+  }
+
+  const fileSetResponse = await getFileSet(id, {
+    allowPrivate,
+    allowUnpublished,
+  });
+  if (fileSetResponse.statusCode !== 200) return fileSetResponse;
+
+  const fileSetSource = JSON.parse(fileSetResponse.body)._source;
+  return iiifSearchResponse.transform(fileSetSource, q);
+});

--- a/api/template.yaml
+++ b/api/template.yaml
@@ -359,6 +359,30 @@ Resources:
             ApiId: !Ref dcApi
             Path: /file-sets/{id}/annotations
             Method: HEAD
+  getFileSetSearchFunction:
+    Type: AWS::Serverless::Function
+    Condition: DeployAPI
+    Properties:
+      Handler: handlers/get-file-set-search.handler
+      Description: IIIF Search 2.0 for a FileSet's transcription annotations.
+      #* Layers:
+      #*   - !Ref apiDependencies
+      Policies:
+        - !Ref SecretsPolicy
+        - !Ref readIndexPolicy
+      Events:
+        ApiGet:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /file-sets/{id}/search
+            Method: GET
+        ApiHead:
+          Type: HttpApi
+          Properties:
+            ApiId: !Ref dcApi
+            Path: /file-sets/{id}/search
+            Method: HEAD
   getAnnotationByIdFunction:
     Type: AWS::Serverless::Function
     Condition: DeployAPI

--- a/api/test/integration/get-annotations.test.js
+++ b/api/test/integration/get-annotations.test.js
@@ -51,6 +51,9 @@ describe("Annotation routes", () => {
       expect(body.items[0].type).to.eq("Annotation");
       expect(body.items[0].motivation).to.eq("commenting");
       expect(body.items[0].body.value).to.exist;
+      expect(body.items[0].target).to.eq(
+        `${process.env.DC_API_ENDPOINT}/file-sets/1234?as=iiif`
+      );
     });
 
     it("returns IIIF annotation page with empty items when no annotations", async () => {

--- a/api/test/integration/get-file-set-search.test.js
+++ b/api/test/integration/get-file-set-search.test.js
@@ -1,0 +1,119 @@
+"use strict";
+
+const chai = require("chai");
+const expect = chai.expect;
+chai.use(require("chai-http"));
+
+describe("IIIF Search 2.0 for a file set", () => {
+  helpers.saveEnvironment();
+  const mock = helpers.mockIndex();
+
+  describe("GET /file-sets/{id}/search", () => {
+    const { handler } = requireSource("handlers/get-file-set-search");
+
+    it("returns a IIIF Search 2.0 AnnotationPage with matching items", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/fileset-annotated-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/file-sets/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+
+      const body = JSON.parse(result.body);
+      expect(body["@context"]).to.eq(
+        "http://iiif.io/api/search/2/context.json"
+      );
+      expect(body.type).to.eq("AnnotationPage");
+      expect(body.id).to.include("/file-sets/1234/search?as=iiif&q=Lorem");
+      expect(body.items).to.have.lengthOf(1);
+
+      const item = body.items[0];
+      expect(item.type).to.eq("Annotation");
+      expect(item.motivation).to.eq("supplementing");
+      expect(item.body.type).to.eq("TextualBody");
+      expect(item.body.value).to.include("Lorem");
+      expect(item.body.format).to.eq("text/plain");
+      expect(item.body.language).to.deep.eq(["lg", "en"]);
+      expect(item.target).to.eq(
+        `${process.env.DC_API_ENDPOINT}/file-sets/1234?as=iiif`
+      );
+    });
+
+    it("returns an empty items array when no annotations match", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/fileset-annotated-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/file-sets/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "zzznomatch" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+
+      const body = JSON.parse(result.body);
+      expect(body.type).to.eq("AnnotationPage");
+      expect(body.items).to.deep.eq([]);
+    });
+
+    it("returns 400 when q parameter is missing", async () => {
+      const event = helpers
+        .mockEvent("GET", "/file-sets/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(400);
+    });
+
+    it("returns 400 when as parameter is not iiif", async () => {
+      const event = helpers
+        .mockEvent("GET", "/file-sets/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(400);
+    });
+
+    it("returns 404 when the file set does not exist", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/missing-fileset-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/file-sets/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(404);
+    });
+
+    it("returns 403 when the file set is private and no token is provided", async () => {
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/fileset-restricted-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/file-sets/{id}/search")
+        .pathParams({ id: "1234" })
+        .queryParams({ as: "iiif", q: "Lorem" })
+        .render();
+
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(403);
+    });
+  });
+});

--- a/api/test/integration/get-work-search.test.js
+++ b/api/test/integration/get-work-search.test.js
@@ -102,10 +102,12 @@ describe("IIIF Search 2.0 for a work", () => {
       expect(item.body.value).to.include("Lorem");
       expect(item.body.format).to.eq("text/plain");
       expect(item.body.language).to.eq("en");
-      expect(item.target).to.include("/canvas/0");
+      expect(item.target).to.eq(
+        `${process.env.DC_API_ENDPOINT}/file-sets/076dcbd8-8c57-40e8-bdf7-dc9153c87a36?as=iiif`
+      );
     });
 
-    it("uses the correct canvas index from the manifest ordering, not sequential search result order", async () => {
+    it("targets the correct file-set canvas from the manifest ordering, not sequential search result order", async () => {
       mock
         .get("/dc-v2-work/_doc/1234")
         .reply(200, helpers.testFixture("mocks/work-1234.json"));
@@ -124,8 +126,10 @@ describe("IIIF Search 2.0 for a work", () => {
 
       const body = JSON.parse(result.body);
       expect(body.items).to.have.lengthOf(1);
-      // Second Access file set in work-1234.json must map to canvas/1, not canvas/0
-      expect(body.items[0].target).to.include("/canvas/1");
+      // Second Access file set in work-1234.json must map to its standalone Canvas URI
+      expect(body.items[0].target).to.eq(
+        `${process.env.DC_API_ENDPOINT}/file-sets/51862c1c-c024-45dc-ab26-694bd8ebc16c?as=iiif`
+      );
     });
 
     it("returns an empty items array when no annotations match", async () => {

--- a/api/test/unit/api/response/iiif/canvas.test.js
+++ b/api/test/unit/api/response/iiif/canvas.test.js
@@ -40,6 +40,10 @@ describe("FileSet as IIIF Canvas response transformer", () => {
     expect(canvas.thumbnail[0].id).to.eq(
       `${source.representative_image_url}/full/!300,300/0/default.jpg`
     );
+    expect(canvas.service).to.deep.include({
+      id: `${dcApiEndpoint()}/file-sets/${source.id}/search?as=iiif`,
+      type: "SearchService2",
+    });
   });
 
   it("builds a painting annotation for image file sets", async () => {

--- a/api/test/unit/api/response/iiif/manifest.test.js
+++ b/api/test/unit/api/response/iiif/manifest.test.js
@@ -171,6 +171,12 @@ describe("Image Work as IIIF Manifest response transformer", () => {
     manifest.items.forEach((canvas) => {
       expect(canvas.type).to.eq("Canvas");
     });
+    expect(manifest.items[0].id).to.eq(
+      `${dcApiEndpoint()}/file-sets/${source.file_sets[0].id}?as=iiif`
+    );
+    expect(manifest.items[0].items[0].id).to.eq(
+      `${manifest.items[0].id}/annotation-page`
+    );
     expect(manifest.items[0].width).to.eq(source.file_sets[0].width);
     expect(manifest.items[0].height).to.eq(source.file_sets[0].height);
     expect(manifest.items[0].label.none[0]).to.eq(source.file_sets[0].label);


### PR DESCRIPTION
## Summary
Adds IIIF Content Search 2.0 support for file sets and aligns work manifest/search targets with standalone file-set `Canvas` URIs.

## Changes

  - Added `GET /file-sets/{id}/search?as=iiif&q={query}` for searching a file set's transcription annotations.
  - Added `SearchService2` discovery to file-set IIIF Canvas responses.
  - Updated work manifests to use `/file-sets/{id}?as=iiif` Canvas IDs instead of work-scoped `/canvas/{index}` IDs.
  - Updated IIIF annotation pages and work content-search results to target the standalone file-set Canvas URIs.
  - Shared IIIF search annotation body/matching logic between work and file-set search.