### PR TITLE
Refine canvas and annotation IIIF responses

### DIFF
--- a/api/src/api/response/iiif/annotations.js
+++ b/api/src/api/response/iiif/annotations.js
@@ -1,48 +1,27 @@
 const { dcApiEndpoint } = require("../../../environment");
+const {
+  buildAnnotationTarget,
+  buildSearchAnnotationBody,
+} = require("./search-helpers");
 
-async function transform(response) {
-  const body = JSON.parse(response.body);
-  const fileSet = body._source;
-  const annotations = fileSet?.annotations ?? [];
-
+function transform(annotation, fileSet) {
   const canvasId = `${dcApiEndpoint()}/file-sets/${fileSet.id}?as=iiif`;
-  const annotationPageId = `${dcApiEndpoint()}/file-sets/${
-    fileSet.id
-  }/annotations?as=iiif`;
-
-  // Build annotation items - filter for transcriptions only
-  // We currently will only have one annotation and it's a transcription
-  const items = annotations
-    .filter((annotation) => annotation.type === "transcription")
-    .map((annotation, idx) => {
-      const annotationId = `${annotationPageId}/a${idx}`;
-      return {
-        id: annotationId,
-        type: "Annotation",
-        motivation: "commenting",
-        body: {
-          type: "TextualBody",
-          value: annotation.content,
-          format: "text/plain",
-          language: annotation.language || "en",
-        },
-        target: canvasId,
-      };
-    });
-
-  const annotationPage = {
-    "@context": "http://iiif.io/api/presentation/3/context.json",
-    id: annotationPageId,
-    type: "AnnotationPage",
-    items: items,
-  };
+  const annotationId = `${dcApiEndpoint()}/annotations/${
+    annotation.id
+  }?as=iiif`;
 
   return {
     statusCode: 200,
-    headers: {
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(annotationPage),
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      "@context": "http://iiif.io/api/presentation/3/context.json",
+      id: annotationId,
+      type: "Annotation",
+      // We have hardcoded motivations here, but in the future we may want to make this more dynamic based on the annotation type
+      motivation: ["contentState", "commenting"],
+      body: buildSearchAnnotationBody(annotation),
+      target: buildAnnotationTarget(canvasId, fileSet.work_id),
+    }),
   };
 }
 

--- a/api/src/api/response/iiif/canvas.js
+++ b/api/src/api/response/iiif/canvas.js
@@ -67,6 +67,22 @@ async function transform(response, options = {}) {
     canvas.partOf = [partOf];
   }
 
