### PR TITLE
Allow the MCP similarity search to work with either a work ID or a work URI

### DIFF
--- a/mcp/apps/mcp/common/works.ts
+++ b/mcp/apps/mcp/common/works.ts
@@ -19,6 +19,9 @@ const ControlledFields = [
   "technique"
 ];
 
+const UUID_REGEX =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/i;
+
 export const controlledFieldList = (conjunction = "and") =>
   ControlledFields.slice(0, -1).join(", ") +
   `, ${conjunction} ` +
@@ -181,6 +184,8 @@ export const similarityworkSearchSchema = z.object({
 export const buildSimilaritySearchQuery = async (
   input: z.infer<typeof similarityworkSearchSchema>
 ) => {
+  const id = input.work_id.match(UUID_REGEX)?.[0] || input.work_id;
+  
   const mlt_query = {
     more_like_this: {
       fields: [
@@ -193,7 +198,7 @@ export const buildSimilaritySearchQuery = async (
       ],
       like: [
         {
-          _id: input.work_id
+          _id: id
         }
       ],
       max_query_terms: 10,
@@ -202,7 +207,7 @@ export const buildSimilaritySearchQuery = async (
     }
   };
 
-  const doc = await getWork(input.work_id, true);
+  const doc = await getWork(id, true);
   const work = doc?.data as components["schemas"]["Work"];
   const embedding = work?.embedding;
 
@@ -216,7 +221,7 @@ export const buildSimilaritySearchQuery = async (
           filter: {
             bool: {
               must_not: {
-                ids: { values: [input.work_id] }
+                ids: { values: [id] }
               }
             }
           }

--- a/mcp/test/integration.test.ts
+++ b/mcp/test/integration.test.ts
@@ -292,6 +292,28 @@ describe("MCP Server Integration Tests", () => {
       expect(response).toHaveProperty("pagination");
       expect(Array.isArray(response.data)).toBe(true);
     });
+
+    it("should extract the work ID from a URI if necessary", async () => {
+      const workId =
+        "https://api.dc.library.northwestern.edu/api/v2/works/6464c86a-29e0-4aeb-ac5c-8e1c9bb0dfc2?as=iiif";
+
+      const result = await context.client.callTool({
+        name: "similarity-search",
+        arguments: {
+          work_id: workId,
+          max_results: 5,
+          page: 1,
+          public_only: true
+        }
+      });
+
+      expect(result.content).toHaveLength(1);
+      const response = JSON.parse((result.content[0] as any).text);
+
+      expect(response).toHaveProperty("data");
+      expect(response).toHaveProperty("pagination");
+      expect(Array.isArray(response.data)).toBe(true);
+    });
   });
 
   describe("tool listing", () => {


### PR DESCRIPTION
## Summary 
A model might look at a manifest a think the full work URI is the ID to search by, so the `similarity-search` and `view-similar-works` tools should extract whatever looks like a UUID from the ID passed in.

## Specific Changes in this PR
- Extract UUID from `work_id`
- Add test that calls `similarity-search` with a work URI

## Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

## Steps to Test
Please let end users know what they need to do to test on staging or production

Also please let developers know if there are any special instructions to test this in the development environment. 
