### PR TITLE
Auto generate release notes on deploy

### DIFF
--- a/.github/scripts/generate_release_notes.sh
+++ b/.github/scripts/generate_release_notes.sh
@@ -1,0 +1,267 @@
+#!/usr/bin/env bash
+# .github/scripts/generate_release_notes.sh
+#
+# Generates human-readable release notes for a DC API production release.
+# Finds PRs merged into deploy/staging since the last production tag, filters
+# noise, calls Claude via Bedrock to summarize, then creates a GitHub Release.
+#
+# Required env vars:
+#   GITHUB_TOKEN      - GitHub token with contents:write and pull-requests:read
+#   AWS_REGION        - AWS region for Bedrock (e.g. "us-east-1")
+#   CURRENT_TAG       - Tag being released (e.g. "v1.2.3")
+#
+# Optional env vars:
+#   PREVIOUS_TAG      - Previous release tag; auto-detected from git if not set
+#   DRAFT_RELEASE     - Set to "true" to create a draft GitHub Release
+#   GITHUB_REPOSITORY - Set automatically by GitHub Actions (owner/repo)
+#   DRY_RUN           - Set to "true" to skip release creation and print output only
+#
+# Local testing (dry run):
+#   export GITHUB_TOKEN=<your-pat>
+#   export CURRENT_TAG=v1.2.3
+#   export PREVIOUS_TAG=v1.1.0
+#   export AWS_REGION=us-east-1
+#   export GITHUB_REPOSITORY=nulib/dc-api-v2
+#   export DRY_RUN=true
+#   bash .github/scripts/generate_release_notes.sh
+
+set -euo pipefail
+
+REPO="${GITHUB_REPOSITORY}"
+CURRENT_TAG="${CURRENT_TAG:?CURRENT_TAG must be set}"
+PREVIOUS_TAG="${PREVIOUS_TAG:-}"
+MODEL_ID="us.anthropic.claude-sonnet-4-6"
+DRAFT_RELEASE="${DRAFT_RELEASE:-false}"
+DRY_RUN="${DRY_RUN:-false}"
+
+FILTERED_COUNT=0
+PR_DETAIL_LIST=""
+SUMMARY=""
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "==> DRY RUN MODE — no GitHub Release will be created"
+fi
+
+TEST_PR_LIST="${TEST_PR_LIST:-}"
+
+echo "==> Generating release notes for ${CURRENT_TAG}"
+
+if [[ -n "$TEST_PR_LIST" ]]; then
+  echo "==> TEST MODE — using provided TEST_PR_LIST, skipping GitHub API"
+  FILTERED_COUNT=$(echo "$TEST_PR_LIST" | grep -c "^-" || true)
+  PR_DETAIL_LIST="$TEST_PR_LIST"
+
+else
+  # ---------------------------------------------------------------------------
+  # 1. Find the previous production tag
+  # ---------------------------------------------------------------------------
+  if [[ -z "$PREVIOUS_TAG" ]]; then
+    echo "==> Finding previous tag..."
+
+    PREVIOUS_TAG=$(git tag \
+      --sort=-creatordate \
+      --list "v*" \
+      | grep -v "^${CURRENT_TAG}$" \
+      | head -1 || true)
+
+    if [[ -z "$PREVIOUS_TAG" ]]; then
+      echo "No previous tag found. Skipping release notes generation."
+      exit 0
+    fi
+  else
+    echo "==> Using provided previous tag: ${PREVIOUS_TAG}"
+  fi
+
+  echo "    Previous tag: ${PREVIOUS_TAG}"
+  echo "    Current tag:  ${CURRENT_TAG}"
+
+  # ---------------------------------------------------------------------------
+  # 2. Fetch merged PRs between the two tags via GitHub API
+  # ---------------------------------------------------------------------------
+  echo "==> Fetching merged PRs between ${PREVIOUS_TAG} and ${CURRENT_TAG}..."
+
+  PREVIOUS_TAG_DATE=$(git log -1 --format="%cI" "${PREVIOUS_TAG}")
+  echo "    Previous tag date: ${PREVIOUS_TAG_DATE}"
+
+  PR_RESPONSE=$(curl -s \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Accept: application/vnd.github.v3+json" \
+    "https://api.github.com/repos/${REPO}/pulls?state=closed&base=deploy/staging&sort=updated&direction=desc&per_page=100&since=${PREVIOUS_TAG_DATE}")
+
+  PR_LIST=$(echo "$PR_RESPONSE" | jq -r --arg since "$PREVIOUS_TAG_DATE" '
+    [
+      .[] |
+      select(
+        .merged_at != null and
+        .merged_at > $since
+      ) |
+      {
+        number: .number,
+        title: .title,
+        labels: [.labels[].name],
+        merged_at: .merged_at
+      }
+    ] | sort_by(.merged_at)
+  ')
+
+  PR_COUNT=$(echo "$PR_LIST" | jq 'length')
+  echo "    Found ${PR_COUNT} merged PRs"
+
+  if [[ "$PR_COUNT" -eq 0 ]]; then
+    echo "No PRs found for this release. Creating release with minimal notes."
+    SUMMARY="No pull requests were found for this release."
+    PR_DETAIL_LIST=""
+  else
+    # -------------------------------------------------------------------------
+    # 3. Filter out noise PRs
+    # -------------------------------------------------------------------------
+    echo "==> Filtering noise PRs..."
+
+    FILTERED_PRS=$(echo "$PR_LIST" | jq -r '
+      [
+        .[] |
+        select(
+          (.title | ascii_downcase | test("^(dependabot|chore:|ci:|ignore:|build:|bump version|increment version|deploy v|dependency rollup|auto-release)") | not) and
+          ((.labels | map(ascii_downcase) | any(. == "dependencies" or . == "chore" or . == "ci" or . == "ignore")) | not)
+        )
+      ]
+    ')
+
+    FILTERED_COUNT=$(echo "$FILTERED_PRS" | jq 'length')
+    EXCLUDED_COUNT=$(( PR_COUNT - FILTERED_COUNT ))
+    echo "    Kept ${FILTERED_COUNT} PRs, excluded ${EXCLUDED_COUNT} noise PRs"
+
+    if [[ "$FILTERED_COUNT" -eq 0 ]]; then
+      echo "All PRs were infrastructure/dependency updates. Creating release with minimal notes."
+      SUMMARY="This release contains dependency updates and infrastructure improvements only."
+      PR_DETAIL_LIST=""
+    else
+      PR_DETAIL_LIST=$(echo "$FILTERED_PRS" | jq -r '
+        .[] | "- #\(.number): \(.title)"
+      ')
+    fi
+  fi
+
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Call Claude via Bedrock to generate plain-language release notes
+# ---------------------------------------------------------------------------
+
+if [[ -n "$PR_DETAIL_LIST" ]]; then
+  echo "==> Calling Claude via Bedrock..."
+  echo "    PRs to summarize:"
+  echo "$PR_DETAIL_LIST" | sed 's/^/      /'
+
+  PROMPT="You are writing release notes for DC API (dc-api-v2), the digital collections API service that powers Northwestern University Libraries' digital asset discovery and delivery platform.
+
+Given the following list of pull request titles merged into this release, write concise, plain-language release notes suitable for both technical staff and library stakeholders. Focus on what changed from the user's perspective — new features, bug fixes, or improvements. Group related changes if it makes sense. Do not mention PR numbers, branch names, version numbers, or technical implementation details. Do not invent a title or header. Use plain prose or a short bullet list. Keep it under 200 words.
+
+Pull requests in this release:
+${PR_DETAIL_LIST}
+
+Write only the release notes text, nothing else."
+
+  REQUEST_PAYLOAD=$(jq -n \
+    --arg prompt "$PROMPT" \
+    '{
+      anthropic_version: "bedrock-2023-05-31",
+      max_tokens: 1024,
+      messages: [
+        {
+          role: "user",
+          content: $prompt
+        }
+      ]
+    }')
+
+  PAYLOAD_FILE=$(mktemp)
+  echo "$REQUEST_PAYLOAD" > "$PAYLOAD_FILE"
+  RESPONSE_FILE=$(mktemp)
+
+  aws bedrock-runtime invoke-model \
+    --region "${AWS_REGION}" \
+    --model-id "${MODEL_ID}" \
+    --content-type "application/json" \
+    --accept "application/json" \
+    --body "fileb://${PAYLOAD_FILE}" \
+    "$RESPONSE_FILE"
+
+  SUMMARY=$(jq -r '.content[0].text' "$RESPONSE_FILE")
+  rm -f "$PAYLOAD_FILE" "$RESPONSE_FILE"
+
+  echo "    Summary generated (${#SUMMARY} chars)"
+fi
+
+RELEASE_BODY="${SUMMARY}"
+
+# ---------------------------------------------------------------------------
+# 5. Create the GitHub Release (or print in dry run mode)
+# ---------------------------------------------------------------------------
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo ""
+  echo "==> DRY RUN: Would create GitHub Release with the following:"
+  echo ""
+  echo "    Tag:  ${CURRENT_TAG}"
+  echo "    Name: DC API ${CURRENT_TAG}"
+  echo ""
+  echo "--- RELEASE BODY ---"
+  echo "${RELEASE_BODY}"
+  echo "--- END RELEASE BODY ---"
+  echo ""
+  echo "==> DRY RUN complete. No release was created."
+
+  if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+    {
+      echo "current_tag=${CURRENT_TAG}"
+      echo "release_url=DRY_RUN"
+      echo "release_body<<__RELEASE_BODY__"
+      echo "${RELEASE_BODY}"
+      echo "__RELEASE_BODY__"
+    } >> "$GITHUB_OUTPUT"
+  fi
+  exit 0
+fi
+
+echo "==> Creating GitHub Release for ${CURRENT_TAG}..."
+
+RELEASE_PAYLOAD=$(jq -n \
+  --arg tag "$CURRENT_TAG" \
+  --arg name "DC API ${CURRENT_TAG}" \
+  --arg body "$RELEASE_BODY" \
+  --argjson draft "$([[ "$DRAFT_RELEASE" == "true" ]] && echo "true" || echo "false")" \
+  '{
+    tag_name: $tag,
+    name: $name,
+    body: $body,
+    draft: $draft,
+    prerelease: false
+  }')
+
+RELEASE_RESPONSE=$(curl -s \
+  -X POST \
+  -H "Authorization: token ${GITHUB_TOKEN}" \
+  -H "Accept: application/vnd.github.v3+json" \
+  "https://api.github.com/repos/${REPO}/releases" \
+  -d "$RELEASE_PAYLOAD")
+
+RELEASE_URL=$(echo "$RELEASE_RESPONSE" | jq -r '.html_url')
+
+if [[ "$RELEASE_URL" == "null" || -z "$RELEASE_URL" ]]; then
+  echo "ERROR: Failed to create release. Response:"
+  echo "$RELEASE_RESPONSE" | jq .
+  exit 1
+fi
+
+echo "==> Release created successfully: ${RELEASE_URL}"
+
+if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+  {
+    echo "current_tag=${CURRENT_TAG}"
+    echo "release_url=${RELEASE_URL}"
+    echo "release_body<<__RELEASE_BODY__"
+    echo "${RELEASE_BODY}"
+    echo "__RELEASE_BODY__"
+  } >> "$GITHUB_OUTPUT"
+fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -107,3 +107,20 @@ jobs:
           github_token: ${{ steps.dispatch-token.outputs.token }}
           tags: true
           branch: main
+      - name: Generate Release Notes
+        if: ${{ github.ref == 'refs/heads/main' }}
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'release_notes.yml',
+              ref: 'main',
+              inputs: {
+                current_tag: `v${process.env.API_VERSION}`,
+                previous_tag: '',
+                draft: 'false',
+                notify_teams: 'true',
+              },
+            })

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -1,0 +1,99 @@
+---
+name: Generate Release Notes
+on:
+  workflow_dispatch:
+    inputs:
+      current_tag:
+        description: "Tag being released (e.g. v1.2.3)"
+        required: true
+      previous_tag:
+        description: "Previous release tag (leave empty to auto-detect)"
+        required: false
+        default: ""
+      draft:
+        description: "Create as draft release"
+        type: boolean
+        default: false
+      notify_teams:
+        description: "Send notification to Teams channel"
+        type: boolean
+        default: true
+permissions:
+  id-token: write
+  contents: write
+  actions: write
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      actions: write
+    environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'staging' }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - uses: aws-actions/configure-aws-credentials@master
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.AwsAccount }}:role/github-actions-role
+          aws-region: us-east-1
+      - name: Generate Release Notes
+        id: generate
+        run: .github/scripts/generate_release_notes.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURRENT_TAG: ${{ inputs.current_tag }}
+          PREVIOUS_TAG: ${{ inputs.previous_tag }}
+          DRAFT_RELEASE: ${{ inputs.draft }}
+          AWS_REGION: us-east-1
+      - name: Notify Teams
+        if: steps.generate.outputs.release_body != '' && inputs.notify_teams
+        env:
+          TEAMS_WEBHOOK_URL: ${{ secrets.TEAMS_WEBHOOK_URL }}
+          RELEASE_URL: ${{ steps.generate.outputs.release_url }}
+          RELEASE_BODY: ${{ steps.generate.outputs.release_body }}
+          CURRENT_TAG: ${{ steps.generate.outputs.current_tag }}
+          IS_DRAFT: ${{ inputs.draft }}
+        run: |
+          if [[ "$IS_DRAFT" == "true" ]]; then
+            TITLE="DC API ${CURRENT_TAG} (Draft Release)"
+          else
+            TITLE="DC API ${CURRENT_TAG} Released"
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg title "$TITLE" \
+            --arg body "$RELEASE_BODY" \
+            --arg url "$RELEASE_URL" \
+            '{
+              type: "message",
+              attachments: [{
+                contentType: "application/vnd.microsoft.card.adaptive",
+                content: {
+                  "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                  type: "AdaptiveCard",
+                  version: "1.2",
+                  body: [
+                    {type: "TextBlock", size: "large", weight: "bolder", text: $title, wrap: true},
+                    {type: "TextBlock", text: $body, wrap: true}
+                  ],
+                  actions: [
+                    {type: "Action.OpenUrl", title: "View Release", url: $url}
+                  ]
+                }
+              }]
+            }')
+
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -X POST \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$TEAMS_WEBHOOK_URL")
+
+          if [[ "$HTTP_STATUS" != "200" && "$HTTP_STATUS" != "202" ]]; then
+            echo "WARNING: Teams notification returned HTTP ${HTTP_STATUS}"
+          else
+            echo "==> Teams notification sent"
+          fi


