### PR TITLE
Try again to update image service.

### DIFF
--- a/api/src/api/response/iiif/manifest.ts
+++ b/api/src/api/response/iiif/manifest.ts
@@ -289,7 +289,7 @@ export async function transform(
           const placeholderFileSet = source.file_sets.find(
             (fs) =>
               fs.representative_image_url ===
-              (thumbnail[0].service as Record<string, string>[])[0]["@id"],
+              (thumbnail[0].service as Record<string, string>[])[0]["id"],
           );
 
           if (

--- a/api/src/api/response/iiif/presentation-api/items.ts
+++ b/api/src/api/response/iiif/presentation-api/items.ts
@@ -80,8 +80,8 @@ export function buildImageService(
   return [
     {
       id: representativeImageUrl,
-      profile: "http://iiif.io/api/image/2/level2.json",
-      type: "ImageService2",
+      profile: "http://iiif.io/api/image/3/level2.json",
+      type: "ImageService3",
     },
   ];
 }

--- a/api/src/api/response/iiif/presentation-api/placeholder-canvas.ts
+++ b/api/src/api/response/iiif/presentation-api/placeholder-canvas.ts
@@ -33,9 +33,9 @@ export function buildPlaceholderCanvas(
               height: placeholderHeight,
               service: [
                 {
-                  ["@id"]: representative_image_url,
-                  ["@type"]: "ImageService2",
-                  profile: "http://iiif.io/api/image/2/level2.json",
+                  id: representative_image_url,
+                  type: "ImageService3",
+                  profile: "http://iiif.io/api/image/3/level2.json",
                 },
               ],
             },

--- a/api/test/unit/api/response/iiif/canvas.test.ts
+++ b/api/test/unit/api/response/iiif/canvas.test.ts
@@ -90,8 +90,8 @@ describe("FileSet as IIIF Canvas response transformer", () => {
     });
     expect(annotation.body.service[0]).toEqual({
       id: source.representative_image_url,
-      type: "ImageService2",
-      profile: "http://iiif.io/api/image/2/level2.json",
+      type: "ImageService3",
+      profile: "http://iiif.io/api/image/3/level2.json",
     });
   });
 

--- a/api/test/unit/api/response/iiif/manifest.test.ts
+++ b/api/test/unit/api/response/iiif/manifest.test.ts
@@ -261,10 +261,10 @@ describe("Image Work as IIIF Manifest response transformer", () => {
       source.file_sets[0].representative_image_url,
     );
     expect(annotation.body.service[0].type).toEqual(
-      "ImageService3",
+      "ImageService3"
     );
     expect(annotation.body.service[0].profile).toEqual(
-      "http://iiif.io/api/image/3/level2.json",
+      "http://iiif.io/api/image/3/level2.json"
     );
   });
 

--- a/api/test/unit/api/response/iiif/manifest.test.ts
+++ b/api/test/unit/api/response/iiif/manifest.test.ts
@@ -257,7 +257,7 @@ describe("Image Work as IIIF Manifest response transformer", () => {
     expect(annotation.body.type).toEqual("Image");
     expect(annotation.body.width).toEqual(source.file_sets[0].width);
     expect(annotation.body.height).toEqual(source.file_sets[0].height);
-    expect(annotation.body.service[0]["@id"]).toEqual(
+    expect(annotation.body.service[0].id).toEqual(
       source.file_sets[0].representative_image_url,
     );
   });

--- a/api/test/unit/api/response/iiif/manifest.test.ts
+++ b/api/test/unit/api/response/iiif/manifest.test.ts
@@ -262,7 +262,7 @@ describe("Image Work as IIIF Manifest response transformer", () => {
     );
     expect(annotation.body.service[0].type).toEqual("ImageService3");
     expect(annotation.body.service[0].profile).toEqual(
-      "http://iiif.io/api/image/3/level2.json"
+      "http://iiif.io/api/image/3/level2.json",
     );
   });
 

--- a/api/test/unit/api/response/iiif/manifest.test.ts
+++ b/api/test/unit/api/response/iiif/manifest.test.ts
@@ -260,9 +260,7 @@ describe("Image Work as IIIF Manifest response transformer", () => {
     expect(annotation.body.service[0].id).toEqual(
       source.file_sets[0].representative_image_url,
     );
-    expect(annotation.body.service[0].type).toEqual(
-      "ImageService3"
-    );
+    expect(annotation.body.service[0].type).toEqual("ImageService3");
     expect(annotation.body.service[0].profile).toEqual(
       "http://iiif.io/api/image/3/level2.json"
     );

--- a/api/test/unit/api/response/iiif/manifest.test.ts
+++ b/api/test/unit/api/response/iiif/manifest.test.ts
@@ -260,6 +260,12 @@ describe("Image Work as IIIF Manifest response transformer", () => {
     expect(annotation.body.service[0].id).toEqual(
       source.file_sets[0].representative_image_url,
     );
+    expect(annotation.body.service[0].type).toEqual(
+      "ImageService3",
+    );
+    expect(annotation.body.service[0].profile).toEqual(
+      "http://iiif.io/api/image/3/level2.json",
+    );
   });
 
   it("includes partOf property only if Work has a Collection", async () => {

--- a/api/test/unit/api/response/iiif/presentation-api/items.test.ts
+++ b/api/test/unit/api/response/iiif/presentation-api/items.test.ts
@@ -67,9 +67,9 @@ describe("IIIF response presentation API items helpers", () => {
 
     expect(imageService.id).toEqual(accessImage.representative_image_url);
     expect(imageService.profile).toEqual(
-      "http://iiif.io/api/image/2/level2.json",
+      "http://iiif.io/api/image/3/level2.json",
     );
-    expect(imageService.type).toEqual("ImageService2");
+    expect(imageService.type).toEqual("ImageService3");
   });
 
   it("buildSupplementingAnnotation({ canvasId, fileSet })", () => {

--- a/api/test/unit/api/response/iiif/presentation-api/placeholder-canvas.test.ts
+++ b/api/test/unit/api/response/iiif/presentation-api/placeholder-canvas.test.ts
@@ -84,7 +84,7 @@ describe("IIIF response presentation API placeholderCanvas helpers", () => {
     expect(body.format).toEqual(fileSet.mime_type);
     expect(body.width).toEqual(640);
     expect(body.height).toEqual(480);
-    expect((body.service as Array<Record<string, unknown>>)[0]["@id"]).toEqual(
+    expect((body.service as Array<Record<string, unknown>>)[0].id).toEqual(
       fileSet.representative_image_url,
     );
   });


### PR DESCRIPTION
## What does this do?

This updates the `type` and and `profile` properties of Images referenced in Manifest, Canvas, Thumbnails, and PlaceholderCanvases -- essentially anywhere where we build out an ImageService in the ?as=iiif API responses.


_From:_

``` 
{
  id: "https://..."
  profile: "http://iiif.io/api/image/2/level2.json",
  type: "ImageService2",
}
```

_To:_

``` 
{
  id: "https://..."
  profile: "http://iiif.io/api/image/3/level2.json",
  type: "ImageService3",
}
```