### PR TITLE
Include Accept in Vary response header

### DIFF
--- a/api/src/handlers/middleware.ts
+++ b/api/src/handlers/middleware.ts
@@ -94,6 +94,7 @@ const encoding = createMiddleware(async (c, next) => {
   await next();
   const contentType = c.res.headers.get("content-type");
 
+  c.res.headers.set("vary", "Accept");
   if (!contentType) {
     c.res.headers.set("content-type", `application/json; charset=UTF-8`);
   } else {

--- a/api/src/helpers.ts
+++ b/api/src/helpers.ts
@@ -43,6 +43,7 @@ export const ExposedHeaders = [
   "Expires",
   "Last-Modified",
   "Pragma",
+  "Vary",
 ];
 
 export async function decodeToken(c: Context): Promise<ApiToken> {

--- a/api/test/integration/get-work-by-id.test.ts
+++ b/api/test/integration/get-work-by-id.test.ts
@@ -111,6 +111,7 @@ describe("Retrieve work by id", () => {
       expect(result.headers.get("content-type") ?? "").toMatch(
         /application\/json.*charset=UTF-8/i,
       );
+      expect(result.headers.get("vary") ?? "").toMatch(/Accept/i);
 
       const body = await result.json();
       expect(body.type).toEqual("Manifest");


### PR DESCRIPTION
## Summary 
Several IIIF validators issue warnings when `Vary: Accept` is not included in a manifest response. It's not really a problem, but it's good practice. This PR adds `Vary: Accept` to all responses, which is fine. (The Hono CORS middleware already adds `Vary: Origin`.)

It fixes the issue shown in yellow here on the [IIIF Service Dashboard](https://rism-digital.github.io/iiif-dashboard/):
<img width="581" height="930" alt="image" src="https://github.com/user-attachments/assets/a0a920ca-3013-46b6-947a-fda8559dcb5d" />


## Specific Changes in this PR
- Update `encoding` middleware to add the `Vary: Accept` header
- Include `Vary` in the CORS `Access-Control-Expose-Headers` list
- Update IIIF work manifest test to check for `Vary: Accept`

## Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

## Steps to Test
Request a work manifest (or anything else) and look at the response headers.