### PR TITLE
Pass chat websocket uri to the chat endpoint lambda

### DIFF
--- a/api/template.yaml
+++ b/api/template.yaml
@@ -171,6 +171,7 @@ Resources:
           READING_ROOM_IPS: !Ref ReadingRoomIPs
           REPOSITORY_EMAIL: !Ref RepositoryEmail
           SECRETS_PATH: !Ref SecretsPath
+          WEBSOCKET_URI: !Ref ChatWebSocketURI
       Policies:
         - !Ref SecretsPolicy
         - !Ref readIndexPolicy


### PR DESCRIPTION
### Summary

Chat from Digitial Collections is failing. It looks like the root cause is that the `/chat/endpoint` request is returning just the auth token and not the `endpoint` as well. The `WEBSOCKET_URI` is not currently being passed in to the lambda in the api's template.

### Changes in this PR
- Bugfix that adds `ChatWebSocketURI` to the lambda's environment variables