### PR DESCRIPTION
## Summary

Ported over the release notes generation & publishing from Meadow. 

On production deploy, a new Github action `generate_release_notes.sh`:
- Fetches all PR's since `PREVIOUS_TAG` 
- Call Claude via AWS Bedrock to summarize PR's
- Ignores "noise" (`dependabot`, `ci`, `chore`, `ignore`)
- Publishes release in Github
- Sends release notification with summary to app status Teams channel 

Workflow can also be manually triggered or within the github UI (once it exists in `main`) with draft release and Teams publishing optional.

## To test locally

### Test Claude summarization only:
- log into staging AWS from your dev env
- set env vars
```bash
export AWS_REGION=us-east-1
export CURRENT_TAG=v1.2.3
export DRY_RUN=true
export GITHUB_REPOSITORY=nulib/dc-api-v2
export TEST_PR_LIST="- #101: Add IIIF manifest caching
  - #102: Fix thumbnail generation for AV works
  - #103: Improve search relevance for collection titles"
```
- Execute script
```bash
bash .github/scripts/generate_release_notes.sh
```
- You should see something like: 
```bash
==> DRY RUN MODE — no GitHub Release will be created
==> Generating release notes for v1.2.3
==> TEST MODE — using provided TEST_PR_LIST, skipping GitHub API
==> Calling Claude via Bedrock...
    PRs to summarize:
      - #101: Add IIIF manifest caching
        - #102: Fix thumbnail generation for AV works
        - #103: Improve search relevance for collection titles
    Summary generated (279 chars)

==> DRY RUN: Would create GitHub Release with the following:

    Tag:  v1.2.3
    Name: DC API v1.2.3

--- RELEASE BODY ---
- IIIF manifests are now cached, reducing load times when viewing items.
- Fixed an issue where thumbnails were not generating correctly for audio and video works.
- Search results now rank collection titles more accurately, improving relevance when searching by collection name.
--- END RELEASE BODY ---

==> DRY RUN complete. No release was created.
```


