### PR TITLE
Add part of PR body to release notes summarization request

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+## Summary 
+Brief high level description of this feature or fix
+
+## Specific Changes in this PR
+- list changes
+- list changes
+
+## Version bump required by the PR
+
+See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.
+
+- [ ] Patch
+- [ ] Minor
+- [ ] Major
+
+## Steps to Test
+Please let end users know what they need to do to test on staging or production
+
+Also please let developers know if there are any special instructions to test this in the development environment. 

--- a/.github/PULL_REQUEST_TEMPLATE/production.md
+++ b/.github/PULL_REQUEST_TEMPLATE/production.md
@@ -1,8 +1,3 @@
-# :open_book: Changelog
-
-- list changes
-- list changes
-
 # Version bump required by the PR
 
 See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

--- a/.github/scripts/generate_release_notes.sh
+++ b/.github/scripts/generate_release_notes.sh
@@ -98,6 +98,7 @@ else
       {
         number: .number,
         title: .title,
+        body: (.body // ""),
         labels: [.labels[].name],
         merged_at: .merged_at
       }
@@ -136,9 +137,33 @@ else
       SUMMARY="This release contains dependency updates and infrastructure improvements only."
       PR_DETAIL_LIST=""
     else
-      PR_DETAIL_LIST=$(echo "$FILTERED_PRS" | jq -r '
-        .[] | "- #\(.number): \(.title)"
-      ')
+      PR_DETAIL_LIST=""
+      while IFS= read -r pr_json; do
+        number=$(echo "$pr_json" | jq -r '.number')
+        title=$(echo "$pr_json" | jq -r '.title')
+        body=$(echo "$pr_json" | jq -r '.body // ""')
+
+        # Extract text under the ## Summary header, stopping at the next ## section.
+        # Strip HTML comments and image markdown; collapse to a single line.
+        summary=$(echo "$body" | awk '
+          /^##+ Summary/{ found=1; next }
+          found && /^##/ { exit }
+          found { print }
+        ' | sed '/^<!--/,/-->/d; s/!\[[^]]*\]([^)]*)//g; s/<img[^>]*>//g; /^[[:space:]]*$/d' \
+          | head -5 | tr '\n' ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+
+        # Fall back to the first few lines of the body if no Summary section found
+        if [[ -z "$summary" ]]; then
+          summary=$(echo "$body" | sed '/^<!--/,/-->/d; s/!\[[^]]*\]([^)]*)//g; s/<img[^>]*>//g; /^[[:space:]]*$/d; /^#/d' \
+            | head -3 | tr '\n' ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+        fi
+
+        if [[ -n "$summary" ]]; then
+          PR_DETAIL_LIST+="- #${number}: ${title}"$'\n'"  ${summary}"$'\n'
+        else
+          PR_DETAIL_LIST+="- #${number}: ${title}"$'\n'
+        fi
+      done < <(echo "$FILTERED_PRS" | jq -c '.[]')
     fi
   fi
 

--- a/.github/workflows/release_notes.yml
+++ b/.github/workflows/release_notes.yml
@@ -58,9 +58,9 @@ jobs:
           IS_DRAFT: ${{ inputs.draft }}
         run: |
           if [[ "$IS_DRAFT" == "true" ]]; then
-            TITLE="DC API ${CURRENT_TAG} (Draft Release)"
+            TITLE="🚀 DC API ${CURRENT_TAG} (Draft Release)"
           else
-            TITLE="DC API ${CURRENT_TAG} Released"
+            TITLE="🚀 DC API ${CURRENT_TAG} Released"
           fi
 
           PAYLOAD=$(jq -n \


### PR DESCRIPTION
## Summary 

Release notes are better when we provide part of the body of the PR along with the title to Claude for summarization.

## Specific Changes in this PR

- `.github/scripts/generate_release_notes.sh` - updated to include part of the body in the request
- `.github/PULL_REQUEST_TEMPLATE.md` - Add PR template that has a `## Summary` section
- `.github/PULL_REQUEST_TEMPLATE/production.md` - git rid of changelog (which is manually updated)
- `.github/workflows/release_notes.yml` - Add the 🚀  to the release notes title

## Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

## Steps to Test

```bash
export GITHUB_TOKEN=<your-gh-pat>
export CURRENT_TAG=v2.11.6
export PREVIOUS_TAG=v2.11.5
export AWS_REGION=us-east-1
export GITHUB_REPOSITORY=nulib/dc-api-v2
export DRY_RUN=true

bash .github/scripts/generate_release_notes.sh
```