### PR TITLE
Configure magic login ses permissions

### DIFF
--- a/api/template.yaml
+++ b/api/template.yaml
@@ -210,6 +210,13 @@ Resources:
               Action:
                 - es:ESHttp*
               Resource: "*"
+            - Sid: SendMagicLinkEmail
+              Effect: Allow
+              Action:
+                - ses:SendTemplatedEmail
+              Resource:
+                - !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${RepositoryEmail}"
+                - !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:template/${AWS::StackName}-magic-link-template"
       Events:
         ApiEvent:
           Type: HttpApi


### PR DESCRIPTION
## Summary

Users of Digital Collections are reporting an error when they try to login via a Magic Link.

Grants the `apiFunction` Lambda the SES permissions it needs to send Magic Link login emails. The role previously had no `ses:` permissions at all, so every `SendTemplatedEmail` call was rejected with `AccessDenied` — first on the sender identity, then (after adding that) on the email template resource — blocking Magic Link login end-to-end.

fixes https://github.com/nulib/repodev_planning_and_docs/issues/5832

## Specific Changes in this PR
- Added a `SendMagicLinkEmail` statement to the `apiFunction` IAM policy in `api/template.yaml`, granting `ses:SendTemplatedEmail` scoped to:
  - the sender identity ARN (`identity/${RepositoryEmail}`)
  - the magic link template ARN (`template/${AWS::StackName}-magic-link-template`)

## Version bump required by the PR

- [x] Patch

## Steps to Test
1. Deploy this branch to a dev stack
2. Request a magic link: `GET /api/v2/auth/login/magic?email=<you>&goto=<dc-url>`.
3. Confirm a `200` response (`{"message":"Magic link sent", ...}`) instead of the previous `500`/`AccessDenied` error, and that the email arrives.
4. (optional) Check CloudWatch logs for the Lambda — should show `Magic link sent to <email>` with no `AccessDenied` errors.