### Test GH PR fetching + Claude summarization

Summarization will fetch all PR's since `PREVIOUS_TAG` (`CURRENT_TAG` is used only for release label)

- login to staging from dev env
- Create GH PAT (classic) with `repo` > `public_repo` selected
- Unset `TEST_PR_LIST` (if set)
```bash
unset TEST_PR_LIST
```
- Set env vars:
```bash
export GITHUB_TOKEN=<your-pat>
export GITHUB_REPOSITORY=nulib/dc-api-v2
export AWS_REGION=us-east-1
export CURRENT_TAG=v2.11.0
export PREVIOUS_TAG=v2.10.10
export DRY_RUN=true
```
- Run script
```bash
bash .github/scripts/generate_release_notes.sh
```
- You should see something like:
```bash
==> Generating release notes for v2.11.0
==> Using provided previous tag: v2.10.10
    Previous tag: v2.10.10
    Current tag:  v2.11.0
==> Fetching merged PRs between v2.10.10 and v2.11.0...
    Previous tag date: 2026-04-20T14:37:29-05:00
    Found 9 merged PRs
==> Filtering noise PRs...
    Kept 9 PRs, excluded 0 noise PRs
==> Calling Claude via Bedrock...
    PRs to summarize:
      - #372: Implement IIIF Content Search 2.0 at `/works/{id}/search`
      - #373: Fix target canvas id in content search results
      - #374: Return full annotation rather than snippet for content search
      - #375: Create file set thumbnail route
      - #376: Promote opensearch `inner_hits` to top level
      - #377: Add ?as=iiif parameter to file set routes
      - #378: Add IIIF content search for file sets
      - #380: Refine canvas and annotation IIIF responses
      - #379: Migrate API to Bun/TypeScript with unified server
    Summary generated (980 chars)

==> DRY RUN: Would create GitHub Release with the following:

    Tag:  v2.11.0
    Name: DC API v2.11.0

--- RELEASE BODY ---
**IIIF Content Search**

Works and file sets now support IIIF Content Search 2.0 via a `/search` endpoint, enabling viewers like the Universal Viewer or Clover to search within a digitized item and jump directly to matching text on the canvas. Search results return complete annotation content rather than truncated snippets, and canvas identifiers in results are correctly resolved.

**File Set Enhancements**

File sets have a new dedicated thumbnail route. File set routes also accept an `?as=iiif` parameter to return IIIF-formatted responses, and file sets now have their own IIIF content search support, consistent with works.

**IIIF Response Improvements**

Canvas and annotation responses have been refined for better conformance and consistency across the API.

**Platform Modernization**

The API has been migrated to a unified server architecture using a modern JavaScript runtime and TypeScript, improving maintainability and laying groundwork for future development.
--- END RELEASE BODY ---

==> DRY RUN complete. No release was created.
```

