### PR TITLE
Fix MCP publish workflow Bun setup

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -11,6 +11,7 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: nulib/dc-api-mcp
+  BUN_VERSION: "1.3.14"
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -25,6 +26,10 @@ jobs:
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org/"
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
       - run: npm ci
         working-directory: ./mcp
       - name: Publish to npm

--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -1,6 +1,8 @@
-FROM node:24-alpine
+FROM oven/bun:1
 LABEL io.modelcontextprotocol.server.name="io.github.nulib/dc-api"
 WORKDIR /app
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile --ignore-scripts
 COPY . .
-RUN npm ci
-CMD ["npm", "run", "--silent", "stdio"]
+RUN PUBLISHING=true bun run ./build.ts
+CMD ["bun", "run", "--silent", "stdio"]

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -22,7 +22,7 @@
       },
       "devDependencies": {
         "@msw/source": "^0.6.1",
-        "@nulib/clover-mcp": "^0.1.0",
+        "@nulib/clover-mcp": "^0.1.3",
         "@types/aws-lambda": "^8.10.161",
         "@types/bun": "latest",
         "@types/cors": "^2.8.19",
@@ -1416,7 +1416,9 @@
       "license": "MIT"
     },
     "node_modules/@nulib/clover-mcp": {
-      "version": "0.1.2",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@nulib/clover-mcp/-/clover-mcp-0.1.3.tgz",
+      "integrity": "sha512-rm8ffCrxGUfWRArPbDp8dgklNqu7PDIXgLvtF0emGCFf0m4h5T7ZrKzVi6Ni0UlTonOWIs6goKU3gwGl2jdBiQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [


### PR DESCRIPTION
## Summary

Publishing the MCP server to npm is failing due to a missing `bun` dependency.

- Install Bun in the MCP npm publish workflow before `npm ci`
- Switch the MCP Docker image to Bun’s official `oven/bun` base image
- Sync the MCP npm lockfile for `@nulib/clover-mcp@0.1.3`