### PR TITLE
Fix timestamp bug in release notes generation

### DIFF
--- a/.github/scripts/generate_release_notes.sh
+++ b/.github/scripts/generate_release_notes.sh
@@ -80,7 +80,12 @@ else
   # ---------------------------------------------------------------------------
   echo "==> Fetching merged PRs between ${PREVIOUS_TAG} and ${CURRENT_TAG}..."
 
-  PREVIOUS_TAG_DATE=$(git log -1 --format="%cI" "${PREVIOUS_TAG}")
+  # Get the date of the previous tag so we can filter PRs by merge date.
+  # Normalize to UTC so the jq string comparison works correctly against
+  # GitHub's Z-suffixed timestamps (a non-UTC offset like -07:00 would
+  # make "T15:...Z" > "T10:...-07:00" true even when the UTC time is later).
+  PREVIOUS_TAG_UNIX=$(git log -1 --format="%ct" "${PREVIOUS_TAG}")
+  PREVIOUS_TAG_DATE=$(date -u -d "@${PREVIOUS_TAG_UNIX}" "+%Y-%m-%dT%H:%M:%SZ")
   echo "    Previous tag date: ${PREVIOUS_TAG_DATE}"
 
   PR_RESPONSE=$(curl -s \


### PR DESCRIPTION
## Summary 

Release notes are sometimes summarizing PR's from the previous release/tag  causing items appearing in the incorrect release.

The root cause: `git log --format="%cI"` returns the date in the committer's local timezone (e.g., -07:00), but GitHub API timestamps are always UTC with a Z suffix. jq's > operator does a lexicographic string comparison, so "T15:43Z" sorts higher than "T10:49-07:00" even though the latter is actually later in real time.

## Specific Changes in this PR
- Use `%ct` (Unix timestamp, which is always UTC-based) and converts it to a Z-suffixed UTC string, so both sides of the jq comparison are in the same format.

## Testing

```bash
# login to staging with aws sso login

git fetch --tags

export GITHUB_TOKEN=<your-gh-pat-classic-repo-public-read>
export CURRENT_TAG=v2.11.5
export PREVIOUS_TAG=v2.11.4
export AWS_REGION=us-east-1
export GITHUB_REPOSITORY=nulib/dc-api-v2
export DRY_RUN=true

bash .github/scripts/generate_release_notes.sh
```

## Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [ ] Patch
- [ ] Minor
- [ ] Major
