### PR TITLE
Add chaos middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,35 @@ The API will be available at:
 
 [View supported endpoints](https://api.dc.library.northwestern.edu/docs/v2/spec/openapi.html) Questions? [View the production API documentation](https://api.dc.library.northwestern.edu/)
 
+### Chaos middleware
+
+The API supports simulated network effects (errors and delays) for local testing via the `CHAOS_CONFIG` environment variable. If the variable is absent the middleware is disabled entirely.
+
+Set it to an inline JSON array:
+
+```shell
+export CHAOS_CONFIG='[
+  { "pattern": "/works/:id", "effect": "error", "status": 500, "chance": 0.3 },
+  { "pattern": "/auth/whoami", "effect": "delay", "ms": 500 },
+  { "pattern": "/file-sets/*", "effect": "delay", "ms": [100, 800] }
+]'
+```
+
+Or set it to the path of a JSON file containing the same array:
+
+```shell
+export CHAOS_CONFIG=/path/to/chaos.json
+```
+
+Each rule has a `pattern` (matched against the request path) and an `effect`:
+
+| Effect | Fields | Behavior |
+|--------|--------|----------|
+| `error` | `status` (HTTP status code), `chance` (0–1) | Returns `{"error":"chaos"}` with the given status; fires `chance * 100`% of the time |
+| `delay` | `ms` (number or `[min, max]`) | Pauses for the given number of milliseconds (random within range if a tuple) |
+
+All matching rules are evaluated in order. Delay rules accumulate; an error rule short-circuits the request only when it fires — otherwise evaluation continues to the next rule.
+
 ## Example workflows
 
 ### Meadow

--- a/api/src/app.ts
+++ b/api/src/app.ts
@@ -25,6 +25,7 @@ import { handler as chatFeedback } from "./handlers/post-chat-feedback.ts";
 import { handler as optionsRequest } from "./handlers/options-request.ts";
 import { handler as workSearch } from "./handlers/get-work-search.ts";
 import middleware from "./handlers/middleware.ts";
+import chaosMiddleware from "./handlers/chaos-middleware.ts";
 import status from "http-status-codes";
 import Honeybadger from "@honeybadger-io/js";
 import setupHoneybadger from "./honeybadger-setup.ts";
@@ -42,6 +43,7 @@ type ErrorWithResponse = Error & {
 
 const app = new Hono<AppEnv>();
 
+if (chaosMiddleware) app.use("*", chaosMiddleware);
 app.use("*", middleware);
 app.use("*", async (c, next) => {
   await next();

--- a/api/src/handlers/chaos-middleware.ts
+++ b/api/src/handlers/chaos-middleware.ts
@@ -1,0 +1,114 @@
+import type { MiddlewareHandler } from "hono/types";
+import { createMiddleware } from "hono/factory";
+import { readFileSync } from "fs";
+import type { ContentfulStatusCode } from "hono/utils/http-status";
+
+type ErrorRule = {
+  pattern: string;
+  effect: "error";
+  status: number;
+  chance: number; // 0–1
+};
+
+type DelayRule = {
+  pattern: string;
+  effect: "delay";
+  ms: number | [number, number];
+};
+
+type ChaosRule = ErrorRule | DelayRule;
+
+function patternToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .replace(/[.+?^${}()|[\]\\]/g, "\\$&")
+    .replace(/\*/g, ".*")
+    .replace(/:[^/]+/g, "[^/]+");
+  // Allow any number of leading path segments so patterns work regardless of
+  // mount prefix (e.g. /works/:id matches both /works/123 and /api/v2/works/123).
+  return new RegExp(`^(/[^/]+)*${escaped}(/.*)?$`);
+}
+
+function loadConfig(): ChaosRule[] | null {
+  const raw = process.env["CHAOS_CONFIG"];
+  if (!raw) return null;
+
+  try {
+    return JSON.parse(raw) as ChaosRule[];
+  } catch {
+    try {
+      return JSON.parse(readFileSync(raw, "utf-8")) as ChaosRule[];
+    } catch {
+      console.error(`[chaos] Failed to load config from path: ${raw}`);
+      return null;
+    }
+  }
+}
+
+const rules = loadConfig();
+
+import type { Context } from "hono";
+
+// Each handler returns true if it short-circuits (i.e. a response was sent).
+type RuleHandler<T extends ChaosRule> = (
+  c: Context,
+  rule: T,
+) => ReturnType<MiddlewareHandler>;
+
+const applyError: RuleHandler<ErrorRule> = async (c, rule) => {
+  if (Math.random() >= rule.chance) return;
+  return c.json(
+    { error: `Chaos rule triggered: ${rule.pattern}` },
+    rule.status as ContentfulStatusCode,
+  );
+};
+
+const applyDelay: RuleHandler<DelayRule> = async (_c, rule) => {
+  const [lo, hi] = Array.isArray(rule.ms) ? rule.ms : [rule.ms, rule.ms];
+  await new Promise((res) => setTimeout(res, lo + Math.random() * (hi - lo)));
+};
+
+const handlers = {
+  error: applyError,
+  delay: applyDelay,
+} satisfies {
+  [K in ChaosRule["effect"]]: RuleHandler<Extract<ChaosRule, { effect: K }>>;
+};
+
+// Iterate all matching rules. Delay rules accumulate; an error rule that fires
+// short-circuits immediately. If an error rule doesn't fire, keep checking.
+const createChaos = (rules: ChaosRule[] | null) => {
+  if (!rules || rules.length === 0) return null;
+
+  return createMiddleware(async (c, next) => {
+    const path = new URL(c.req.url).pathname;
+
+    for (const rule of rules) {
+      if (!patternToRegex(rule.pattern).test(path)) continue;
+      const handler = handlers[rule.effect] as RuleHandler<typeof rule>;
+      const handlerResponse = await handler(c, rule);
+      if (handlerResponse) return handlerResponse;
+    }
+
+    await next();
+  });
+};
+
+const logRules = (rules: ChaosRule[] | null) => {
+  if (!rules || rules.length === 0) return;
+  console.warn("[chaos] Loaded rules:");
+  for (const rule of rules) {
+    if (rule.effect === "error") {
+      console.warn(
+        `[chaos]   ${rule.pattern} -> error ${rule.status} (${rule.chance})`,
+      );
+    } else if (rule.effect === "delay") {
+      const ms = Array.isArray(rule.ms)
+        ? `${rule.ms[0]}-${rule.ms[1]}`
+        : rule.ms;
+      console.warn(`[chaos]   ${rule.pattern} -> delay ${ms}ms`);
+    }
+  }
+};
+
+logRules(rules ?? []);
+export default createChaos(rules);


### PR DESCRIPTION
## Summary 
Add minimal chaos middleware for testing network glitches and race conditions in dev mode

## Specific Changes in this PR
- Create chaos middleware handler
- Add new handler to main API in `app.ts`
- Update README to include instructions on using chaos middleware 

## Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

## Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 
