### PR TITLE
Include signed query string in awsFetch URL to fix SigV4 403s

### DIFF
--- a/api/bun.lock
+++ b/api/bun.lock
@@ -13,6 +13,7 @@
         "@aws-sdk/client-sns": "^3.563.0",
         "@aws-sdk/credential-provider-node": "^3.563.0",
         "@aws-sdk/s3-request-presigner": "^3.563.0",
+        "@aws-sdk/util-format-url": "^3.667.0",
         "@honeybadger-io/js": "^4.9.3",
         "@hono/mcp": "^0.3.0",
         "@smithy/protocol-http": "^3.3.0",
@@ -113,6 +114,8 @@
     "@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1049.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.12", "@aws-sdk/nested-clients": "^3.997.10", "@aws-sdk/types": "^3.973.8", "@smithy/core": "^3.24.2", "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-r7+d0lQMTHKypkmaF5jRTBYLYHCUHzt3gaVoN9SidLhQeWhCmHk3AKrboDTpPF5b7Pt7vKu3+oeMjznM2Eu1ow=="],
 
     "@aws-sdk/types": ["@aws-sdk/types@3.973.8", "", { "dependencies": { "@smithy/types": "^4.14.1", "tslib": "^2.6.2" } }, "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw=="],
+
+    "@aws-sdk/util-format-url": ["@aws-sdk/util-format-url@3.972.19", "", { "dependencies": { "@aws-sdk/core": "^3.974.17", "tslib": "^2.6.2" } }, "sha512-H/3cQxE0tg6bK0RabsTKLQeOrrHkHkEtQHTRuB9W658c4FjBJznUzxVevKlT2DH9FsWIiItzMUVbKmIjjdquAg=="],
 
     "@aws-sdk/util-locate-window": ["@aws-sdk/util-locate-window@3.965.5", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-WhlJNNINQB+9qtLtZJcpQdgZw3SCDCpXdUJP7cToGwHbCWCnRckGlc6Bx/OhWwIYFNAn+FIydY8SZ0QmVu3xTQ=="],
 
@@ -798,6 +801,8 @@
 
     "@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.4.3", "", { "dependencies": { "@smithy/core": "^3.24.3", "@smithy/types": "^4.14.2", "tslib": "^2.6.2" } }, "sha512-53+75QuPl6DL+ct6vVEB51FDO5oulXr20TPV46VvJZg76lIlXNWfxi8j+G2V/t0I2qxCBOa3vX/8bmjrpFVo9g=="],
 