+  const transcriptions = (fileSet.annotations || []).filter(
+    (a) => a.type === "transcription"
+  );
+  if (
+    /^image\//i.test(fileSet.mime_type) &&
+    fileSet.role === "Access" &&
+    transcriptions.length
+  ) {
+    canvas.annotations = [
+      {
+        id: `${dcApiEndpoint()}/file-sets/${fileSet.id}/annotations?as=iiif`,
+        type: "AnnotationPage",
+      },
+    ];
+  }
+
   return {
     statusCode: 200,
     headers: {

--- a/api/src/api/response/iiif/file-set-annotations.js
+++ b/api/src/api/response/iiif/file-set-annotations.js
@@ -1,0 +1,55 @@
+const { dcApiEndpoint } = require("../../../environment");
+const {
+  buildAnnotationTarget,
+  buildSearchAnnotationBody,
+} = require("./search-helpers");
+
+async function transform(response) {
+  const body = JSON.parse(response.body);
+  const fileSet = body._source;
+  const annotations = fileSet?.annotations ?? [];
+
+  const canvasId = `${dcApiEndpoint()}/file-sets/${fileSet.id}?as=iiif`;
+  const annotationPageId = `${dcApiEndpoint()}/file-sets/${
+    fileSet.id
+  }/annotations?as=iiif`;
+
+  // Build annotation items - filter for transcriptions only
+  // We currently will only have one annotation and it's a transcription
+  const items = annotations
+    .filter((annotation) => annotation.type === "transcription")
+    .map((annotation) => {
+      const annotationId = `${dcApiEndpoint()}/annotations/${
+        annotation.id
+      }?as=iiif`;
+      return {
+        id: annotationId,
+        type: "Annotation",
+        motivation: "commenting",
+        body: {
+          type: "TextualBody",
+          value: annotation.content,
+          format: "text/plain",
+          language: annotation.language || "en",
+        },
+        target: buildAnnotationTarget(canvasId, fileSet.work_id),
+      };
+    });
+
+  const annotationPage = {
+    "@context": "http://iiif.io/api/presentation/3/context.json",
+    id: annotationPageId,
+    type: "AnnotationPage",
+    items: items,
+  };
+
+  return {
+    statusCode: 200,
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(annotationPage),
+  };
+}
+
+module.exports = { transform };

--- a/api/src/api/response/iiif/file-set-search.js
+++ b/api/src/api/response/iiif/file-set-search.js
@@ -1,5 +1,6 @@
 const { dcApiEndpoint } = require("../../../environment");
 const {
+  buildAnnotationTarget,
   buildSearchAnnotationBody,
   transcriptionAnnotationsMatching,
 } = require("./search-helpers");
@@ -12,11 +13,11 @@ async function transform(fileSet, q) {
 
   const items = transcriptionAnnotationsMatching(fileSet.annotations, q).map(
     (ann) => ({
-      id: `${canvasId}/annotation/${ann.id}`,
+      id: `${dcApiEndpoint()}/annotations/${ann.id}?as=iiif`,
       type: "Annotation",
-      motivation: "supplementing",
+      motivation: "commenting",
       body: buildSearchAnnotationBody(ann),
-      target: canvasId,
+      target: buildAnnotationTarget(canvasId, fileSet.work_id),
     })
   );
 

--- a/api/src/api/response/iiif/search-helpers.js
+++ b/api/src/api/response/iiif/search-helpers.js
@@ -1,3 +1,4 @@
+const { dcApiEndpoint } = require("../../../environment");
 const {
   getTranscriptionContent,
   normalizeLanguages,
@@ -30,7 +31,21 @@ function transcriptionAnnotationsMatching(annotations = [], q) {
     .filter((annotation) => annotationMatches(annotation, q));
 }
 
+function buildAnnotationTarget(canvasId, workId) {
+  const source = { id: canvasId, type: "Canvas" };
+  if (workId) {
+    source.partOf = [
+      {
+        id: `${dcApiEndpoint()}/works/${workId}?as=iiif`,
+        type: "Manifest",
+      },
+    ];
+  }
+  return { type: "SpecificResource", source };
+}
+
 module.exports = {
+  buildAnnotationTarget,
   buildSearchAnnotationBody,
   transcriptionAnnotationsMatching,
 };

--- a/api/src/api/response/iiif/search.js
+++ b/api/src/api/response/iiif/search.js
@@ -1,6 +1,7 @@
 const { dcApiEndpoint } = require("../../../environment");
 const { getWorkFileSets } = require("../../opensearch");
 const {
+  buildAnnotationTarget,
   buildSearchAnnotationBody,
   transcriptionAnnotationsMatching,
 } = require("./search-helpers");
@@ -66,11 +67,11 @@ async function transform(workSource, q, opts = {}) {
 
     transcriptionAnnotationsMatching(primary.annotations, q).forEach((ann) => {
       items.push({
-        id: `${canvasId}/annotation/${ann.id}`,
+        id: `${dcApiEndpoint()}/annotations/${ann.id}?as=iiif`,
         type: "Annotation",
-        motivation: "supplementing",
+        motivation: "commenting",
         body: buildSearchAnnotationBody(ann),
-        target: canvasId,
+        target: buildAnnotationTarget(canvasId, workId),
       });
     });
   });

--- a/api/src/handlers/get-annotation-by-id.js
+++ b/api/src/handlers/get-annotation-by-id.js
@@ -2,6 +2,7 @@ const { wrap } = require("./middleware");
 const { search, getFileSet } = require("../api/opensearch");
 const { prefix, appInfo } = require("../environment");
 const { transformError } = require("../api/response/error");
+const iiifAnnotationsResponse = require("../api/response/iiif/annotations");
 
 /**
  * Retrieves a single annotation by id
@@ -58,13 +59,25 @@ exports.handler = wrap(async (event) => {
 
   if (!annotation) return transformError({ statusCode: 404 });
 
+  const as = event.queryStringParameters?.as;
+  if (as === "iiif") {
+    return iiifAnnotationsResponse.transform(
+      annotation,
+      fileSetPayload._source
+    );
+  }
+
   return {
     statusCode: 200,
     headers: {
       "content-type": "application/json",
     },
     body: JSON.stringify({
-      data: annotation,
+      data: {
+        ...annotation,
+        file_set_id: fileSetPayload._source.id,
+        work_id: fileSetPayload._source.work_id,
+      },
       info: appInfo(),
     }),
   };

--- a/api/src/handlers/get-file-set-annotations.js
+++ b/api/src/handlers/get-file-set-annotations.js
@@ -2,7 +2,7 @@ const { wrap } = require("./middleware");
 const { getFileSet } = require("../api/opensearch");
 const { appInfo } = require("../environment");
 const opensearchResponse = require("../api/response/opensearch");
-const annotationsResponse = require("../api/response/iiif/annotations.js");
+const annotationsResponse = require("../api/response/iiif/file-set-annotations.js");
 
 /**
  * Returns annotations for a FileSet

--- a/api/test/fixtures/mocks/fileset-annotated-1234.json
+++ b/api/test/fixtures/mocks/fileset-annotated-1234.json
@@ -7,6 +7,7 @@
   "_source": {
     "id": "1234",
     "api_model": "FileSet",
+    "work_id": "work-1234",
     "visibility": "Public",
     "published": true,
     "mime_type": "image/tiff",

--- a/api/test/integration/get-annotations.test.js
+++ b/api/test/integration/get-annotations.test.js
@@ -48,12 +48,25 @@ describe("Annotation routes", () => {
       const body = JSON.parse(result.body);
       expect(body.type).to.eq("AnnotationPage");
       expect(body.items).to.be.an("array").with.lengthOf(1);
+      expect(body.items[0].id).to.eq(
+        `${process.env.DC_API_ENDPOINT}/annotations/36a47020-5410-4dda-a7ca-967fe3885bcd?as=iiif`
+      );
       expect(body.items[0].type).to.eq("Annotation");
       expect(body.items[0].motivation).to.eq("commenting");
       expect(body.items[0].body.value).to.exist;
-      expect(body.items[0].target).to.eq(
-        `${process.env.DC_API_ENDPOINT}/file-sets/1234?as=iiif`
-      );
+      expect(body.items[0].target).to.deep.eq({
+        type: "SpecificResource",
+        source: {
+          id: `${process.env.DC_API_ENDPOINT}/file-sets/1234?as=iiif`,
+          type: "Canvas",
+          partOf: [
+            {
+              id: `${process.env.DC_API_ENDPOINT}/works/work-1234?as=iiif`,
+              type: "Manifest",
+            },
+          ],
+        },
+      });
     });
 
     it("returns IIIF annotation page with empty items when no annotations", async () => {
@@ -100,6 +113,53 @@ describe("Annotation routes", () => {
 
       const body = JSON.parse(result.body);
       expect(body.data.id).to.eq("36a47020-5410-4dda-a7ca-967fe3885bcd");
+      expect(body.data.file_set_id).to.eq("1234");
+      expect(body.data.work_id).to.eq("work-1234");
+    });
+
+    it("returns a IIIF contentState Annotation for ?as=iiif", async () => {
+      mock
+        .post("/dc-v2-file-set/_search", () => true)
+        .reply(200, helpers.testFixture("mocks/annotation-search-hit.json"));
+
+      mock
+        .get("/dc-v2-file-set/_doc/1234")
+        .reply(200, helpers.testFixture("mocks/fileset-annotated-1234.json"));
+
+      const event = helpers
+        .mockEvent("GET", "/annotations/{id}")
+        .pathParams({ id: "36a47020-5410-4dda-a7ca-967fe3885bcd" })
+        .queryParams({ as: "iiif" })
+        .render();
+      const result = await handler(event);
+      expect(result.statusCode).to.eq(200);
+
+      const body = JSON.parse(result.body);
+      expect(body["@context"]).to.eq(
+        "http://iiif.io/api/presentation/3/context.json"
+      );
+      expect(body.type).to.eq("Annotation");
+      expect(body.motivation).to.deep.eq(["contentState", "commenting"]);
+      expect(body.body.type).to.eq("TextualBody");
+      expect(body.body.format).to.eq("text/plain");
+      expect(body.body.value).to.be.a("string").and.not.empty;
+      expect(body.body.language).to.exist;
+      expect(body.id).to.include(
+        "/annotations/36a47020-5410-4dda-a7ca-967fe3885bcd?as=iiif"
+      );
+      expect(body.target).to.deep.eq({
+        type: "SpecificResource",
+        source: {
+          id: `${process.env.DC_API_ENDPOINT}/file-sets/1234?as=iiif`,
+          type: "Canvas",
+          partOf: [
+            {
+              id: `${process.env.DC_API_ENDPOINT}/works/work-1234?as=iiif`,
+              type: "Manifest",
+            },
+          ],
+        },
+      });
     });
   });
 });

--- a/api/test/integration/get-file-set-search.test.js
+++ b/api/test/integration/get-file-set-search.test.js
@@ -34,15 +34,28 @@ describe("IIIF Search 2.0 for a file set", () => {
       expect(body.items).to.have.lengthOf(1);
 
       const item = body.items[0];
+      expect(item.id).to.eq(
+        `${process.env.DC_API_ENDPOINT}/annotations/36a47020-5410-4dda-a7ca-967fe3885bcd?as=iiif`
+      );
       expect(item.type).to.eq("Annotation");
-      expect(item.motivation).to.eq("supplementing");
+      expect(item.motivation).to.eq("commenting");
       expect(item.body.type).to.eq("TextualBody");
       expect(item.body.value).to.include("Lorem");
       expect(item.body.format).to.eq("text/plain");
       expect(item.body.language).to.deep.eq(["lg", "en"]);
-      expect(item.target).to.eq(
-        `${process.env.DC_API_ENDPOINT}/file-sets/1234?as=iiif`
-      );
+      expect(item.target).to.deep.eq({
+        type: "SpecificResource",
+        source: {
+          id: `${process.env.DC_API_ENDPOINT}/file-sets/1234?as=iiif`,
+          type: "Canvas",
+          partOf: [
+            {
+              id: `${process.env.DC_API_ENDPOINT}/works/work-1234?as=iiif`,
+              type: "Manifest",
+            },
+          ],
+        },
+      });
     });
 
     it("returns an empty items array when no annotations match", async () => {

--- a/api/test/integration/get-work-search.test.js
+++ b/api/test/integration/get-work-search.test.js
@@ -97,14 +97,24 @@ describe("IIIF Search 2.0 for a work", () => {
 
       const item = body.items[0];
       expect(item.type).to.eq("Annotation");
-      expect(item.motivation).to.eq("supplementing");
+      expect(item.motivation).to.eq("commenting");
       expect(item.body.type).to.eq("TextualBody");
       expect(item.body.value).to.include("Lorem");
       expect(item.body.format).to.eq("text/plain");
       expect(item.body.language).to.eq("en");
-      expect(item.target).to.eq(
-        `${process.env.DC_API_ENDPOINT}/file-sets/076dcbd8-8c57-40e8-bdf7-dc9153c87a36?as=iiif`
-      );
+      expect(item.target).to.deep.eq({
+        type: "SpecificResource",
+        source: {
+          id: `${process.env.DC_API_ENDPOINT}/file-sets/076dcbd8-8c57-40e8-bdf7-dc9153c87a36?as=iiif`,
+          type: "Canvas",
+          partOf: [
+            {
+              id: `${process.env.DC_API_ENDPOINT}/works/1234?as=iiif`,
+              type: "Manifest",
+            },
+          ],
+        },
+      });
     });
 
     it("targets the correct file-set canvas from the manifest ordering, not sequential search result order", async () => {
@@ -127,9 +137,19 @@ describe("IIIF Search 2.0 for a work", () => {
       const body = JSON.parse(result.body);
       expect(body.items).to.have.lengthOf(1);
       // Second Access file set in work-1234.json must map to its standalone Canvas URI
-      expect(body.items[0].target).to.eq(
-        `${process.env.DC_API_ENDPOINT}/file-sets/51862c1c-c024-45dc-ab26-694bd8ebc16c?as=iiif`
-      );
+      expect(body.items[0].target).to.deep.eq({
+        type: "SpecificResource",
+        source: {
+          id: `${process.env.DC_API_ENDPOINT}/file-sets/51862c1c-c024-45dc-ab26-694bd8ebc16c?as=iiif`,
+          type: "Canvas",
+          partOf: [
+            {
+              id: `${process.env.DC_API_ENDPOINT}/works/1234?as=iiif`,
+              type: "Manifest",
+            },
+          ],
+        },
+      });
     });
 
     it("returns an empty items array when no annotations match", async () => {

--- a/api/test/unit/api/response/iiif/canvas.test.js
+++ b/api/test/unit/api/response/iiif/canvas.test.js
@@ -210,6 +210,81 @@ describe("FileSet as IIIF Canvas response transformer", () => {
     });
   });
 
+  it("adds annotations reference for Image Access file sets with transcriptions", async () => {
+    const responseBody = JSON.parse(
+      helpers.testFixture("mocks/fileset-image-canvas-1234.json")
+    );
+    responseBody._source.annotations = [
+      { type: "transcription", content: "some text" },
+    ];
+
+    const result = await transformer.transform({
+      statusCode: 200,
+      body: JSON.stringify(responseBody),
+    });
+    const canvas = JSON.parse(result.body);
+
+    expect(canvas.annotations).to.deep.eq([
+      {
+        id: `${dcApiEndpoint()}/file-sets/${
+          responseBody._source.id
+        }/annotations?as=iiif`,
+        type: "AnnotationPage",
+      },
+    ]);
+  });
+
+  it("does not add annotations reference when mime_type is not image/", async () => {
+    const responseBody = JSON.parse(
+      helpers.testFixture("mocks/fileset-image-canvas-1234.json")
+    );
+    responseBody._source.mime_type = "video/mp4";
+    responseBody._source.annotations = [
+      { type: "transcription", content: "some text" },
+    ];
+
+    const result = await transformer.transform({
+      statusCode: 200,
+      body: JSON.stringify(responseBody),
+    });
+    const canvas = JSON.parse(result.body);
+
+    expect(canvas.annotations).to.be.undefined;
+  });
+
+  it("does not add annotations reference when role is not Access", async () => {
+    const responseBody = JSON.parse(
+      helpers.testFixture("mocks/fileset-image-canvas-1234.json")
+    );
+    responseBody._source.role = "Auxiliary";
+    responseBody._source.annotations = [
+      { type: "transcription", content: "some text" },
+    ];
+
+    const result = await transformer.transform({
+      statusCode: 200,
+      body: JSON.stringify(responseBody),
+    });
+    const canvas = JSON.parse(result.body);
+
+    expect(canvas.annotations).to.be.undefined;
+  });
+
+  it("does not add annotations reference when there are no transcription annotations", async () => {
+    const responseBody = JSON.parse(
+      helpers.testFixture("mocks/fileset-image-canvas-1234.json")
+    );
+    responseBody._source.annotations = [{ type: "other", content: "nope" }];
+
+    const result = await transformer.transform({
+      statusCode: 200,
+      body: JSON.stringify(responseBody),
+    });
+    const canvas = JSON.parse(result.body);
+
+    expect(canvas.annotations).to.be.undefined;
+  });
+
   it("passes non-200 responses through error transformation", async () => {
     const result = await transformer.transform({ statusCode: 404 });
     const body = JSON.parse(result.body);


### PR DESCRIPTION
## What does this do

  Four commits refining IIIF canvas and annotation responses to be more
  contextually complete and internally consistent.

  ### 1. Add `annotations` property to standalone canvas responses
  - `canvas.js` now includes a `canvas.annotations` reference for Image Access
  file sets that have transcription annotations, matching the same pattern
  already used in `manifest.js`
  - The reference is an external `AnnotationPage` pointer
  (`/file-sets/{id}/annotations?as=iiif`) rather than embedded content

```json 
{
  "@context": "http://iiif.io/api/presentation/3/context.json",
  "id": "https://mat.dev.rdc.library.northwestern.edu:3002/file-sets/07baba97-3a53-4a77-8254-0065fde1aa20?as=iiif",
  "type": "Canvas",
  "width": 2355,
  "height": 2957,
  "label": {
    "none": [
      "1recto"
    ]
  },
  "items": [],
  "partOf": [],
  "annotations": [
    {
      "id": "https://mat.dev.rdc.library.northwestern.edu:3002/file-sets/07baba97-3a53-4a77-8254-0065fde1aa20/annotations?as=iiif",
      "type": "AnnotationPage"
    }
  ]
}
```

  ### 2. Add `SpecificResource` type to annotation targets
  - All annotation responses (`file-set-annotations`, `file-set-search`,
  `work-search`) previously set `target` as a bare canvas URI string
  - Targets are now a `SpecificResource` wrapping the Canvas ID with a `partOf`
  Manifest reference, giving viewers the full hierarchy context
  - Shared `buildAnnotationTarget(canvasId, workId)` helper added to
  `search-helpers.js`

```json
{
  "target": {
    "type": "SpecificResource",
    "source": {
      "id": "https://mat.dev.rdc.library.northwestern.edu:3002/file-sets/3e0d6655-184b-4461-b912-22b114b980b7?as=iiif",
      "type": "Canvas",
      "partOf": [
        {
          "id": "https://mat.dev.rdc.library.northwestern.edu:3002/works/d9fd957d-87fa-44b3-ac67-28df5ecdd381?as=iiif",
          "type": "Manifest"
        }
      ]
    }
  }
}
```

  ### 3. Define standalone annotations route with IIIF responses
  - `annotations.js` → `file-set-annotations.js` (renamed; handles the
  `AnnotationPage` for `/file-sets/{id}/annotations?as=iiif`)
  - New `annotations.js` transformer for the `/annotations/{id}?as=iiif` route,
  returning a single `Annotation` with `motivation: ["contentState",
  "commenting"]` and the same `SpecificResource` target shape
  - Plain JSON response from `/annotations/{id}` now includes `file_set_id` and
  `work_id` for context

```json
{
  "@context": "http://iiif.io/api/presentation/3/context.json",
  "id": "https://mat.dev.rdc.library.northwestern.edu:3002/annotations/4999c318-0c64-4fb7-b004-09af56bfc98b?as=iiif",
  "type": "Annotation",
  "motivation": [
    "contentState",
    "commenting"
  ],
  "body": {
    "type": "TextualBody",
    "value": "...",
    "format": "text/plain",
    "language": "en"
  },
  "target": {
    "type": "SpecificResource",
    "source": {
      "id": "https://mat.dev.rdc.library.northwestern.edu:3002/file-sets/3e0d6655-184b-4461-b912-22b114b980b7?as=iiif",
      "type": "Canvas",
      "partOf": [
        {
          "id": "https://mat.dev.rdc.library.northwestern.edu:3002/works/d9fd957d-87fa-44b3-ac67-28df5ecdd381?as=iiif",
          "type": "Manifest"
        }
      ]
    }
  }
}
```

  ### 4. Normalize annotation `id` values across responses
  - `file-set-annotations.js` previously used index-based IDs (`/a0`, `/a1`);
  `search.js` used canvas-scoped IDs
  - All annotation item `id` fields now use the canonical
  `/annotations/{id}?as=iiif` URI, making them dereferenceable and consistent
  across all response types
  - `motivation: "commenting"` used consistently for transcription annotations
  across all search and annotation responses (`supplementing` is reserved for
  WebVTT only)

```
https://mat.dev.rdc.library.northwestern.edu:3002/annotations/[id]?as=iiif
```