### PR TITLE
Use domain identity for SES repository email

### DIFF
--- a/api/template.yaml
+++ b/api/template.yaml
@@ -215,7 +215,9 @@ Resources:
               Action:
                 - ses:SendTemplatedEmail
               Resource:
-                - !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${RepositoryEmail}"
+                - !Sub
+                  - "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:identity/${EmailDomain}"
+                  - EmailDomain: !Select [1, !Split ["@", !Ref RepositoryEmail]]
                 - !Sub "arn:aws:ses:${AWS::Region}:${AWS::AccountId}:template/${AWS::StackName}-magic-link-template"
       Events:
         ApiEvent:


### PR DESCRIPTION
## Summary 

further refinement for https://github.com/nulib/repodev_planning_and_docs/issues/5832


## Specific Changes in this PR
- Standardize staging and prod repository email configuration - make staging use no-reply email as well and use domain based SES identity for both envs

## Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

## Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 