+    "@aws-sdk/util-format-url/@aws-sdk/core": ["@aws-sdk/core@3.974.17", "", { "dependencies": { "@aws-sdk/types": "^3.973.10", "@aws-sdk/xml-builder": "^3.972.27", "@aws/lambda-invoke-store": "^0.2.2", "@smithy/core": "^3.24.6", "@smithy/signature-v4": "^5.4.6", "@smithy/types": "^4.14.3", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-r8o4h2K7j6P9ngno+8ei0aK0U/4JwDb7A2fMMxGVoSqDN8AFlIzSDeZHME9LcVLR2codyhtr1WAAg+/nmkeeMA=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
@@ -879,6 +884,16 @@
     "@aws-sdk/nested-clients/@aws-crypto/sha256-browser/@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
 
     "@aws-sdk/nested-clients/@aws-crypto/sha256-js/@aws-crypto/util": ["@aws-crypto/util@5.2.0", "", { "dependencies": { "@aws-sdk/types": "^3.222.0", "@smithy/util-utf8": "^2.0.0", "tslib": "^2.6.2" } }, "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ=="],
+
+    "@aws-sdk/util-format-url/@aws-sdk/core/@aws-sdk/types": ["@aws-sdk/types@3.973.10", "", { "dependencies": { "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-992QrTO7G9qCvKD0fx1rMlqcL14plUcRAbwmqqYVsuF3GrqcvlAL9qxR+baMafarEZ+l7DUQ5lCMmt5mbMhF7g=="],
+
+    "@aws-sdk/util-format-url/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.27", "", { "dependencies": { "@smithy/types": "^4.14.3", "fast-xml-parser": "5.7.3", "tslib": "^2.6.2" } }, "sha512-hpsCXCOI436kxWpjtRuIHVvuPP81MOw8f18jzfZeg+UOiiOvlqWcmWChzEhJEu16cOC6+ku4ncBN+7rdt+DZ9g=="],
+
+    "@aws-sdk/util-format-url/@aws-sdk/core/@smithy/core": ["@smithy/core@3.24.6", "", { "dependencies": { "@aws-crypto/crc32": "5.2.0", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-wBXDRup6UU97VKyaiRo8AssnfStPtG0oAAfpq/bC0a1YYau8pM86YB4kM6ccoVi1mS8l/UHbn9oDM+7uozr/ug=="],
+
+    "@aws-sdk/util-format-url/@aws-sdk/core/@smithy/signature-v4": ["@smithy/signature-v4@5.4.6", "", { "dependencies": { "@smithy/core": "^3.24.6", "@smithy/types": "^4.14.3", "tslib": "^2.6.2" } }, "sha512-Ojg4B6oIDlIr1R86xCDJt1zJWnYa0VINmqdjfe9qxWjdRivHalZ3iSlQgVqYbW0MdpFOC5XfHEWsnbmdnpIILQ=="],
+
+    "@aws-sdk/util-format-url/@aws-sdk/core/@smithy/types": ["@smithy/types@4.14.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 

--- a/api/package.json
+++ b/api/package.json
@@ -25,6 +25,7 @@
     "@aws-sdk/client-sns": "^3.563.0",
     "@aws-sdk/credential-provider-node": "^3.563.0",
     "@aws-sdk/s3-request-presigner": "^3.563.0",
+    "@aws-sdk/util-format-url": "^3.667.0",
     "@honeybadger-io/js": "^4.9.3",
     "@hono/mcp": "^0.3.0",
     "@smithy/protocol-http": "^3.3.0",

--- a/api/src/aws/fetch.ts
+++ b/api/src/aws/fetch.ts
@@ -1,8 +1,13 @@
 import { defaultProvider } from "@aws-sdk/credential-provider-node";
+import { formatUrl } from "@aws-sdk/util-format-url";
 import { SignatureV4 } from "@smithy/signature-v4";
 import { HttpRequest } from "@smithy/protocol-http";
 import { Sha256 } from "@aws-crypto/sha256-browser";
 import { region } from "../environment.ts";
+import type { HttpRequest as SmithyHttpRequest } from "@smithy/types";
+
+export const requestUrl = (request: SmithyHttpRequest): string =>
+  formatUrl(request);
 
 export async function awsFetch(
   request: HttpRequest,
@@ -15,7 +20,7 @@ export async function awsFetch(
   });
 
   const signed = await signer.sign(request);
-  const url = `https://${signed.hostname}${signed.path}`;
+  const url = requestUrl(signed);
 
   const resp = await fetch(url, {
     method: signed.method,

--- a/api/test/unit/api/opensearch.test.ts
+++ b/api/test/unit/api/opensearch.test.ts
@@ -229,4 +229,32 @@ describe("search()", () => {
     expect(body.hits.hits.length).toEqual(10);
     expect(body.hits.total.value).toEqual(4331);
   });
+
+  it("passes search query options to OpenSearch", async () => {
+    const received: { searchPipeline: string | null } = {
+      searchPipeline: null,
+    };
+    server.use(
+      http.post(
+        "https://index.test.library.northwestern.edu/dc-v2-work/_search",
+        ({ request }) => {
+          received.searchPipeline = new URL(request.url).searchParams.get(
+            "search_pipeline",
+          );
+          return HttpResponse.json(
+            JSON.parse(testFixture("mocks/search.json")),
+          );
+        },
+      ),
+    );
+
+    const result = await opensearch.search(
+      "dc-v2-work",
+      "{ query: { match_all: {} } }",
+      { search_pipeline: "dc-v2-work-pipeline" },
+    );
+
+    expect(result.status).toEqual(200);
+    expect(received.searchPipeline).toEqual("dc-v2-work-pipeline");
+  });
 });

--- a/api/test/unit/aws/fetch.test.ts
+++ b/api/test/unit/aws/fetch.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, beforeEach, afterEach, expect, spyOn } from "bun:test";
+import { HttpRequest } from "@smithy/protocol-http";
+import { awsFetch, requestUrl } from "../../../src/aws/fetch.ts";
+import { setupEnv, teardownEnv } from "../../test-helpers/index.ts";
+
+describe("requestUrl()", () => {
+  it("includes Smithy request query parameters", () => {
+    const request = new HttpRequest({
+      method: "POST",
+      hostname: "index.test.library.northwestern.edu",
+      path: "/dc-v2-work/_search",
+      query: {
+        bare: null,
+        repeated: ["one", "two"],
+        search_pipeline: "dc-v2-work-pipeline",
+        space: "has spaces",
+      },
+    });
+
+    expect(requestUrl(request)).toEqual(
+      "https://index.test.library.northwestern.edu/dc-v2-work/_search?bare&repeated=one&repeated=two&search_pipeline=dc-v2-work-pipeline&space=has%20spaces",
+    );
+  });
+});
+
+describe("awsFetch()", () => {
+  beforeEach(() => setupEnv());
+  afterEach(() => teardownEnv());
+
+  it("sends signed query parameters in the fetch URL", async () => {
+    const fetchSpy = spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ ok: true }), { status: 200 }),
+    );
+
+    try {
+      const result = await awsFetch(
+        new HttpRequest({
+          method: "POST",
+          hostname: "index.test.library.northwestern.edu",
+          headers: {
+            Host: "index.test.library.northwestern.edu",
+            "Content-Type": "application/json",
+          },
+          body: "{}",
+          path: "/dc-v2-work/_search",
+          query: { search_pipeline: "dc-v2-work-pipeline" },
+        }),
+      );
+
+      expect(result.status).toEqual(200);
+      const calledUrl = fetchSpy.mock.calls[0][0].toString();
+      expect(calledUrl).toContain("?search_pipeline=dc-v2-work-pipeline");
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

`awsFetch` built the request URL as `https://${signed.hostname}${signed.path}`, dropping the query string. SigV4 includes the canonical query string in the signature, so any request with query params (e.g. `?search_pipeline=dc-v2-work-pipeline`) was signed with the query but sent without it. OpenSearch recomputed the signature from what it actually received and rejected the request:

> 403 — The request signature we calculated does not match the signature you provided.

## Fix

Build the fetch URL with `formatUrl` from `@aws-sdk/util-format-url` (already a transitive dep of the SigV4 signer, now declared explicitly). It serializes the query string the same way `@smithy/signature-v4` does when signing, so the URL sent matches the URL signed.