### PR TITLE
Add MODS metadata format (metadataPrefix=mods) to the OAI-PMH endpoint

### DIFF
--- a/.github/workflows/production-types.yml
+++ b/.github/workflows/production-types.yml
@@ -31,11 +31,7 @@ jobs:
         with:
           path: "${{ env.TMP_SRCDIR }}"
           fetch-depth: 1
-      - uses: actions/setup-node@v4
-        with:
-          cache-dependency-path: "${{ env.TMP_SRCDIR }}/api/package-lock.json"
-          node-version: 20.x
-          cache: "npm"
+      - uses: oven-sh/setup-bun@v2
       - name: Set short git commit SHA
         working-directory: "${{ env.TMP_SRCDIR }}"
         id: short-sha
@@ -49,8 +45,8 @@ jobs:
       - name: Generate Typescript file
         working-directory: "${{ env.TMP_SRCDIR }}/api"
         run: |
-          npm ci
-          npx openapi-typescript ../docs/docs/spec/data-types.yaml --output schemas.ts
+          bun install
+          bun run schemas
       - name: Checkout nulib/dcapi-types
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/staging-types.yml
+++ b/.github/workflows/staging-types.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: "${{ env.TMP_SRCDIR }}/api"
         run: |
           bun install
-          bun x openapi-typescript ../docs/docs/spec/data-types.yaml --output schemas.ts
+          bun run schemas
       - name: Checkout dcapi-types
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -25,6 +25,8 @@ jobs:
         run: bun run test:coverage
       - name: Validate OpenAPI spec
         run: bun run validate-spec
+      - name: Check generated schema types are current
+        run: bun run schemas:check
   test-mcp:
     runs-on: ubuntu-latest
     defaults:

--- a/api/bun.lock
+++ b/api/bun.lock
@@ -41,6 +41,7 @@
         "bun-types": "latest",
         "eslint": "^9",
         "msw": "^2.0.0",
+        "openapi-typescript": "^7.13.0",
         "prettier": "^3",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.59.3",
@@ -126,6 +127,10 @@
 
     "@aws/lambda-invoke-store": ["@aws/lambda-invoke-store@0.2.4", "", {}, "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ=="],
 
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
     "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
@@ -193,6 +198,12 @@
     "@open-draft/logger": ["@open-draft/logger@0.3.0", "", { "dependencies": { "is-node-process": "^1.2.0", "outvariant": "^1.4.0" } }, "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ=="],
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
+
+    "@redocly/ajv": ["@redocly/ajv@8.11.2", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2", "uri-js-replace": "^1.0.1" } }, "sha512-io1JpnwtIcvojV7QKDUSIuMN/ikdOUd1ReEnUnMKGfDVridQZ31J0MmIuqwuRjWDZfmvr+Q0MqCcfHM2gTivOg=="],
+
+    "@redocly/config": ["@redocly/config@0.22.0", "", {}, "sha512-gAy93Ddo01Z3bHuVdPWfCwzgfaYgMdaZPcfL7JZ7hWJoK9V0lXDbigTWkhiPFAaLWzbOJ+kbUQG1+XwIm0KRGQ=="],
+
+    "@redocly/openapi-core": ["@redocly/openapi-core@1.34.19", "", { "dependencies": { "@redocly/ajv": "8.11.2", "@redocly/config": "0.22.0", "colorette": "1.4.0", "https-proxy-agent": "7.0.6", "js-levenshtein": "1.1.6", "js-yaml": "4.3.1", "minimatch": "5.1.9", "pluralize": "8.0.0", "yaml-ast-parser": "0.0.43" } }, "sha512-o/0VgsBXgwcY1lyeqcVtSGdTQAPnVggo0fbFVPlxl5XVDKUcVH0OLRqt3CbkwByT5FU305E0iE0O7MzThjDblw=="],
 
     "@sinonjs/commons": ["@sinonjs/commons@3.0.1", "", { "dependencies": { "type-detect": "4.0.8" } }, "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ=="],
 
@@ -296,9 +307,13 @@
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-colors": ["ansi-colors@4.1.3", "", {}, "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw=="],
 
     "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
@@ -330,6 +345,8 @@
 
     "chalk": ["chalk@4.1.2", "", { "dependencies": { "ansi-styles": "^4.1.0", "supports-color": "^7.1.0" } }, "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA=="],
 
+    "change-case": ["change-case@5.4.4", "", {}, "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w=="],
+
     "charenc": ["charenc@0.0.2", "", {}, "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="],
 
     "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
@@ -339,6 +356,8 @@
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "colorette": ["colorette@1.4.0", "", {}, "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
@@ -486,6 +505,8 @@
 
     "http-status-codes": ["http-status-codes@2.3.0", "", {}, "sha512-RJ8XvFvpPM/Dmc5SV+dC4y5PCeOhT3x1Hq0NU3rjGeg5a/CqlhZ7uudknPwZFz4aeAXDcbAyaeP7GAo9lvngtA=="],
 
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
@@ -495,6 +516,8 @@
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
+    "index-to-position": ["index-to-position@1.2.0", "", {}, "sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
@@ -517,6 +540,10 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jose": ["jose@5.10.0", "", {}, "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg=="],
+
+    "js-levenshtein": ["js-levenshtein@1.1.6", "", {}, "sha512-X2BB11YZtrRqY4EnQcLX5Rh373zbK4alC1FW7D7MBhL2gtcC17cTnr6DmfHZeS0s2rTHjUTMMHfG7gO8SSdw+g=="],
+
+    "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
@@ -584,6 +611,8 @@
 
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
+    "openapi-typescript": ["openapi-typescript@7.13.0", "", { "dependencies": { "@redocly/openapi-core": "^1.34.6", "ansi-colors": "^4.1.3", "change-case": "^5.4.4", "parse-json": "^8.3.0", "supports-color": "^10.2.2", "yargs-parser": "^21.1.1" }, "peerDependencies": { "typescript": "^5.x" }, "bin": { "openapi-typescript": "bin/cli.js" } }, "sha512-EFP392gcqXS7ntPvbhBzbF8TyBA+baIYEm791Hy5YkjDYKTnk/Tn5OQeKm5BIZvJihpp8Zzr4hzx0Irde1LNGQ=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "outvariant": ["outvariant@1.4.3", "", {}, "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA=="],
@@ -595,6 +624,8 @@
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
 
     "parse-http-header": ["parse-http-header@1.0.1", "", {}, "sha512-xOoH7vzokDoenX4e3c+4ik8lf30kq9Pawq20TH5uq3RURsIJquqFTE0gS7OAEE6nvMQzuP5OXxubYuN7YLsTiw=="],
+
+    "parse-json": ["parse-json@8.3.0", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "index-to-position": "^1.1.0", "type-fest": "^4.39.1" } }, "sha512-ybiGyvspI+fAoRQbIPRddCcSTV9/LsJbf0e/S85VLowVGzRmokfneg2kwVW/KU5rOXrPSbF1qAKPMgNTqqROQQ=="],
 
     "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
 
@@ -611,6 +642,8 @@
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
+
+    "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
@@ -688,7 +721,7 @@
 
     "strnum": ["strnum@2.3.0", "", {}, "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q=="],
 
-    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
 
     "tagged-tag": ["tagged-tag@1.0.0", "", {}, "sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng=="],
 
@@ -730,6 +763,8 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "uri-js-replace": ["uri-js-replace@1.0.1", "", {}, "sha512-W+C9NWNLFOoBI2QWDp4UT9pv65r2w5Cx+3sTYFvtMdDBxkKt1syCqsUdSFAChbEe1uK5TfS04wt/nGwmaeIQ0g=="],
+
     "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "web-streams-polyfill": ["web-streams-polyfill@3.3.3", "", {}, "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw=="],
@@ -747,6 +782,8 @@
     "xml-naming": ["xml-naming@0.1.0", "", {}, "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw=="],
 
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
+
+    "yaml-ast-parser": ["yaml-ast-parser@0.0.43", "", {}, "sha512-2PTINUwsRqSd+s8XxKaJWQlUuEMHJQyEuh2edBbW8KNJz0SJPwUSD2zRWqezFEdN7IzAgeuYHFUCF7o8zRdZ0A=="],
 
     "yargs": ["yargs@17.7.2", "", { "dependencies": { "cliui": "^8.0.1", "escalade": "^3.1.1", "get-caller-file": "^2.0.5", "require-directory": "^2.1.1", "string-width": "^4.2.3", "y18n": "^5.0.5", "yargs-parser": "^21.1.1" } }, "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w=="],
 
@@ -818,6 +855,12 @@
 
     "@mswjs/interceptors/@open-draft/deferred-promise": ["@open-draft/deferred-promise@2.2.0", "", {}, "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA=="],
 
+    "@redocly/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@redocly/openapi-core/js-yaml": ["js-yaml@4.3.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ=="],
+
+    "@redocly/openapi-core/minimatch": ["minimatch@5.1.9", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw=="],
+
     "@sinonjs/samsam/type-detect": ["type-detect@4.1.0", "", {}, "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw=="],
 
     "@smithy/protocol-http/@smithy/types": ["@smithy/types@2.12.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-QwYgloJ0sVNBeBuBs65cIkTbfzV/Q6ZNPCJ99EICFEdJYG50nGIY/uYXp+TbsdJReIuPr0a0kXmCvren3MbRRw=="],
@@ -836,6 +879,8 @@
 
     "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
+    "chalk/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
     "express/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
@@ -846,9 +891,13 @@
 
     "nise/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
+    "parse-json/type-fest": ["type-fest@4.41.0", "", {}, "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA=="],
+
     "router/path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "send/mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
+    "sinon/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "stacktrace-parser/type-fest": ["type-fest@0.7.1", "", {}, "sha512-Ne2YiiGN8bmrmJJEuTWTLJR32nh/JdL1+PSicowtNb0WFpn59GK8/lfD61bVtzguz7b3PBt74nxpv/Pw5po5Rg=="],
 
@@ -903,6 +952,8 @@
     "@aws-sdk/util-format-url/@aws-sdk/core/@smithy/types": ["@smithy/types@4.14.3", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-YupL0ZWmFtJexUN2cHzkvvF/b9pKrtAIfT1o7/oY/Ppu8IYeZ+lDPM5vZdQJaSeA132dJCqojjGC9NhXeF71VQ=="],
 
     "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "@redocly/openapi-core/minimatch/brace-expansion": ["brace-expansion@2.1.4", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg=="],
 
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 

--- a/api/package.json
+++ b/api/package.json
@@ -14,6 +14,8 @@
     "lint": "eslint src test",
     "prettier": "prettier -c src test",
     "prettier:fix": "prettier -cw src test",
+    "schemas": "openapi-typescript ../docs/docs/spec/data-types.yaml --output schemas.ts",
+    "schemas:check": "openapi-typescript ../docs/docs/spec/data-types.yaml --output schemas.ts --check",
     "validate-spec": "bunx @openapitools/openapi-generator-cli validate -i ../docs/docs/spec/openapi.yaml"
   },
   "dependencies": {
@@ -53,6 +55,7 @@
     "bun-types": "latest",
     "eslint": "^9",
     "msw": "^2.0.0",
+    "openapi-typescript": "^7.13.0",
     "prettier": "^3",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.59.3"

--- a/api/schemas.ts
+++ b/api/schemas.ts
@@ -325,6 +325,8 @@ export interface components {
             published: boolean;
             /** @description An entity responsible for making the resource available. */
             publisher: string[];
+            /** @description Description of materials related to the resource. */
+            related_material: string[];
             /** @description URL of a related resource. */
             related_url: {
                 /** Format: uri */

--- a/api/src/dcapi-types.ts
+++ b/api/src/dcapi-types.ts
@@ -1,0 +1,29 @@
+// Friendly names for the schema types generated from
+// docs/docs/spec/data-types.yaml (see the schemas script in package.json),
+// mirroring the exports of the published @nulib/dcapi-types package. The API
+// consumes its own generated types directly so it never lags behind the spec;
+// the npm package is published (by the *-types workflows) for external
+// consumers only.
+
+import type { components } from "../schemas.ts";
+
+export type Collection = components["schemas"]["Collection"];
+export type CollectionRepresentativeImage =
+  components["schemas"]["CollectionRepresentativeImage"];
+export type ControlledTerm = components["schemas"]["ControlledTerm"];
+export type ControlledTermWithRole =
+  components["schemas"]["ControlledTermWithRole"];
+export type FileSet = components["schemas"]["FileSet"];
+export type FileSetBase = components["schemas"]["FileSetBase"];
+export type FileSetRole = components["schemas"]["FileSetRole"];
+export type LibraryUnit = components["schemas"]["LibraryUnit"];
+export type NoteType = components["schemas"]["NoteType"];
+export type PaginationInfo = components["schemas"]["PaginationInfo"];
+export type PreservationLevel = components["schemas"]["PreservationLevel"];
+export type RelatedUrlLabel = components["schemas"]["RelatedUrlLabel"];
+export type RepresentativeFileSet =
+  components["schemas"]["RepresentativeFileSet"];
+export type Status = components["schemas"]["Status"];
+export type Visibility = components["schemas"]["Visibility"];
+export type Work = components["schemas"]["Work"];
+export type WorkType = components["schemas"]["WorkType"];

--- a/api/src/handlers/oai.ts
+++ b/api/src/handlers/oai.ts
@@ -75,7 +75,7 @@ export const handler = async (c: Context<AppEnv>): Promise<Response> => {
 
   switch (verb) {
     case "GetRecord":
-      return await getRecord(url, identifier);
+      return await getRecord(url, identifier, metadataPrefix);
     case "Identify":
       return await identify(url);
     case "ListIdentifiers":

--- a/api/src/handlers/oai/mods-transformer.ts
+++ b/api/src/handlers/oai/mods-transformer.ts
@@ -1,0 +1,436 @@
+// Transforms a work document into a MODS v3.7 metadata element for the
+// OAI-PMH endpoint, implementing the Digital Collections to MODS crosswalk
+// (DigitalCollectionstoMODSJuly2026_forOAIPMH.xlsx)
+
+import type {
+  ControlledTerm,
+  ControlledTermWithRole,
+  Work,
+  WorkType,
+} from "../../dcapi-types.ts";
+
+export const MODS_NAMESPACE = "http://www.loc.gov/mods/v3";
+export const MODS_SCHEMA = "http://www.loc.gov/standards/mods/v3/mods-3-7.xsd";
+
+type XmlElement = Record<string, unknown>;
+
+// The helpers below keep their runtime guards even where the Work type makes
+// stronger promises, because indexed documents can predate the current schema
+
+function normalizeSpace(value: unknown): string {
+  return String(value).replace(/\s+/g, " ").trim();
+}
+
+function asArray<T>(value: T | T[] | null | undefined): T[] {
+  if (value === null || value === undefined) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function stringItems(value: string | string[] | null | undefined): string[] {
+  return asArray(value)
+    .filter((item): item is string => typeof item === "string")
+    .map(normalizeSpace)
+    .filter((item) => item !== "");
+}
+
+function termItems<T extends object>(value: T | T[] | null | undefined): T[] {
+  return asArray(value).filter(
+    (item): item is T =>
+      typeof item === "object" && item !== null && !Array.isArray(item),
+  );
+}
+
+function textElement(value: unknown): XmlElement {
+  return { _text: normalizeSpace(value) };
+}
+
+function validUri(id: unknown): string | undefined {
+  return typeof id === "string" && id !== "" && id !== "null" ? id : undefined;
+}
+
+function titleInfo(work: Work): XmlElement[] {
+  const result: XmlElement[] = [];
+  if (work.title) result.push({ "mods:title": textElement(work.title) });
+  for (const title of [
+    ...stringItems(work.alternate_title),
+    ...stringItems(work.caption),
+  ]) {
+    result.push({
+      _attributes: { type: "alternative" },
+      "mods:title": textElement(title),
+    });
+  }
+  return result;
+}
+
+function name(
+  item: ControlledTerm | ControlledTermWithRole,
+  defaultRole: string,
+): XmlElement {
+  const element: XmlElement = {};
+  const valueURI = validUri(item.id);
+  if (valueURI) element._attributes = { valueURI };
+  const role = ("role" in item && item.role) || defaultRole;
+  if (role) {
+    element["mods:role"] = {
+      "mods:roleTerm": { _attributes: { type: "text" }, _text: role },
+    };
+  }
+  element["mods:namePart"] = textElement(item.label);
+  element["mods:displayForm"] = textElement(item.label);
+  return element;
+}
+
+function names(work: Work): XmlElement[] {
+  return [
+    ...termItems(work.creator).map((item) => name(item, "Creator")),
+    ...termItems(work.contributor).map((item) => name(item, "Contributor")),
+  ];
+}
+
+const typeOfResourceMap: Record<
+  NonNullable<WorkType>,
+  { valueURI: string; value: string }
+> = {
+  Image: {
+    valueURI: "https://www.loc.gov/standards/mods/userguide/typeofresource/img",
+    value: "still image",
+  },
+  Video: {
+    valueURI: "https://www.loc.gov/standards/mods/userguide/typeofresource/mov",
+    value: "moving image",
+  },
+  Audio: {
+    valueURI: "https://www.loc.gov/standards/mods/userguide/typeofresource/aud",
+    value: "audio",
+  },
+};
+
+function typeOfResource(work: Work): XmlElement | undefined {
+  const mapped = work.work_type ? typeOfResourceMap[work.work_type] : undefined;
+  if (!mapped) return undefined;
+  return { _attributes: { valueURI: mapped.valueURI }, _text: mapped.value };
+}
+
+function genres(work: Work): XmlElement[] {
+  return [...termItems(work.genre), ...termItems(work.technique)].map(
+    (item) => {
+      const valueURI = validUri(item.id);
+      return {
+        ...(valueURI && { _attributes: { valueURI } }),
+        _text: normalizeSpace(item.label),
+      };
+    },
+  );
+}
+
+function originInfo(work: Work): XmlElement | undefined {
+  const publishers = stringItems(work.publisher);
+  const datesCreated = stringItems(work.date_created);
+  if (publishers.length === 0 && datesCreated.length === 0) return undefined;
+  return {
+    ...(publishers.length > 0 && {
+      "mods:publisher": publishers.map(textElement),
+    }),
+    ...(datesCreated.length > 0 && {
+      "mods:dateCreated": datesCreated.map(textElement),
+    }),
+  };
+}
+
+const languageUriPrefix = "http://id.loc.gov/vocabulary/languages/";
+
+function languages(work: Work): XmlElement[] {
+  return termItems(work.language).map((item) => {
+    const valueURI = validUri(item.id);
+    return {
+      "mods:languageTerm": [
+        {
+          _attributes: { type: "text", ...(valueURI && { valueURI }) },
+          _text: normalizeSpace(item.label),
+        },
+        {
+          _attributes: {
+            type: "code",
+            authority: "iso639-2b",
+            ...(valueURI && { valueURI }),
+          },
+          _text: valueURI?.startsWith(languageUriPrefix)
+            ? valueURI.slice(languageUriPrefix.length)
+            : normalizeSpace(item.id ?? ""),
+        },
+      ],
+    };
+  });
+}
+
+function physicalDescription(work: Work): XmlElement | undefined {
+  const materials = stringItems(work.physical_description_material);
+  const sizes = stringItems(work.physical_description_size);
+  const extent = [materials.join(", "), sizes.join(", ")]
+    .filter((part) => part !== "")
+    .join("; ");
+  if (extent === "") return undefined;
+  return { "mods:extent": { _text: extent } };
+}
+
+function notes(work: Work): XmlElement[] {
+  const result: XmlElement[] = [];
+  for (const item of termItems(work.notes)) {
+    if (!item.note || normalizeSpace(item.note) === "") continue;
+    result.push({
+      _attributes: { displayLabel: item.type ?? "General Note" },
+      _text: normalizeSpace(item.note),
+    });
+  }
+  for (const scopeAndContents of stringItems(work.scope_and_contents)) {
+    result.push({
+      _attributes: { displayLabel: "Scope and Contents" },
+      _text: scopeAndContents,
+    });
+  }
+  return result;
+}
+
+function fullTextNote(work: Work): XmlElement {
+  const strings: string[] = [];
+  const walk = (value: unknown): void => {
+    if (typeof value === "string") {
+      const normalized = normalizeSpace(value);
+      if (normalized !== "") strings.push(normalized);
+    } else if (Array.isArray(value)) {
+      value.forEach(walk);
+    } else if (typeof value === "object" && value !== null) {
+      Object.values(value).forEach(walk);
+    }
+  };
+  walk(work);
+  return {
+    _attributes: { type: "for indexing only" },
+    _text: strings.join("  "),
+  };
+}
+
+function accessConditions(work: Work): XmlElement[] {
+  const result: XmlElement[] = [];
+  const rightsStatement = work.rights_statement;
+  if (rightsStatement?.label) {
+    const href = validUri(rightsStatement.id);
+    result.push({
+      _attributes: { type: "rights", ...(href && { "xlink:href": href }) },
+      _text: normalizeSpace(rightsStatement.label),
+    });
+  }
+  for (const termsOfUse of stringItems(work.terms_of_use)) {
+    result.push({
+      _attributes: { type: "useAndReproduction" },
+      _text: termsOfUse,
+    });
+  }
+  return result;
+}
+
+const subjectElementForRole: Record<string, string> = {
+  Topical: "mods:topic",
+  Temporal: "mods:temporal",
+  Geographical: "mods:geographic",
+};
+
+function subjects(work: Work): XmlElement[] {
+  const result: XmlElement[] = [];
+  for (const item of termItems(work.subject)) {
+    const childName = subjectElementForRole[item.role] ?? "mods:topic";
+    const valueURI = validUri(item.id);
+    result.push({
+      ...(valueURI && { _attributes: { valueURI } }),
+      [childName]: textElement(item.label),
+    });
+  }
+  for (const item of termItems(work.style_period)) {
+    const valueURI = validUri(item.id);
+    result.push({
+      ...(valueURI && { _attributes: { valueURI } }),
+      "mods:topic": textElement(item.label),
+    });
+  }
+  return result;
+}
+
+function identifiers(work: Work): XmlElement[] {
+  const result: XmlElement[] = stringItems(work.identifier).map((item) => ({
+    _attributes: { type: "local" },
+    _text: item,
+  }));
+  result.push({
+    _attributes: { displayLabel: "PID", type: "local" },
+    _text: work.id,
+  });
+  return result;
+}
+
+function locations(work: Work): XmlElement[] {
+  const urls: XmlElement[] = [
+    {
+      _attributes: {
+        displayLabel: "Digitized Image",
+        access: "object in context",
+        ...(work.visibility === "Institution" && { note: "netID" }),
+      },
+      _text: `https://dc.library.northwestern.edu/items/${work.id}`,
+    },
+  ];
+  const representativeFileSet = work.representative_file_set;
+  if (representativeFileSet?.url) {
+    urls.push({
+      _attributes: { displayLabel: "Thumbnail", note: "thumbnail" },
+      _text: `${representativeFileSet.url}/square/100,100/0/default.jpg`,
+    });
+  }
+  const result: XmlElement[] = [{ "mods:url": urls }];
+
+  const localIdentifiers = stringItems(work.identifier);
+  if (work.library_unit || localIdentifiers.length > 0) {
+    const physicalLocation: XmlElement = {};
+    if (work.library_unit)
+      physicalLocation["mods:physicalLocation"] = textElement(
+        work.library_unit,
+      );
+    if (localIdentifiers.length > 0)
+      physicalLocation["mods:shelfLocator"] = { _text: localIdentifiers[0] };
+    result.push(physicalLocation);
+  }
+  return result;
+}
+
+function recordInfo(work: Work): XmlElement {
+  return {
+    "mods:recordOrigin": {
+      _text: "Northwestern University Libraries Digital Collections API",
+    },
+    "mods:recordContentSource": {
+      _attributes: { authority: "marcorg" },
+      _text: "IEN",
+    },
+    "mods:recordCreationDate": {
+      _attributes: { encoding: "marc" },
+      _text: work.create_date,
+    },
+    "mods:recordIdentifier": {
+      _attributes: { source: "IEN" },
+      _text: work.id,
+    },
+    "mods:languageOfCataloging": {
+      "mods:languageTerm": {
+        _attributes: { authority: "iso639-2b", type: "code" },
+        _text: "eng",
+      },
+    },
+    "mods:recordInfoNote": { _text: "item" },
+  };
+}
+
+function relatedItems(work: Work): XmlElement[] {
+  const result: XmlElement[] = [];
+
+  const collection = work.collection;
+  if (collection?.title) {
+    result.push({
+      _attributes: { type: "host", displayLabel: "Collection" },
+      "mods:titleInfo": { "mods:title": textElement(collection.title) },
+      "mods:identifier": {
+        _attributes: { displayLabel: "Collection PID", type: "local" },
+        _text: collection.id,
+      },
+    });
+  }
+
+  for (const series of stringItems(work.series)) {
+    result.push({
+      _attributes: { type: "series" },
+      "mods:titleInfo": { "mods:title": { _text: series } },
+    });
+  }
+
+  for (const relatedUrl of termItems(work.related_url)) {
+    if (!relatedUrl.url) continue;
+    result.push({
+      _attributes: {
+        otherType: "Related URL",
+        ...(relatedUrl.label && { displayLabel: relatedUrl.label }),
+      },
+      "mods:location": { "mods:url": textElement(relatedUrl.url) },
+    });
+  }
+
+  for (const relatedMaterial of stringItems(work.related_material)) {
+    result.push({
+      _attributes: {
+        otherType: "Related Material",
+        displayLabel: "Related Material",
+      },
+      "mods:titleInfo": { "mods:title": { _text: relatedMaterial } },
+    });
+  }
+
+  for (const source of stringItems(work.source)) {
+    result.push({
+      _attributes: { type: "original", displayLabel: "Source" },
+      "mods:titleInfo": { "mods:title": { _text: source } },
+    });
+  }
+
+  result.push({
+    _attributes: { type: "host", otherType: "sourceSystem" },
+    "mods:titleInfo": {
+      "mods:title": { _text: "Digital Collections Images Repository" },
+    },
+  });
+
+  return result;
+}
+
+export function modsTransform(work: Work): Record<string, unknown> {
+  const mods: XmlElement = {
+    _attributes: {
+      "xmlns:mods": MODS_NAMESPACE,
+      "xmlns:xlink": "http://www.w3.org/1999/xlink",
+      "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+      "xsi:schemaLocation": `${MODS_NAMESPACE} ${MODS_SCHEMA}`,
+      version: "3.7",
+    },
+  };
+
+  const addIfPresent = (
+    elementName: string,
+    value: XmlElement | XmlElement[] | undefined,
+  ): void => {
+    if (value === undefined) return;
+    if (Array.isArray(value) && value.length === 0) return;
+    mods[elementName] = value;
+  };
+
+  addIfPresent("mods:titleInfo", titleInfo(work));
+  addIfPresent("mods:name", names(work));
+  addIfPresent("mods:typeOfResource", typeOfResource(work));
+  addIfPresent("mods:genre", genres(work));
+  addIfPresent("mods:originInfo", originInfo(work));
+  addIfPresent("mods:language", languages(work));
+  addIfPresent("mods:physicalDescription", physicalDescription(work));
+  addIfPresent("mods:abstract", [
+    ...stringItems(work.description).map(textElement),
+    ...stringItems(work.abstract).map(textElement),
+  ]);
+  addIfPresent(
+    "mods:tableOfContents",
+    stringItems(work.table_of_contents).map(textElement),
+  );
+  addIfPresent("mods:note", [...notes(work), fullTextNote(work)]);
+  addIfPresent("mods:accessCondition", accessConditions(work));
+  addIfPresent("mods:subject", subjects(work));
+  addIfPresent("mods:identifier", identifiers(work));
+  addIfPresent("mods:location", locations(work));
+  addIfPresent("mods:recordInfo", recordInfo(work));
+  addIfPresent("mods:relatedItem", relatedItems(work));
+
+  return { "mods:mods": mods };
+}

--- a/api/src/handlers/oai/verbs.ts
+++ b/api/src/handlers/oai/verbs.ts
@@ -2,12 +2,18 @@ import { invalidOaiRequest, output } from "../oai/xml-transformer.ts";
 import { earliestRecord, oaiSearch, oaiSets } from "../oai/search.ts";
 import { deleteScroll, getWork, scroll } from "../../api/opensearch.ts";
 import { formatOaiDate } from "./date-utils.ts";
+import {
+  MODS_NAMESPACE,
+  MODS_SCHEMA,
+  modsTransform,
+} from "./mods-transformer.ts";
 import type {
   OpenSearchGetResponse,
   OpenSearchSearchResponse,
 } from "../../api/opensearch-types.ts";
+import type { Collection, Work } from "../../dcapi-types.ts";
 
-const fieldMapper: Record<string, string> = {
+const fieldMapper: Partial<Record<keyof Work, string>> = {
   contributor: "dc:contributor",
   create_date: "dc:date",
   description: "dc:description",
@@ -23,6 +29,39 @@ const fieldMapper: Record<string, string> = {
   subject: "dc:subject",
   work_type: "dc:type",
 };
+
+const SUPPORTED_METADATA_PREFIXES = ["oai_dc", "mods"];
+
+const unsupportedMetadataPrefix = (metadataPrefix: string): Response =>
+  invalidOaiRequest(
+    "cannotDisseminateFormat",
+    `The metadata format identified by '${metadataPrefix}' is not supported by this repository`,
+  );
+
+// Scroll-based resumptionTokens carry no format information of their own, so
+// non-default formats are prepended to the token (e.g. "mods:<scrollId>").
+// A bare token is an oai_dc scroll id, which keeps old tokens valid.
+function encodeResumptionToken(
+  scrollId: string,
+  metadataPrefix: string,
+): string {
+  if (!scrollId || metadataPrefix === "oai_dc") return scrollId;
+  return `${metadataPrefix}:${scrollId}`;
+}
+
+function decodeResumptionToken(token: string): {
+  scrollId: string;
+  metadataPrefix: string;
+} {
+  const separator = token.indexOf(":");
+  if (separator > -1) {
+    const prefix = token.slice(0, separator);
+    if (SUPPORTED_METADATA_PREFIXES.includes(prefix)) {
+      return { scrollId: token.slice(separator + 1), metadataPrefix: prefix };
+    }
+  }
+  return { scrollId: token, metadataPrefix: "oai_dc" };
+}
 
 const oaiAttributes = {
   xmlns: "http://www.openarchives.org/OAI/2.0/",
@@ -77,30 +116,37 @@ function extractSingleValue(
   }
 }
 
-function header(work: Record<string, unknown>): Record<string, unknown> {
+function header(work: Work): Record<string, unknown> {
   let fields: Record<string, unknown> = {
     identifier: work.id,
-    datestamp: formatOaiDate(work.modified_date as string),
+    datestamp: formatOaiDate(work.modified_date),
   };
 
-  if (work?.collection && Object.keys(work.collection as object).length > 0) {
-    fields = {
-      ...fields,
-      setSpec: (work.collection as Record<string, unknown>).id,
-    };
+  if (work.collection && Object.keys(work.collection).length > 0) {
+    fields = { ...fields, setSpec: work.collection.id };
   }
 
   return fields;
 }
 
-function transform(work: Record<string, unknown>): Record<string, unknown> {
-  const filteredWork = Object.keys(work)
+function transform(
+  work: Work,
+  metadataPrefix = "oai_dc",
+): Record<string, unknown> {
+  const metadata =
+    metadataPrefix === "mods" ? modsTransform(work) : oaiDcTransform(work);
+  return { header: { ...header(work) }, metadata };
+}
+
+function oaiDcTransform(work: Work): Record<string, unknown> {
+  const filteredWork = (Object.keys(work) as (keyof Work)[])
     .filter((key) => Object.keys(fieldMapper).includes(key))
     .reduce((obj: Record<string, unknown>, key) => {
       const dcFieldName = fieldMapper[key];
       const extractedValue = extractDcValue(key, work[key]);
 
       if (
+        dcFieldName &&
         extractedValue !== null &&
         extractedValue !== undefined &&
         !(Array.isArray(extractedValue) && extractedValue.length === 0)
@@ -111,42 +157,38 @@ function transform(work: Record<string, unknown>): Record<string, unknown> {
       return obj;
     }, {});
 
-  const metadata = {
-    metadata: {
-      "oai_dc:dc": {
-        _attributes: {
-          "xmlns:oai_dc": "http://www.openarchives.org/OAI/2.0/oai_dc/",
-          "xmlns:dc": "http://purl.org/dc/elements/1.1/",
-          "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
-          "xsi:schemaLocation":
-            "http://www.openarchives.org/OAI/2.0/oai_dc/\nhttp://www.openarchives.org/OAI/2.0/oai_dc.xsd",
-        },
-        ...filteredWork,
+  return {
+    "oai_dc:dc": {
+      _attributes: {
+        "xmlns:oai_dc": "http://www.openarchives.org/OAI/2.0/oai_dc/",
+        "xmlns:dc": "http://purl.org/dc/elements/1.1/",
+        "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
+        "xsi:schemaLocation":
+          "http://www.openarchives.org/OAI/2.0/oai_dc/\nhttp://www.openarchives.org/OAI/2.0/oai_dc.xsd",
       },
+      ...filteredWork,
     },
   };
-
-  return { header: { ...header(work) }, ...metadata };
 }
 
 export const getRecord = async (
   url: string,
   id: string | undefined,
+  metadataPrefix = "oai_dc",
 ): Promise<Response> => {
   if (!id)
     return invalidOaiRequest(
       "badArgument",
       "You must supply an identifier for GetRecord requests",
     );
+  if (!SUPPORTED_METADATA_PREFIXES.includes(metadataPrefix))
+    return unsupportedMetadataPrefix(metadataPrefix);
 
   const esResponse = await getWork(id);
   if (esResponse.status === 200) {
-    const work = (
-      JSON.parse(esResponse.body) as OpenSearchGetResponse<
-        Record<string, unknown>
-      >
-    )._source!;
-    const record = transform(work);
+    const work = (JSON.parse(esResponse.body) as OpenSearchGetResponse<Work>)
+      ._source!;
+    const record = transform(work, metadataPrefix);
     const document = {
       "OAI-PMH": {
         _attributes: oaiAttributes,
@@ -155,7 +197,7 @@ export const getRecord = async (
           _attributes: {
             verb: "GetRecord",
             identifier: id,
-            metadataPrefix: "oai_dc",
+            metadataPrefix,
           },
           _text: url,
         },
@@ -206,15 +248,22 @@ export const listIdentifiers = async (
       "Missing required metadataPrefix argument",
     );
   }
-  const response =
+  if (metadataPrefix && !SUPPORTED_METADATA_PREFIXES.includes(metadataPrefix))
+    return unsupportedMetadataPrefix(metadataPrefix);
+
+  const decodedToken =
     typeof resumptionToken === "string" && resumptionToken.length !== 0
-      ? await scroll(resumptionToken)
-      : await oaiSearch(dates, set);
+      ? decodeResumptionToken(resumptionToken)
+      : undefined;
+  const format = decodedToken?.metadataPrefix ?? metadataPrefix ?? "oai_dc";
+  const response = decodedToken
+    ? await scroll(decodedToken.scrollId)
+    : await oaiSearch(dates, set);
 
   if (response.status === 200) {
-    const responseBody = JSON.parse(response.body) as OpenSearchSearchResponse<
-      Record<string, unknown>
-    >;
+    const responseBody = JSON.parse(
+      response.body,
+    ) as OpenSearchSearchResponse<Work>;
     const {
       hits: { hits },
     } = responseBody;
@@ -232,7 +281,7 @@ export const listIdentifiers = async (
           (response as { expiration?: string }).expiration,
         ),
       },
-      _text: scrollId,
+      _text: encodeResumptionToken(scrollId, format),
     };
     const obj = {
       "OAI-PMH": {
@@ -276,11 +325,18 @@ export const listMetadataFormats = (url: string): Response => {
       responseDate: formatOaiDate(new Date()),
       request: { _attributes: { verb: "ListMetadataFormats" }, _text: url },
       ListMetadataFormats: {
-        metadataFormat: {
-          metadataPrefix: "oai_dc",
-          schema: "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
-          metadataNamespace: "http://www.openarchives.org/OAI/2.0/oai_dc/",
-        },
+        metadataFormat: [
+          {
+            metadataPrefix: "oai_dc",
+            schema: "http://www.openarchives.org/OAI/2.0/oai_dc.xsd",
+            metadataNamespace: "http://www.openarchives.org/OAI/2.0/oai_dc/",
+          },
+          {
+            metadataPrefix: "mods",
+            schema: MODS_SCHEMA,
+            metadataNamespace: MODS_NAMESPACE,
+          },
+        ],
       },
     },
   };
@@ -300,15 +356,22 @@ export const listRecords = async (
       "Missing required metadataPrefix argument",
     );
   }
-  const response =
+  if (metadataPrefix && !SUPPORTED_METADATA_PREFIXES.includes(metadataPrefix))
+    return unsupportedMetadataPrefix(metadataPrefix);
+
+  const decodedToken =
     typeof resumptionToken === "string" && resumptionToken.length !== 0
-      ? await scroll(resumptionToken)
-      : await oaiSearch(dates, set);
+      ? decodeResumptionToken(resumptionToken)
+      : undefined;
+  const format = decodedToken?.metadataPrefix ?? metadataPrefix ?? "oai_dc";
+  const response = decodedToken
+    ? await scroll(decodedToken.scrollId)
+    : await oaiSearch(dates, set);
 
   if (response.status === 200) {
-    const responseBody = JSON.parse(response.body) as OpenSearchSearchResponse<
-      Record<string, unknown>
-    >;
+    const responseBody = JSON.parse(
+      response.body,
+    ) as OpenSearchSearchResponse<Work>;
     const {
       hits: { hits },
     } = responseBody;
@@ -319,14 +382,14 @@ export const listRecords = async (
       scrollId = "";
     }
 
-    const records = hits.map((hit) => transform(hit._source));
+    const records = hits.map((hit) => transform(hit._source, format));
     const resumptionTokenElement = {
       _attributes: {
         expirationDate: formatOaiDate(
           (response as { expiration?: string }).expiration,
         ),
       },
-      _text: scrollId,
+      _text: encodeResumptionToken(scrollId, format),
     };
     const obj = {
       "OAI-PMH": {
@@ -361,7 +424,7 @@ export const listSets = async (url: string): Promise<Response> => {
   const response = await oaiSets();
   if (response.status === 200) {
     const responseBody = JSON.parse(response.body) as OpenSearchSearchResponse<
-      Record<string, unknown>
+      Pick<Collection, "id" | "title">
     >;
     const {
       hits: { hits },

--- a/api/test/integration/oai.test.ts
+++ b/api/test/integration/oai.test.ts
@@ -18,6 +18,7 @@ import {
   teardownEnv,
   testFixture,
 } from "../test-helpers/index.ts";
+import { formatOaiDate } from "../../src/handlers/oai/date-utils.ts";
 
 const SCROLL_TOKEN =
   "FGluY2x1ZGVfY29udGV4dF91dWlkDXF1ZXJ5QW5kRmV0Y2gBFm1jN3ZCajdnUURpbUhad1hIYnNsQmcAAAAAAAB2DhZXbmtMZVF5Q1JsMi1ScGRsYUlHLUtB";
@@ -32,6 +33,12 @@ const xmlOpts = {
 function parseXml(text: string): any {
   return xmlJs.xml2js(text, xmlOpts);
 }
+
+describe("formatOaiDate", () => {
+  it("returns undefined for an invalid Date object", () => {
+    expect(formatOaiDate(new Date("invalid"))).toBeUndefined();
+  });
+});
 
 describe("Oai routes", () => {
   const server = setupServer();
@@ -88,10 +95,33 @@ describe("Oai routes", () => {
       expect("dc:type" in metadata).toBe(true);
     });
 
-    it("properly extracts values from complex fields for GetRecord", async () => {
+    it("strips fractional seconds from datestamps that cannot be parsed as dates", async () => {
+      const work = JSON.parse(testFixture("mocks/work-1234.json"));
+      work._source.modified_date = "9999-99-99T99:99:99.123456Z";
       server.use(
         http.get(`https://${TEST_OPENSEARCH_HOST}/dc-v2-work/_doc/1234`, () =>
-          HttpResponse.json(JSON.parse(testFixture("mocks/work-1234.json"))),
+          HttpResponse.json(work),
+        ),
+      );
+
+      const req = buildRequest("POST", "/oai", {
+        body: "verb=GetRecord&identifier=1234&metadataPrefix=oai_dc",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+
+      const resultBody = parseXml(await result.text());
+      const header = resultBody["OAI-PMH"].GetRecord.record.header;
+      expect(header.datestamp._text).toEqual("9999-99-99T99:99:99Z");
+    });
+
+    it("properly extracts values from complex fields for GetRecord", async () => {
+      const work = JSON.parse(testFixture("mocks/work-1234.json"));
+      work._source.work_type = { label: "Sound" };
+      server.use(
+        http.get(`https://${TEST_OPENSEARCH_HOST}/dc-v2-work/_doc/1234`, () =>
+          HttpResponse.json(work),
         ),
       );
 
@@ -147,6 +177,322 @@ describe("Oai routes", () => {
 
       // Verify rights contains label
       expect(metadata["dc:rights"]._text.includes("Copyright")).toBe(true);
+
+      // Verify object fields without special handling fall back to label
+      expect(metadata["dc:type"]._text).toEqual("Sound");
+    });
+
+    it("supports the mods metadataPrefix for the GetRecord verb", async () => {
+      server.use(
+        http.get(`https://${TEST_OPENSEARCH_HOST}/dc-v2-work/_doc/1234`, () =>
+          HttpResponse.json(JSON.parse(testFixture("mocks/work-1234.json"))),
+        ),
+      );
+
+      const req = buildRequest("POST", "/oai", {
+        body: "verb=GetRecord&identifier=1234&metadataPrefix=mods",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+      expect(result.headers.get("content-type") ?? "").toMatch(
+        /application\/xml/,
+      );
+
+      const resultBody = parseXml(await result.text());
+      expect(resultBody["OAI-PMH"].request._attributes.metadataPrefix).toEqual(
+        "mods",
+      );
+
+      const record = resultBody["OAI-PMH"].GetRecord.record;
+      expect("identifier" in record.header).toBe(true);
+      const mods = record.metadata["mods:mods"];
+      expect(typeof mods === "object").toBe(true);
+      expect(mods._attributes["xmlns:mods"]).toEqual(
+        "http://www.loc.gov/mods/v3",
+      );
+
+      // titleInfo: main title plus alternate_title and caption as alternatives
+      expect(mods["mods:titleInfo"].length).toEqual(3);
+      expect(mods["mods:titleInfo"][0]["mods:title"]._text).toEqual(
+        "Canary Record TEST 1",
+      );
+      expect(mods["mods:titleInfo"][1]._attributes.type).toEqual("alternative");
+      expect(mods["mods:titleInfo"][1]["mods:title"]._text).toEqual(
+        "This is an alternative title",
+      );
+      expect(mods["mods:titleInfo"][2]["mods:title"]._text).toEqual("Beebo");
+
+      // names: creators first (default role Creator), then contributors with
+      // their own roles; valueURI carries the authority URI
+      const names = mods["mods:name"];
+      expect(names[0]._attributes.valueURI).toEqual(
+        "http://id.loc.gov/authorities/names/no2011059409",
+      );
+      expect(names[0]["mods:namePart"]._text).toEqual("Dessa (Vocalist)");
+      expect(names[0]["mods:displayForm"]._text).toEqual("Dessa (Vocalist)");
+      expect(names[0]["mods:role"]["mods:roleTerm"]._text).toEqual("Creator");
+      const metallica = names.find(
+        (n: { [key: string]: { _text: string } }) =>
+          n["mods:namePart"]._text === "Metallica (Musical group)",
+      );
+      expect(metallica["mods:role"]["mods:roleTerm"]._text).toEqual(
+        "Cartographer",
+      );
+
+      // typeOfResource from work_type
+      expect(mods["mods:typeOfResource"]._text).toEqual("still image");
+      expect(mods["mods:typeOfResource"]._attributes.valueURI).toEqual(
+        "https://www.loc.gov/standards/mods/userguide/typeofresource/img",
+      );
+
+      // genre includes both genre and technique terms
+      const genres = mods["mods:genre"].map((g: { _text: string }) => g._text);
+      expect(genres).toContain("Biographies");
+      expect(genres).toContain("drypoint (printing process)");
+
+      // originInfo
+      expect(mods["mods:originInfo"]["mods:publisher"]._text).toEqual(
+        "Northwestern University Press",
+      );
+      expect(mods["mods:originInfo"]["mods:dateCreated"][0]._text).toEqual(
+        "August 1906 to December 1910",
+      );
+
+      // language has text and code terms
+      const languageTerms = mods["mods:language"]["mods:languageTerm"];
+      expect(languageTerms[0]._text).toEqual("Crimean Tatar");
+      expect(languageTerms[1]._text).toEqual("crh");
+      expect(languageTerms[1]._attributes.authority).toEqual("iso639-2b");
+
+      // physicalDescription concatenates material and size
+      expect(mods["mods:physicalDescription"]["mods:extent"]._text).toEqual(
+        "Acrylic paint on cement block; 16 x 24 inches",
+      );
+
+      // abstract from description
+      expect(mods["mods:abstract"]._text).toEqual(
+        "This is a private record for RepoDev testing on production",
+      );
+
+      // notes carry displayLabel from note type; scope and contents included
+      const notes = mods["mods:note"];
+      const generalNote = notes.find(
+        (n: { _attributes?: { displayLabel?: string } }) =>
+          n._attributes?.displayLabel === "General Note",
+      );
+      expect(generalNote._text).toEqual("Here are some notes");
+      const scopeNote = notes.find(
+        (n: { _attributes?: { displayLabel?: string } }) =>
+          n._attributes?.displayLabel === "Scope and Contents",
+      );
+      expect(scopeNote._text).toEqual("I promise there is scope and content");
+      const indexingNote = notes.find(
+        (n: { _attributes?: { type?: string } }) =>
+          n._attributes?.type === "for indexing only",
+      );
+      expect(indexingNote._text).toContain("Canary Record TEST 1");
+
+      // accessCondition from rights_statement and terms_of_use
+      const accessConditions = mods["mods:accessCondition"];
+      expect(accessConditions[0]._attributes.type).toEqual("rights");
+      expect(accessConditions[0]._attributes["xlink:href"]).toEqual(
+        "http://rightsstatements.org/vocab/InC-EDU/1.0/",
+      );
+      expect(accessConditions[0]._text).toEqual(
+        "In Copyright - Educational Use Permitted",
+      );
+      expect(accessConditions[1]._attributes.type).toEqual(
+        "useAndReproduction",
+      );
+      expect(accessConditions[1]._text).toEqual("Terms");
+
+      // subjects use the right child element for their role
+      const subjects = mods["mods:subject"];
+      const geographic = subjects.find(
+        (s: Record<string, unknown>) => "mods:geographic" in s,
+      );
+      expect(geographic["mods:geographic"]._text).toEqual("Leelanau");
+      const stylePeriod = subjects.find(
+        (s: { _attributes?: { valueURI?: string } }) =>
+          s._attributes?.valueURI === "http://vocab.getty.edu/aat/300018478",
+      );
+      expect(stylePeriod["mods:topic"]._text).toEqual(
+        "Qing (dynastic styles and periods)",
+      );
+
+      // identifiers: local identifiers plus the PID
+      const identifiers = mods["mods:identifier"];
+      expect(identifiers[0]._text).toEqual("555");
+      expect(identifiers[1]._attributes.displayLabel).toEqual("PID");
+      expect(identifiers[1]._text).toEqual("1234");
+
+      // locations: item/thumbnail URLs and the physical location
+      const locations = mods["mods:location"];
+      const urls = locations[0]["mods:url"];
+      expect(urls[0]._text).toEqual(
+        "https://dc.library.northwestern.edu/items/1234",
+      );
+      expect(urls[1]._attributes.displayLabel).toEqual("Thumbnail");
+      expect(urls[1]._text).toEqual(
+        "https://index.test.library.northwestern.edu/iiif/2/mbk-dev/5678/square/100,100/0/default.jpg",
+      );
+      expect(locations[1]["mods:physicalLocation"]._text).toEqual(
+        "Charles Deering McCormick Library of Special Collections",
+      );
+      expect(locations[1]["mods:shelfLocator"]._text).toEqual("555");
+
+      // recordInfo
+      const recordInfo = mods["mods:recordInfo"];
+      expect(recordInfo["mods:recordOrigin"]._text).toEqual(
+        "Northwestern University Libraries Digital Collections API",
+      );
+      expect(recordInfo["mods:recordIdentifier"]._text).toEqual("1234");
+      expect(recordInfo["mods:recordContentSource"]._text).toEqual("IEN");
+
+      // relatedItems: collection host, series, related URLs, source system
+      const relatedItems = mods["mods:relatedItem"];
+      const collection = relatedItems.find(
+        (r: { _attributes?: { displayLabel?: string } }) =>
+          r._attributes?.displayLabel === "Collection",
+      );
+      expect(collection["mods:titleInfo"]["mods:title"]._text).toEqual(
+        "TEST Canary Records",
+      );
+      expect(collection["mods:identifier"]._text).toEqual(
+        "7c50096c-89eb-43e8-b357-5836a788ddeb",
+      );
+      const series = relatedItems.find(
+        (r: { _attributes?: { type?: string } }) =>
+          r._attributes?.type === "series",
+      );
+      expect(series["mods:titleInfo"]["mods:title"]._text).toEqual(
+        "Canaries and How to Care for Them",
+      );
+      const findingAid = relatedItems.find(
+        (r: { _attributes?: { displayLabel?: string } }) =>
+          r._attributes?.displayLabel === "Finding Aid",
+      );
+      expect(findingAid["mods:location"]["mods:url"]._text).toEqual(
+        "https://findingaids.library.northwestern.edu/",
+      );
+      const sourceSystem = relatedItems.find(
+        (r: { _attributes?: { otherType?: string } }) =>
+          r._attributes?.otherType === "sourceSystem",
+      );
+      expect(sourceSystem["mods:titleInfo"]["mods:title"]._text).toEqual(
+        "Digital Collections Images Repository",
+      );
+    });
+
+    it("returns cannotDisseminateFormat for an unsupported metadataPrefix", async () => {
+      const req = buildRequest("POST", "/oai", {
+        body: "verb=GetRecord&identifier=1234&metadataPrefix=marc21",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(400);
+
+      const resultBody = parseXml(await result.text());
+      expect(resultBody["OAI-PMH"].error._attributes.code).toEqual(
+        "cannotDisseminateFormat",
+      );
+    });
+
+    it("supports the mods metadataPrefix for the ListRecords verb", async () => {
+      server.use(
+        http.post(`https://${TEST_OPENSEARCH_HOST}/dc-v2-work/_search`, () =>
+          HttpResponse.json(JSON.parse(testFixture("mocks/scroll.json"))),
+        ),
+      );
+
+      const req = buildRequest("POST", "/oai", {
+        body: "verb=ListRecords&metadataPrefix=mods",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+
+      const resultBody = parseXml(await result.text());
+      const records = resultBody["OAI-PMH"].ListRecords.record;
+      expect(records.length).toEqual(12);
+      for (const record of records) {
+        expect("mods:mods" in record.metadata).toBe(true);
+        expect("oai_dc:dc" in record.metadata).toBe(false);
+      }
+
+      // resumptionToken carries the metadata format so subsequent
+      // token-only requests keep producing MODS
+      const resumptionToken = resultBody["OAI-PMH"].ListRecords.resumptionToken;
+      expect(resumptionToken._text.startsWith("mods:")).toBe(true);
+    });
+
+    it("resumes a MODS ListRecords request from a mods-prefixed resumptionToken", async () => {
+      server.use(
+        http.post(
+          `https://${TEST_OPENSEARCH_HOST}/_search/scroll/${SCROLL_TOKEN}`,
+          () => HttpResponse.json(JSON.parse(testFixture("mocks/scroll.json"))),
+        ),
+      );
+
+      const req = buildRequest("POST", "/oai", {
+        body: `verb=ListRecords&resumptionToken=mods:${SCROLL_TOKEN}`,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+
+      const resultBody = parseXml(await result.text());
+      const records = resultBody["OAI-PMH"].ListRecords.record;
+      expect(records.length).toEqual(12);
+      for (const record of records) {
+        expect("mods:mods" in record.metadata).toBe(true);
+      }
+      const resumptionToken = resultBody["OAI-PMH"].ListRecords.resumptionToken;
+      expect(resumptionToken._text.startsWith("mods:")).toBe(true);
+    });
+
+    it("treats a resumptionToken with an unrecognized prefix as a plain oai_dc token", async () => {
+      server.use(
+        http.post(
+          `https://${TEST_OPENSEARCH_HOST}/_search/scroll/unknown\\:${SCROLL_TOKEN}`,
+          () => HttpResponse.json(JSON.parse(testFixture("mocks/scroll.json"))),
+        ),
+      );
+
+      const req = buildRequest("POST", "/oai", {
+        body: `verb=ListRecords&resumptionToken=unknown:${SCROLL_TOKEN}`,
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+
+      const resultBody = parseXml(await result.text());
+      const records = resultBody["OAI-PMH"].ListRecords.record;
+      expect(records.length).toEqual(12);
+      for (const record of records) {
+        expect("oai_dc:dc" in record.metadata).toBe(true);
+      }
+    });
+
+    it("supports the mods metadataPrefix for the ListIdentifiers verb", async () => {
+      server.use(
+        http.post(`https://${TEST_OPENSEARCH_HOST}/dc-v2-work/_search`, () =>
+          HttpResponse.json(JSON.parse(testFixture("mocks/scroll.json"))),
+        ),
+      );
+
+      const req = buildRequest("POST", "/oai", {
+        body: "verb=ListIdentifiers&metadataPrefix=mods",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+
+      const resultBody = parseXml(await result.text());
+      const resumptionToken =
+        resultBody["OAI-PMH"].ListIdentifiers.resumptionToken;
+      expect(resumptionToken._text.startsWith("mods:")).toBe(true);
     });
 
     it("enforces the id parameter for the GetRecord verb", async () => {
@@ -468,10 +814,19 @@ describe("Oai routes", () => {
       );
 
       const resultBody = parseXml(await result.text());
-      const listMetadataFormatsElement =
+      const metadataFormats =
         resultBody["OAI-PMH"].ListMetadataFormats.metadataFormat;
-      expect(listMetadataFormatsElement.metadataNamespace._text).toEqual(
+      expect(metadataFormats.length).toEqual(2);
+      expect(metadataFormats[0].metadataPrefix._text).toEqual("oai_dc");
+      expect(metadataFormats[0].metadataNamespace._text).toEqual(
         "http://www.openarchives.org/OAI/2.0/oai_dc/",
+      );
+      expect(metadataFormats[1].metadataPrefix._text).toEqual("mods");
+      expect(metadataFormats[1].metadataNamespace._text).toEqual(
+        "http://www.loc.gov/mods/v3",
+      );
+      expect(metadataFormats[1].schema._text).toEqual(
+        "http://www.loc.gov/standards/mods/v3/mods-3-7.xsd",
       );
     });
   });

--- a/docs/docs/oai.md
+++ b/docs/docs/oai.md
@@ -14,3 +14,12 @@ All six verbs are supported:
 - `ListMetadataFormats`: Lists the metadata formats supported by the repository.
 - `ListRecords`: Returns a list of records, along with metadata records.
 - `ListSets`: Lists the sets or collections available in the repository.
+
+## Metadata Formats
+
+Two metadata formats are supported via the `metadataPrefix` parameter:
+
+- `oai_dc`: [Dublin Core](http://www.openarchives.org/OAI/2.0/oai_dc.xsd), the format required by the OAI-PMH specification.
+- `mods`: [MODS v3.7](http://www.loc.gov/standards/mods/v3/mods-3-7.xsd), which provides richer metadata, including names with authority URIs and roles, typed subjects, rights statement URIs, and links to the item and its thumbnail.
+
+For example: `?verb=GetRecord&identifier=<id>&metadataPrefix=mods`

--- a/docs/docs/spec/data-types.yaml
+++ b/docs/docs/spec/data-types.yaml
@@ -740,6 +740,11 @@ components:
           description: An entity responsible for making the resource available.
           items:
             type: string
+        related_material:
+          type: array
+          description: Description of materials related to the resource.
+          items:
+            type: string
         related_url:
           type: array
           description: URL of a related resource.

--- a/docs/docs/spec/openapi.yaml
+++ b/docs/docs/spec/openapi.yaml
@@ -371,6 +371,7 @@ paths:
             type: string
             enum:
               - oai_dc
+              - mods
         - name: from
           description: Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ`
           in: query
@@ -423,7 +424,7 @@ paths:
                   description: Required for `GetRecord` requests
                   type: string
                 metadataPrefix:
-                  description: Required for `ListIdentifiers`, `ListRecords`, and `GetRecord` requests. The only supported value is `"oai_dc"` currently.
+                  description: Required for `ListIdentifiers`, `ListRecords`, and `GetRecord` requests. Supported values are `"oai_dc"` and `"mods"`.
                   type: string
                 resumptionToken:
                   description: Exclusive parameter for retrieving additional results

--- a/mcp/apps/mcp/api-schema.d.ts
+++ b/mcp/apps/mcp/api-schema.d.ts
@@ -4,1289 +4,1248 @@
  */
 
 export interface paths {
-  "/auth/login/{provider}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/login/{provider}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Initiate a user login */
+        get: operations["getAuthLogin"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** @description Initiate a user login */
-    get: operations["getAuthLogin"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/token": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/token": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Obtain a bearer auth token for the logged in user */
+        get: operations["getAuthToken"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** @description Obtain a bearer auth token for the logged in user */
-    get: operations["getAuthToken"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/whoami": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/whoami": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** @description Obtain information about the logged in user */
+        get: operations["getAuthWhoami"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** @description Obtain information about the logged in user */
-    get: operations["getAuthWhoami"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/collections": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/collections": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getCollections"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getCollections"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/collections/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/collections/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getCollectionById"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getCollectionById"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/collections/{id}/thumbnail": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/collections/{id}/thumbnail": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getCollectionThumbnail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getCollectionThumbnail"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/file-sets/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/file-sets/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getFileSetById"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getFileSetById"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/file-sets/{id}/annotations": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/file-sets/{id}/annotations": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getFileSetAnnotations"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getFileSetAnnotations"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/annotations/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/annotations/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getAnnotationById"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getAnnotationById"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/file-sets/{id}/authorization": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/file-sets/{id}/authorization": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getFileSetAuth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getFileSetAuth"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/file-sets/{id}/download": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/file-sets/{id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getFileSetDownload"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getFileSetDownload"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/works/{id}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/works/{id}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getWorkById"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getWorkById"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/works/{id}/similar": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/works/{id}/similar": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getSimilarWorks"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getSimilarWorks"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/works/{id}/thumbnail": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/works/{id}/thumbnail": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getWorkThumbnail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getWorkThumbnail"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/search": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getSearch"];
+        put?: never;
+        post: operations["postSearch"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getSearch"];
-    put?: never;
-    post: operations["postSearch"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/search/{models}": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/search/{models}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["getSearchWithModels"];
+        put?: never;
+        post: operations["postSearchWithModels"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["getSearchWithModels"];
-    put?: never;
-    post: operations["postSearchWithModels"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/oai": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/oai": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get: operations["oaiGet"];
+        put?: never;
+        post: operations["oaiPost"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get: operations["oaiGet"];
-    put?: never;
-    post: operations["oaiPost"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    CollectionRepresentativeImage: {
-      /** Format: uuid */
-      work_id: string | null;
-      /** Format: uri */
-      url: string;
-    } | null;
-    /**
-     * @description The access level of the resource
-     * @enum {string|null}
-     */
-    Visibility: "Private" | "Institution" | "Public" | null;
-    Collection: {
-      admin_email: string | null;
-      api_link: string;
-      api_model: string;
-      /** Format: date-time */
-      create_date: string;
-      description: string | null;
-      featured: boolean;
-      /** Format: uri */
-      finding_aid_url: string | null;
-      /** Format: uuuid */
-      id: string;
-      /** Format: uri */
-      iiif_collection: string | null;
-      /** Format: date-time */
-      indexed_at: string | null;
-      keywords: string[];
-      /** Format: date-time */
-      modified_date: string;
-      published: boolean;
-      representative_image: components["schemas"]["CollectionRepresentativeImage"];
-      /** Format: uri */
-      thumbnail: string;
-      title: string;
-      visibility: components["schemas"]["Visibility"];
-    };
-    /**
-     * @description Role of the file set
-     * @enum {string|null}
-     */
-    FileSetRole:
-      | "Access"
-      | "Auxiliary"
-      | "Preservation"
-      | "Supplemental"
-      | null;
-    FileSetBase: {
-      /** Format: uuid */
-      id: string;
-      accession_number: string;
-      description: string | null;
-      download_url: string | null;
-      duration: number | null;
-      /** Format: uuid */
-      group_with: string | null;
-      height: number | null;
-      label: string;
-      mime_type: string | null;
-      original_filename: string | null;
-      poster_offset: number | null;
-      rank: number;
-      /** Format: uri */
-      representative_image_url: string | null;
-      role: components["schemas"]["FileSetRole"];
-      /** Format: uri */
-      streaming_url: string | null;
-      /** Format: uri */
-      webvtt: string | null;
-      width: number | null;
-    };
-    Annotation: {
-      /** Format: uuid */
-      id: string;
-      type: string;
-      language: string[];
-      content: string;
-      model: string;
-    };
-    FileSet: components["schemas"]["FileSetBase"] & {
-      api_link: string;
-      api_model: string;
-      /** Format: date-time */
-      create_date: string;
-      digests: {
-        [key: string]: string;
-      } | null;
-      annotations?: components["schemas"]["Annotation"][] | null;
-      extracted_metadata: Record<string, never> | null;
-      indexed_at: string | null;
-      /** Format: date-time */
-      modified_date: string;
-      published: boolean;
-      visibility: components["schemas"]["Visibility"];
-      /** Format: uuid */
-      work_id: string | null;
-    };
-    ControlledTermWithRole: {
-      id: string;
-      facet: string;
-      label: string;
-      label_with_role: string;
-      role: string;
-      variants: string[];
-    };
-    ControlledTerm: {
-      id: string;
-      facet: string;
-      label: string;
-      variants: string[];
-    };
-    /**
-     * @description NUL Library Unit
-     * @enum {string|null}
-     */
-    LibraryUnit:
-      | "Special Collections"
-      | "Faculty Collections"
-      | "Government and Geographic Information Collection"
-      | "Herskovits Library"
-      | "Music Library"
-      | "Transportation Library"
-      | "University Archives"
-      | "University Main Library"
-      | null;
-    GenericIdLabel: {
-      id: string;
-      label: string;
-    } | null;
-    NavPlaceEntry: {
-      /** @description Identifier for the place. */
-      id: string | null;
-      /** @description Human-readable label for the place. */
-      label: string;
-      /** @description Optional summary for the place. */
-      summary: string | null;
-      /** @description Longitude/latitude coordinates. */
-      coordinates: number[];
-    };
-    /** @description Geographic points for IIIF navPlace construction. */
-    NavPlace: components["schemas"]["NavPlaceEntry"][];
-    /**
-     * @description The type of the note
-     * @enum {string}
-     */
-    NoteType:
-      | "Awards"
-      | "Bibliographical/Historical Note"
-      | "Creation/Production Credits"
-      | "General Note"
-      | "Lanugage Note"
-      | "Local Note"
-      | "Performers"
-      | "Statement of Responsibility"
-      | "Venue/Event Date";
-    /**
-     * @description The preservation workflow applied to the resource
-     * @enum {string|null}
-     */
-    PreservationLevel: "Level 1" | "Level 2" | "Level 3" | null;
-    /**
-     * @description Type of related resource
-     * @enum {string|null}
-     */
-    RelatedUrlLabel:
-      | "Finding Aid"
-      | "Hathi Trust"
-      | "Related Information"
-      | "Resource Guide"
-      | null;
-    /** @description Information about the representative image for the resource */
-    RepresentativeFileSet: {
-      aspect_ratio: number;
-      /** Format: uuid */
-      id?: string | null;
-      /** Format: uri */
-      url: string;
-    } | null;
-    /**
-     * @description Preservation status of the resource
-     * @enum {string|null}
-     */
-    Status: "Not Started" | "In Progress" | "Done" | null;
-    /**
-     * @description The media type of the resource
-     * @enum {string|null}
-     */
-    WorkType: "Audio" | "Image" | "Video" | null;
-    /** @description A single work response */
-    Work: {
-      /** @description A summary of the resource */
-      abstract: string[];
-      /** @description Accession number for the work. Serves as basis for the filename. */
-      accession_number: string;
-      alternate_title: string[];
-      /** @description DC API url */
-      api_link: string | null;
-      /** @description Type of resource. (Work, FileSet, Collection) */
-      api_model: string | null;
-      /** @description Archival Resource Key (ARK) */
-      ark: string;
-      /** @description Associated batch update operations */
-      batch_ids: string[];
-      /** @description The IIIF behavior of the resource */
-      behavior: string | null;
-      /** @description Physical box name. Sometimes used with Distinctive Collections materials. */
-      box_name: string[];
-      /** @description Physical box number. Sometimes used with Distinctive Collections materials. */
-      box_number: string[];
-      /** @description The caption for a resource. */
-      caption: string[];
-      /** @description Alma bibliographic ID. */
-      catalog_key: string[];
-      /** @description The parent collection of the resource */
-      collection: {
-        /** @description UUID of the collection */
-        id: string;
-        /** @description Description of the collection */
-        description?: string | null;
-        /** @description Title of the collection */
-        title: string;
-      } | null;
-      /** @description An entity responsible for making contributions to the resource */
-      contributor: components["schemas"]["ControlledTermWithRole"][];
-      /**
-       * Format: date-time
-       * @description The creation date of the record in the repository.
-       */
-      create_date: string;
-      /** @description An entity primarily responsible for making the resource */
-      creator: components["schemas"]["ControlledTerm"][];
-      /** @description Associated csv metadata update operations */
-      csv_metadata_update_jobs: string[];
-      /** @description The cultural context of the resource. */
-      cultural_context: string[];
-      /** @description A point or a period of time associatied with an event in the lifecycle of the resource. */
-      date_created: string[];
-      /** @description An account of the resource. */
-      description: string[];
-      /** @description Vector representation of the resource's location in the repository's semantic space. */
-      embedding: number[];
-      /** @description The name of the inference model used to generate the `embedding` from the resource's content. */
-      embedding_model: string;
-      /** @description The length of the embedding text in bytes. */
-      embedding_text_length: string;
-      /** @description File sets associated with the resource. */
-      file_sets: components["schemas"]["FileSetBase"][];
-      /** @description Name of the containing folder. */
-      folder_name: string[];
-      /** @description Number of the containing folder. */
-      folder_number: string[];
-      /** @description Describes what the original object is, not what it is about. */
-      genre: components["schemas"]["ControlledTerm"][];
-      /**
-       * Format: uuid
-       * @description UUID for the work record in the repository.
-       */
-      id: string;
-      /** @description Identifiers for the object */
-      identifier: string[];
-      /** Format: uri */
-      iiif_manifest: string | null;
-      /** Format: date-time */
-      indexed_at: string | null;
-      /** @description Associated ingest project */
-      ingest_project: {
-        /** Format: uuid */
-        id: string;
-        title: string;
-      } | null;
-      /** @description Associated ingest sheet */
-      ingest_sheet: {
-        /** Format: uuid */
-        id: string;
-        title: string;
-      } | null;
-      /** @description Keywords or tags used to describe this content. */
-      keywords: string[];
-      /** @description A language of the resource. */
-      language: components["schemas"]["ControlledTerm"][];
-      /** @description PIDs from previous repository. */
-      legacy_identifier: string[];
-      library_unit: components["schemas"]["LibraryUnit"];
-      /** @description Creative Commons licenses */
-      license: components["schemas"]["GenericIdLabel"];
-      /** @description Place of publication. */
-      location: components["schemas"]["ControlledTerm"][];
-      nav_place: components["schemas"]["NavPlace"];
-      /**
-       * Format: date-time
-       * @description Date resource last modified in repository
-       */
-      modified_date: string;
-      notes: {
-        note: string;
-        type: components["schemas"]["NoteType"];
-      }[];
-      /** @description The material or physical carrier of the resource. */
-      physical_description_material: string[];
-      /** @description The size or duration of the resource. */
-      physical_description_size: string[];
-      preservation_level: components["schemas"]["PreservationLevel"];
-      /** @description Project related information */
-      project: {
-        desc: string | null;
-        cycle: string | null;
-        manager: string | null;
-        name: string | null;
-        proposer: string | null;
-        task_number: string | null;
-      } | null;
-      /** @description Location of Physical Object // will also include messy dates. Information about the provenance, such as origin, ownership and custodial history (chain of custody), of a resource. */
-      provenance: string[];
-      /** @description Resource is available on Digital Collections. */
-      published: boolean;
-      /** @description An entity responsible for making the resource available. */
-      publisher: string[];
-      /** @description URL of a related resource. */
-      related_url: {
-        /** Format: uri */
-        url: string;
-        label: components["schemas"]["RelatedUrlLabel"];
-      }[];
-      representative_file_set: components["schemas"]["RepresentativeFileSet"];
-      /** @description A person or organization owning or managing rights over the resource. */
-      rights_holder: string[];
-      /** @description Expresses the copyright status of the resource. */
-      rights_statement: components["schemas"]["GenericIdLabel"];
-      /** @description Sometimes used with Distincitive Collections materials */
-      scope_and_contents: string[];
-      /** @description Sometimes used with Distincitive Collections materials. Used for archival series and subseries information. */
-      series: string[];
-      /** @description A related resource from which the described resource is derived. Source of digital object - book, journal, etc. Follow Chicago Manual of Style for citation. */
-      source: string[];
-      status: components["schemas"]["Status"];
-      /** @description A defined style, historical period, group, school, dynasty, movement, etc. whose characteristics are represented in the work. */
-      style_period: components["schemas"]["ControlledTerm"][];
-      /** @description A defined style, historical period, group, school, dynasty, movement, etc. whose characteristics are represented in the work. */
-      subject: components["schemas"]["ControlledTermWithRole"][];
-      /** @description Used to provide the titles of separate works or parts of a resource. Information provided may also contain statements of responsibility or other sequential designations. */
-      table_of_contents: string[];
-      /** @description A defined style, historical period, group, school, dynasty, movement, etc. whose characteristics are represented in the work. */
-      technique: components["schemas"]["ControlledTerm"][];
-      /** @description Terms of use of resource. */
-      terms_of_use: string | null;
-      /**
-       * Format: uri
-       * @description Url of thumbnail image.
-       */
-      thumbnail: string | null;
-      /** @description A name given to the resource */
-      title: string | null;
-      visibility: components["schemas"]["Visibility"];
-      work_type: components["schemas"]["WorkType"];
-    };
-    /** @description A single index document */
-    IndexDocument:
-      | components["schemas"]["Collection"]
-      | components["schemas"]["FileSet"]
-      | components["schemas"]["Work"];
-    /** @description Pagination info for the current response. */
-    PaginationInfo: {
-      /** @description Full URL to the next page of results */
-      next_url?: string;
-      /** @description Full URL to the previous page of results */
-      prev_url?: string;
-      /** @description Base URL to repeat this query for a given page */
-      query_url?: string;
-      /** @description Tokenized query to use in subsequent GET requests */
-      search_token?: string;
-      /** @description Index of current page of results */
-      current_page?: number;
-      /** @description Number of results per page */
-      limit?: number;
-      /** @description Starting index of first result on the current page */
-      offset?: number;
-      /** @description Total number of results */
-      total_hits?: number;
-      /** @description Total number of result pages */
-      total_pages?: number;
-    };
-    /** @description Additional Information */
-    Info: {
-      description: string;
-      /** Format: date-time */
-      link_expiration?: string | null;
-      name: string;
-      version: string;
-    };
-    OpenSearchResponse: {
-      /** @description An array of response documents */
-      data?: components["schemas"]["IndexDocument"][];
-      pagination?: components["schemas"]["PaginationInfo"];
-      info?: components["schemas"]["Info"];
-    };
-    /** @description A [IIIF Presentation v3.x](https://iiif.io/api/presentation/3.0/) Manifest */
-    IiifPresentationManifest: Record<string, never>;
-  };
-  responses: {
-    /** @description A page of search results */
-    SearchResponse: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        "application/json":
-          | components["schemas"]["OpenSearchResponse"]
-          | components["schemas"]["IiifPresentationManifest"];
-      };
-    };
-    /** @description A single document response */
-    DocumentResponse: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        "application/json": {
-          data?:
-            | components["schemas"]["IndexDocument"]
-            | components["schemas"]["IiifPresentationManifest"];
-          info?: Record<string, never>;
+    schemas: {
+        CollectionRepresentativeImage: {
+            /** Format: uuid */
+            work_id: string | null;
+            /** Format: uri */
+            url: string;
+        } | null;
+        /**
+         * @description The access level of the resource
+         * @enum {string|null}
+         */
+        Visibility: "Private" | "Institution" | "Public" | null;
+        Collection: {
+            admin_email: string | null;
+            api_link: string;
+            api_model: string;
+            /** Format: date-time */
+            create_date: string;
+            description: string | null;
+            featured: boolean;
+            /** Format: uri */
+            finding_aid_url: string | null;
+            /** Format: uuuid */
+            id: string;
+            /** Format: uri */
+            iiif_collection: string | null;
+            /** Format: date-time */
+            indexed_at: string | null;
+            keywords: string[];
+            /** Format: date-time */
+            modified_date: string;
+            published: boolean;
+            representative_image: components["schemas"]["CollectionRepresentativeImage"];
+            /** Format: uri */
+            thumbnail: string;
+            title: string;
+            visibility: components["schemas"]["Visibility"];
         };
-      };
-    };
-    /** @description Annotations for a FileSet */
-    AnnotationsResponse: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        "application/json": {
-          data?: components["schemas"]["Annotation"][] | null;
-          info?: components["schemas"]["Info"];
+        /**
+         * @description Role of the file set
+         * @enum {string|null}
+         */
+        FileSetRole: "Access" | "Auxiliary" | "Preservation" | "Supplemental" | null;
+        FileSetBase: {
+            /** Format: uuid */
+            id: string;
+            accession_number: string;
+            description: string | null;
+            download_url: string | null;
+            duration: number | null;
+            /** Format: uuid */
+            group_with: string | null;
+            height: number | null;
+            label: string;
+            mime_type: string | null;
+            original_filename: string | null;
+            poster_offset: number | null;
+            rank: number;
+            /** Format: uri */
+            representative_image_url: string | null;
+            role: components["schemas"]["FileSetRole"];
+            /** Format: uri */
+            streaming_url: string | null;
+            /** Format: uri */
+            webvtt: string | null;
+            width: number | null;
         };
-      };
-    };
-    /** @description A single annotation response */
-    AnnotationResponse: {
-      headers: {
-        [name: string]: unknown;
-      };
-      content: {
-        "application/json": {
-          data?: components["schemas"]["Annotation"];
-          info?: components["schemas"]["Info"];
+        Annotation: {
+            /** Format: uuid */
+            id: string;
+            type: string;
+            language: string[];
+            content: string;
+            model: string;
         };
-      };
+        FileSet: components["schemas"]["FileSetBase"] & {
+            api_link: string;
+            api_model: string;
+            /** Format: date-time */
+            create_date: string;
+            digests: {
+                [key: string]: string;
+            } | null;
+            annotations?: components["schemas"]["Annotation"][] | null;
+            extracted_metadata: Record<string, never> | null;
+            indexed_at: string | null;
+            /** Format: date-time */
+            modified_date: string;
+            published: boolean;
+            visibility: components["schemas"]["Visibility"];
+            /** Format: uuid */
+            work_id: string | null;
+        };
+        ControlledTermWithRole: {
+            id: string;
+            facet: string;
+            label: string;
+            label_with_role: string;
+            role: string;
+            variants: string[];
+        };
+        ControlledTerm: {
+            id: string;
+            facet: string;
+            label: string;
+            variants: string[];
+        };
+        /**
+         * @description NUL Library Unit
+         * @enum {string|null}
+         */
+        LibraryUnit: "Special Collections" | "Faculty Collections" | "Government and Geographic Information Collection" | "Herskovits Library" | "Music Library" | "Transportation Library" | "University Archives" | "University Main Library" | null;
+        GenericIdLabel: {
+            id: string;
+            label: string;
+        } | null;
+        NavPlaceEntry: {
+            /** @description Identifier for the place. */
+            id: string | null;
+            /** @description Human-readable label for the place. */
+            label: string;
+            /** @description Optional summary for the place. */
+            summary: string | null;
+            /** @description Longitude/latitude coordinates. */
+            coordinates: number[];
+        };
+        /** @description Geographic points for IIIF navPlace construction. */
+        NavPlace: components["schemas"]["NavPlaceEntry"][];
+        /**
+         * @description The type of the note
+         * @enum {string}
+         */
+        NoteType: "Awards" | "Bibliographical/Historical Note" | "Creation/Production Credits" | "General Note" | "Lanugage Note" | "Local Note" | "Performers" | "Statement of Responsibility" | "Venue/Event Date";
+        /**
+         * @description The preservation workflow applied to the resource
+         * @enum {string|null}
+         */
+        PreservationLevel: "Level 1" | "Level 2" | "Level 3" | null;
+        /**
+         * @description Type of related resource
+         * @enum {string|null}
+         */
+        RelatedUrlLabel: "Finding Aid" | "Hathi Trust" | "Related Information" | "Resource Guide" | null;
+        /** @description Information about the representative image for the resource */
+        RepresentativeFileSet: {
+            aspect_ratio: number;
+            /** Format: uuid */
+            id?: string | null;
+            /** Format: uri */
+            url: string;
+        } | null;
+        /**
+         * @description Preservation status of the resource
+         * @enum {string|null}
+         */
+        Status: "Not Started" | "In Progress" | "Done" | null;
+        /**
+         * @description The media type of the resource
+         * @enum {string|null}
+         */
+        WorkType: "Audio" | "Image" | "Video" | null;
+        /** @description A single work response */
+        Work: {
+            /** @description A summary of the resource */
+            abstract: string[];
+            /** @description Accession number for the work. Serves as basis for the filename. */
+            accession_number: string;
+            alternate_title: string[];
+            /** @description DC API url */
+            api_link: string | null;
+            /** @description Type of resource. (Work, FileSet, Collection) */
+            api_model: string | null;
+            /** @description Archival Resource Key (ARK) */
+            ark: string;
+            /** @description Associated batch update operations */
+            batch_ids: string[];
+            /** @description The IIIF behavior of the resource */
+            behavior: string | null;
+            /** @description Physical box name. Sometimes used with Distinctive Collections materials. */
+            box_name: string[];
+            /** @description Physical box number. Sometimes used with Distinctive Collections materials. */
+            box_number: string[];
+            /** @description The caption for a resource. */
+            caption: string[];
+            /** @description Alma bibliographic ID. */
+            catalog_key: string[];
+            /** @description The parent collection of the resource */
+            collection: {
+                /** @description UUID of the collection */
+                id: string;
+                /** @description Description of the collection */
+                description?: string | null;
+                /** @description Title of the collection */
+                title: string;
+            } | null;
+            /** @description An entity responsible for making contributions to the resource */
+            contributor: components["schemas"]["ControlledTermWithRole"][];
+            /**
+             * Format: date-time
+             * @description The creation date of the record in the repository.
+             */
+            create_date: string;
+            /** @description An entity primarily responsible for making the resource */
+            creator: components["schemas"]["ControlledTerm"][];
+            /** @description Associated csv metadata update operations */
+            csv_metadata_update_jobs: string[];
+            /** @description The cultural context of the resource. */
+            cultural_context: string[];
+            /** @description A point or a period of time associatied with an event in the lifecycle of the resource. */
+            date_created: string[];
+            /** @description An account of the resource. */
+            description: string[];
+            /** @description Vector representation of the resource's location in the repository's semantic space. */
+            embedding: number[];
+            /** @description The name of the inference model used to generate the `embedding` from the resource's content. */
+            embedding_model: string;
+            /** @description The length of the embedding text in bytes. */
+            embedding_text_length: string;
+            /** @description File sets associated with the resource. */
+            file_sets: components["schemas"]["FileSetBase"][];
+            /** @description Name of the containing folder. */
+            folder_name: string[];
+            /** @description Number of the containing folder. */
+            folder_number: string[];
+            /** @description Describes what the original object is, not what it is about. */
+            genre: components["schemas"]["ControlledTerm"][];
+            /**
+             * Format: uuid
+             * @description UUID for the work record in the repository.
+             */
+            id: string;
+            /** @description Identifiers for the object */
+            identifier: string[];
+            /** Format: uri */
+            iiif_manifest: string | null;
+            /** Format: date-time */
+            indexed_at: string | null;
+            /** @description Associated ingest project */
+            ingest_project: {
+                /** Format: uuid */
+                id: string;
+                title: string;
+            } | null;
+            /** @description Associated ingest sheet */
+            ingest_sheet: {
+                /** Format: uuid */
+                id: string;
+                title: string;
+            } | null;
+            /** @description Keywords or tags used to describe this content. */
+            keywords: string[];
+            /** @description A language of the resource. */
+            language: components["schemas"]["ControlledTerm"][];
+            /** @description PIDs from previous repository. */
+            legacy_identifier: string[];
+            library_unit: components["schemas"]["LibraryUnit"];
+            /** @description Creative Commons licenses */
+            license: components["schemas"]["GenericIdLabel"];
+            /** @description Place of publication. */
+            location: components["schemas"]["ControlledTerm"][];
+            nav_place: components["schemas"]["NavPlace"];
+            /**
+             * Format: date-time
+             * @description Date resource last modified in repository
+             */
+            modified_date: string;
+            notes: {
+                note: string;
+                type: components["schemas"]["NoteType"];
+            }[];
+            /** @description The material or physical carrier of the resource. */
+            physical_description_material: string[];
+            /** @description The size or duration of the resource. */
+            physical_description_size: string[];
+            preservation_level: components["schemas"]["PreservationLevel"];
+            /** @description Project related information */
+            project: {
+                desc: string | null;
+                cycle: string | null;
+                manager: string | null;
+                name: string | null;
+                proposer: string | null;
+                task_number: string | null;
+            } | null;
+            /** @description Location of Physical Object // will also include messy dates. Information about the provenance, such as origin, ownership and custodial history (chain of custody), of a resource. */
+            provenance: string[];
+            /** @description Resource is available on Digital Collections. */
+            published: boolean;
+            /** @description An entity responsible for making the resource available. */
+            publisher: string[];
+            /** @description URL of a related resource. */
+            related_url: {
+                /** Format: uri */
+                url: string;
+                label: components["schemas"]["RelatedUrlLabel"];
+            }[];
+            representative_file_set: components["schemas"]["RepresentativeFileSet"];
+            /** @description A person or organization owning or managing rights over the resource. */
+            rights_holder: string[];
+            /** @description Expresses the copyright status of the resource. */
+            rights_statement: components["schemas"]["GenericIdLabel"];
+            /** @description Sometimes used with Distincitive Collections materials */
+            scope_and_contents: string[];
+            /** @description Sometimes used with Distincitive Collections materials. Used for archival series and subseries information. */
+            series: string[];
+            /** @description A related resource from which the described resource is derived. Source of digital object - book, journal, etc. Follow Chicago Manual of Style for citation. */
+            source: string[];
+            status: components["schemas"]["Status"];
+            /** @description A defined style, historical period, group, school, dynasty, movement, etc. whose characteristics are represented in the work. */
+            style_period: components["schemas"]["ControlledTerm"][];
+            /** @description A defined style, historical period, group, school, dynasty, movement, etc. whose characteristics are represented in the work. */
+            subject: components["schemas"]["ControlledTermWithRole"][];
+            /** @description Used to provide the titles of separate works or parts of a resource. Information provided may also contain statements of responsibility or other sequential designations. */
+            table_of_contents: string[];
+            /** @description A defined style, historical period, group, school, dynasty, movement, etc. whose characteristics are represented in the work. */
+            technique: components["schemas"]["ControlledTerm"][];
+            /** @description Terms of use of resource. */
+            terms_of_use: string | null;
+            /**
+             * Format: uri
+             * @description Url of thumbnail image.
+             */
+            thumbnail: string | null;
+            /** @description A name given to the resource */
+            title: string | null;
+            visibility: components["schemas"]["Visibility"];
+            work_type: components["schemas"]["WorkType"];
+        };
+        /** @description A single index document */
+        IndexDocument: components["schemas"]["Collection"] | components["schemas"]["FileSet"] | components["schemas"]["Work"];
+        /** @description Pagination info for the current response. */
+        PaginationInfo: {
+            /** @description Full URL to the next page of results */
+            next_url?: string;
+            /** @description Full URL to the previous page of results */
+            prev_url?: string;
+            /** @description Base URL to repeat this query for a given page */
+            query_url?: string;
+            /** @description Tokenized query to use in subsequent GET requests */
+            search_token?: string;
+            /** @description Index of current page of results */
+            current_page?: number;
+            /** @description Number of results per page */
+            limit?: number;
+            /** @description Starting index of first result on the current page */
+            offset?: number;
+            /** @description Total number of results */
+            total_hits?: number;
+            /** @description Total number of result pages */
+            total_pages?: number;
+        };
+        /** @description Additional Information */
+        Info: {
+            description: string;
+            /** Format: date-time */
+            link_expiration?: string | null;
+            name: string;
+            version: string;
+        };
+        OpenSearchResponse: {
+            /** @description An array of response documents */
+            data?: components["schemas"]["IndexDocument"][];
+            pagination?: components["schemas"]["PaginationInfo"];
+            info?: components["schemas"]["Info"];
+        };
+        /** @description A [IIIF Presentation v3.x](https://iiif.io/api/presentation/3.0/) Manifest */
+        IiifPresentationManifest: Record<string, never>;
     };
-  };
-  parameters: {
-    /** @description Desired output format */
-    as: "iiif" | "opensearch";
-    /** @description Page number of results to retrieve */
-    page: number;
-    /** @description Maximum number of results per page */
-    size: number;
-    /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
-    sort: string;
-    /** @description Collection, FileSet, or Work ID */
-    id: string;
-    /** @description Desired aspect ratio */
-    thumbnailAspect: "full" | "square";
-    /** @description Size of largest dimension */
-    thumbnailSize: number;
-    /** @description Keyword query */
-    query: string;
-    /** @description Search token from previous search response */
-    searchToken: string;
-    /** @description Filter search results by visibility */
-    visibility: ("public" | "institution" | "private")[];
-    /** @description Comma-delimited list of models to search */
-    models: ("collections" | "file-sets" | "works")[];
-  };
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: {
+        /** @description A page of search results */
+        SearchResponse: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": components["schemas"]["OpenSearchResponse"] | components["schemas"]["IiifPresentationManifest"];
+            };
+        };
+        /** @description A single document response */
+        DocumentResponse: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    data?: components["schemas"]["IndexDocument"] | components["schemas"]["IiifPresentationManifest"];
+                    info?: Record<string, never>;
+                };
+            };
+        };
+        /** @description Annotations for a FileSet */
+        AnnotationsResponse: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    data?: components["schemas"]["Annotation"][] | null;
+                    info?: components["schemas"]["Info"];
+                };
+            };
+        };
+        /** @description A single annotation response */
+        AnnotationResponse: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    data?: components["schemas"]["Annotation"];
+                    info?: components["schemas"]["Info"];
+                };
+            };
+        };
+    };
+    parameters: {
+        /** @description Desired output format */
+        as: "iiif" | "opensearch";
+        /** @description Page number of results to retrieve */
+        page: number;
+        /** @description Maximum number of results per page */
+        size: number;
+        /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
+        sort: string;
+        /** @description Collection, FileSet, or Work ID */
+        id: string;
+        /** @description Desired aspect ratio */
+        thumbnailAspect: "full" | "square";
+        /** @description Size of largest dimension */
+        thumbnailSize: number;
+        /** @description Keyword query */
+        query: string;
+        /** @description Search token from previous search response */
+        searchToken: string;
+        /** @description Filter search results by visibility */
+        visibility: ("public" | "institution" | "private")[];
+        /** @description Comma-delimited list of models to search */
+        models: ("collections" | "file-sets" | "works")[];
+    };
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  getAuthLogin: {
-    parameters: {
-      query?: {
-        /** @description Email address to use for magic link login */
-        email?: string;
-        /** @description URL to redirect to after login */
-        goto?: string;
-      };
-      header?: never;
-      path: {
-        /** @description The authentication provider to use */
-        provider: "nusso" | "magic";
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description A redirect to the login page */
-      302: {
-        headers: {
-          [name: string]: unknown;
+    getAuthLogin: {
+        parameters: {
+            query?: {
+                /** @description Email address to use for magic link login */
+                email?: string;
+                /** @description URL to redirect to after login */
+                goto?: string;
+            };
+            header?: never;
+            path: {
+                /** @description The authentication provider to use */
+                provider: "nusso" | "magic";
+            };
+            cookie?: never;
         };
-        content?: never;
-      };
-    };
-  };
-  getAuthToken: {
-    parameters: {
-      query?: {
-        /** @description TTL in seconds for the token expiration */
-        ttl?: number;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Authentication token response */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            /** @description A redirect to the login page */
+            302: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
         };
-        content: {
-          "application/json": {
-            token?: string;
-            /** Format: date-time */
-            expires?: string;
-          };
+    };
+    getAuthToken: {
+        parameters: {
+            query?: {
+                /** @description TTL in seconds for the token expiration */
+                ttl?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-  };
-  getAuthWhoami: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description User details */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            /** @description Authentication token response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        token?: string;
+                        /** Format: date-time */
+                        expires?: string;
+                    };
+                };
+            };
         };
-        content: {
-          "application/json": Record<string, never>;
+    };
+    getAuthWhoami: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-  };
-  getCollections: {
-    parameters: {
-      query?: {
-        /** @description Desired output format */
-        as?: components["parameters"]["as"];
-        /** @description Page number of results to retrieve */
-        page?: components["parameters"]["page"];
-        /** @description Maximum number of results per page */
-        size?: components["parameters"]["size"];
-        /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
-        sort?: components["parameters"]["sort"];
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["SearchResponse"];
-    };
-  };
-  getCollectionById: {
-    parameters: {
-      query?: {
-        /** @description Desired output format */
-        as?: components["parameters"]["as"];
-      };
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["DocumentResponse"];
-    };
-  };
-  getCollectionThumbnail: {
-    parameters: {
-      query?: {
-        /** @description Desired aspect ratio */
-        aspect?: components["parameters"]["thumbnailAspect"];
-        /** @description Size of largest dimension */
-        size?: components["parameters"]["thumbnailSize"];
-      };
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description A thumbnail image for the given collection */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            /** @description User details */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
         };
-        content: {
-          "image/jpeg": string;
+    };
+    getCollections: {
+        parameters: {
+            query?: {
+                /** @description Desired output format */
+                as?: components["parameters"]["as"];
+                /** @description Page number of results to retrieve */
+                page?: components["parameters"]["page"];
+                /** @description Maximum number of results per page */
+                size?: components["parameters"]["size"];
+                /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
+                sort?: components["parameters"]["sort"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
-    };
-  };
-  getFileSetById: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["DocumentResponse"];
-    };
-  };
-  getFileSetAnnotations: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["AnnotationsResponse"];
-    };
-  };
-  getAnnotationById: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["AnnotationResponse"];
-    };
-  };
-  getFileSetAuth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description The resource is authorized */
-      204: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["SearchResponse"];
         };
-        content?: never;
-      };
-      /** @description The resource is not authorized */
-      403: {
-        headers: {
-          [name: string]: unknown;
+    };
+    getCollectionById: {
+        parameters: {
+            query?: {
+                /** @description Desired output format */
+                as?: components["parameters"]["as"];
+            };
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
         };
-        content?: never;
-      };
-    };
-  };
-  getFileSetDownload: {
-    parameters: {
-      query: {
-        /** @description Email to send the download link to */
-        email: string;
-      };
-      header?: never;
-      path: {
-        /** @description Id of the file set */
-        id: string;
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description The download is being created */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["DocumentResponse"];
         };
-        content?: never;
-      };
-      /** @description Bad Request */
-      400: {
-        headers: {
-          [name: string]: unknown;
+    };
+    getCollectionThumbnail: {
+        parameters: {
+            query?: {
+                /** @description Desired aspect ratio */
+                aspect?: components["parameters"]["thumbnailAspect"];
+                /** @description Size of largest dimension */
+                size?: components["parameters"]["thumbnailSize"];
+            };
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
         };
-        content?: never;
-      };
-      /** @description Method Not allowed for work type, file set role combo */
-      405: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            /** @description A thumbnail image for the given collection */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/jpeg": string;
+                };
+            };
         };
-        content?: never;
-      };
     };
-  };
-  getWorkById: {
-    parameters: {
-      query?: {
-        /** @description Desired output format */
-        as?: components["parameters"]["as"];
-      };
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["DocumentResponse"];
-    };
-  };
-  getSimilarWorks: {
-    parameters: {
-      query?: {
-        /** @description Page number of results to retrieve */
-        page?: components["parameters"]["page"];
-        /** @description Maximum number of results per page */
-        size?: components["parameters"]["size"];
-        /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
-        sort?: components["parameters"]["sort"];
-        /** @description Desired output format */
-        as?: components["parameters"]["as"];
-      };
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["SearchResponse"];
-    };
-  };
-  getWorkThumbnail: {
-    parameters: {
-      query?: {
-        /** @description Desired aspect ratio */
-        aspect?: components["parameters"]["thumbnailAspect"];
-        /** @description Size of largest dimension */
-        size?: components["parameters"]["thumbnailSize"];
-      };
-      header?: never;
-      path: {
-        /** @description Collection, FileSet, or Work ID */
-        id: components["parameters"]["id"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description A thumbnail image for the given work */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getFileSetById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
         };
-        content: {
-          "image/jpeg": string;
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["DocumentResponse"];
         };
-      };
     };
-  };
-  getSearch: {
-    parameters: {
-      query?: {
-        /** @description Keyword query */
-        query?: components["parameters"]["query"];
-        /** @description Search token from previous search response */
-        searchToken?: components["parameters"]["searchToken"];
-        /** @description Page number of results to retrieve */
-        page?: components["parameters"]["page"];
-        /** @description Maximum number of results per page */
-        size?: components["parameters"]["size"];
-        /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
-        sort?: components["parameters"]["sort"];
-        /** @description Desired output format */
-        as?: components["parameters"]["as"];
-        /** @description Filter search results by visibility */
-        visibility?: components["parameters"]["visibility"];
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["SearchResponse"];
-    };
-  };
-  postSearch: {
-    parameters: {
-      query?: {
-        /** @description Page number of results to retrieve */
-        page?: components["parameters"]["page"];
-        /** @description Maximum number of results per page */
-        size?: components["parameters"]["size"];
-        /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
-        sort?: components["parameters"]["sort"];
-        /** @description Desired output format */
-        as?: components["parameters"]["as"];
-        /** @description Filter search results by visibility */
-        visibility?: components["parameters"]["visibility"];
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": Record<string, any>;
-      };
-    };
-    responses: {
-      200: components["responses"]["SearchResponse"];
-    };
-  };
-  getSearchWithModels: {
-    parameters: {
-      query?: {
-        /** @description Keyword query */
-        query?: components["parameters"]["query"];
-        /** @description Search token from previous search response */
-        searchToken?: components["parameters"]["searchToken"];
-        /** @description Page number of results to retrieve */
-        page?: components["parameters"]["page"];
-        /** @description Maximum number of results per page */
-        size?: components["parameters"]["size"];
-        /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
-        sort?: components["parameters"]["sort"];
-        /** @description Desired output format */
-        as?: components["parameters"]["as"];
-        /** @description Filter search results by visibility */
-        visibility?: components["parameters"]["visibility"];
-      };
-      header?: never;
-      path: {
-        /** @description Comma-delimited list of models to search */
-        models: components["parameters"]["models"];
-      };
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      200: components["responses"]["SearchResponse"];
-    };
-  };
-  postSearchWithModels: {
-    parameters: {
-      query?: {
-        /** @description Page number of results to retrieve */
-        page?: components["parameters"]["page"];
-        /** @description Maximum number of results per page */
-        size?: components["parameters"]["size"];
-        /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
-        sort?: components["parameters"]["sort"];
-        /** @description Desired output format */
-        as?: components["parameters"]["as"];
-        /** @description Filter search results by visibility */
-        visibility?: components["parameters"]["visibility"];
-      };
-      header?: never;
-      path: {
-        /** @description Comma-delimited list of models to search */
-        models: components["parameters"]["models"];
-      };
-      cookie?: never;
-    };
-    requestBody?: {
-      content: {
-        "application/json": Record<string, any>;
-      };
-    };
-    responses: {
-      200: components["responses"]["SearchResponse"];
-    };
-  };
-  oaiGet: {
-    parameters: {
-      query: {
-        /** @description All OAI-PMH verbs are supported. */
-        verb:
-          | "GetRecord"
-          | "Identify"
-          | "ListIdentifiers"
-          | "ListMetadataFormats"
-          | "ListRecords"
-          | "ListSets";
-        /**
-         * @description Required for `GetRecord` requests
-         * @example d75a851f-b773-4bdf-baec-62a8ec974126
-         */
-        identifier?: string;
-        /** @description Required for `ListIdentifiers`, `ListRecords`, and `GetRecord` requests */
-        metadataPrefix?: "oai_dc";
-        /**
-         * @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ`
-         * @example 2023-01-01T08:12:23Z
-         */
-        from?: string;
-        /**
-         * @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ`
-         * @example 2023-01-12T12:03:59Z
-         */
-        until?: string;
-        /**
-         * @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a collection id.
-         * @example c4f30015-88b5-4291-b3a6-8ac9b7c7069c
-         */
-        set?: string;
-        /** @description Exclusive parameter for retrieving additional results */
-        resumptionToken?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description An OAI-PMH response document */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    getFileSetAnnotations: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
         };
-        content: {
-          "application/xml": Record<string, never>;
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["AnnotationsResponse"];
         };
-      };
     };
-  };
-  oaiPost: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/x-www-form-urlencoded": {
-          /** @description All OAI-PMH verbs are supported */
-          verb?: string;
-          /** @description Required for `GetRecord` requests */
-          identifier?: string;
-          /** @description Required for `ListIdentifiers`, `ListRecords`, and `GetRecord` requests. The only supported value is `"oai_dc"` currently. */
-          metadataPrefix?: string;
-          /** @description Exclusive parameter for retrieving additional results */
-          resumptionToken?: string;
-          /** @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ` */
-          from?: string;
-          /** @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ` */
-          until?: string;
-          /** @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a collection id. */
-          set?: string;
+    getAnnotationById: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
         };
-      };
-    };
-    responses: {
-      /** @description An OAI-PMH response document */
-      200: {
-        headers: {
-          [name: string]: unknown;
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["AnnotationResponse"];
         };
-        content: {
-          "application/xml": Record<string, never>;
-        };
-      };
     };
-  };
+    getFileSetAuth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The resource is authorized */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description The resource is not authorized */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getFileSetDownload: {
+        parameters: {
+            query: {
+                /** @description Email to send the download link to */
+                email: string;
+            };
+            header?: never;
+            path: {
+                /** @description Id of the file set */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description The download is being created */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Method Not allowed for work type, file set role combo */
+            405: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    getWorkById: {
+        parameters: {
+            query?: {
+                /** @description Desired output format */
+                as?: components["parameters"]["as"];
+            };
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["DocumentResponse"];
+        };
+    };
+    getSimilarWorks: {
+        parameters: {
+            query?: {
+                /** @description Page number of results to retrieve */
+                page?: components["parameters"]["page"];
+                /** @description Maximum number of results per page */
+                size?: components["parameters"]["size"];
+                /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
+                sort?: components["parameters"]["sort"];
+                /** @description Desired output format */
+                as?: components["parameters"]["as"];
+            };
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["SearchResponse"];
+        };
+    };
+    getWorkThumbnail: {
+        parameters: {
+            query?: {
+                /** @description Desired aspect ratio */
+                aspect?: components["parameters"]["thumbnailAspect"];
+                /** @description Size of largest dimension */
+                size?: components["parameters"]["thumbnailSize"];
+            };
+            header?: never;
+            path: {
+                /** @description Collection, FileSet, or Work ID */
+                id: components["parameters"]["id"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A thumbnail image for the given work */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "image/jpeg": string;
+                };
+            };
+        };
+    };
+    getSearch: {
+        parameters: {
+            query?: {
+                /** @description Keyword query */
+                query?: components["parameters"]["query"];
+                /** @description Search token from previous search response */
+                searchToken?: components["parameters"]["searchToken"];
+                /** @description Page number of results to retrieve */
+                page?: components["parameters"]["page"];
+                /** @description Maximum number of results per page */
+                size?: components["parameters"]["size"];
+                /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
+                sort?: components["parameters"]["sort"];
+                /** @description Desired output format */
+                as?: components["parameters"]["as"];
+                /** @description Filter search results by visibility */
+                visibility?: components["parameters"]["visibility"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["SearchResponse"];
+        };
+    };
+    postSearch: {
+        parameters: {
+            query?: {
+                /** @description Page number of results to retrieve */
+                page?: components["parameters"]["page"];
+                /** @description Maximum number of results per page */
+                size?: components["parameters"]["size"];
+                /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
+                sort?: components["parameters"]["sort"];
+                /** @description Desired output format */
+                as?: components["parameters"]["as"];
+                /** @description Filter search results by visibility */
+                visibility?: components["parameters"]["visibility"];
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            200: components["responses"]["SearchResponse"];
+        };
+    };
+    getSearchWithModels: {
+        parameters: {
+            query?: {
+                /** @description Keyword query */
+                query?: components["parameters"]["query"];
+                /** @description Search token from previous search response */
+                searchToken?: components["parameters"]["searchToken"];
+                /** @description Page number of results to retrieve */
+                page?: components["parameters"]["page"];
+                /** @description Maximum number of results per page */
+                size?: components["parameters"]["size"];
+                /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
+                sort?: components["parameters"]["sort"];
+                /** @description Desired output format */
+                as?: components["parameters"]["as"];
+                /** @description Filter search results by visibility */
+                visibility?: components["parameters"]["visibility"];
+            };
+            header?: never;
+            path: {
+                /** @description Comma-delimited list of models to search */
+                models: components["parameters"]["models"];
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            200: components["responses"]["SearchResponse"];
+        };
+    };
+    postSearchWithModels: {
+        parameters: {
+            query?: {
+                /** @description Page number of results to retrieve */
+                page?: components["parameters"]["page"];
+                /** @description Maximum number of results per page */
+                size?: components["parameters"]["size"];
+                /** @description Comma-delimited list of fields to sort search results (e.g. "create_date:asc,modified_date:desc") */
+                sort?: components["parameters"]["sort"];
+                /** @description Desired output format */
+                as?: components["parameters"]["as"];
+                /** @description Filter search results by visibility */
+                visibility?: components["parameters"]["visibility"];
+            };
+            header?: never;
+            path: {
+                /** @description Comma-delimited list of models to search */
+                models: components["parameters"]["models"];
+            };
+            cookie?: never;
+        };
+        requestBody?: {
+            content: {
+                "application/json": Record<string, never>;
+            };
+        };
+        responses: {
+            200: components["responses"]["SearchResponse"];
+        };
+    };
+    oaiGet: {
+        parameters: {
+            query: {
+                /** @description All OAI-PMH verbs are supported. */
+                verb: "GetRecord" | "Identify" | "ListIdentifiers" | "ListMetadataFormats" | "ListRecords" | "ListSets";
+                /**
+                 * @description Required for `GetRecord` requests
+                 * @example d75a851f-b773-4bdf-baec-62a8ec974126
+                 */
+                identifier?: string;
+                /** @description Required for `ListIdentifiers`, `ListRecords`, and `GetRecord` requests */
+                metadataPrefix?: "oai_dc" | "mods";
+                /**
+                 * @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ`
+                 * @example 2023-01-01T08:12:23Z
+                 */
+                from?: string;
+                /**
+                 * @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ`
+                 * @example 2023-01-12T12:03:59Z
+                 */
+                until?: string;
+                /**
+                 * @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a collection id.
+                 * @example c4f30015-88b5-4291-b3a6-8ac9b7c7069c
+                 */
+                set?: string;
+                /** @description Exclusive parameter for retrieving additional results */
+                resumptionToken?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description An OAI-PMH response document */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/xml": Record<string, never>;
+                };
+            };
+        };
+    };
+    oaiPost: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/x-www-form-urlencoded": {
+                    /** @description All OAI-PMH verbs are supported */
+                    verb?: string;
+                    /** @description Required for `GetRecord` requests */
+                    identifier?: string;
+                    /** @description Required for `ListIdentifiers`, `ListRecords`, and `GetRecord` requests. Supported values are `"oai_dc"` and `"mods"`. */
+                    metadataPrefix?: string;
+                    /** @description Exclusive parameter for retrieving additional results */
+                    resumptionToken?: string;
+                    /** @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ` */
+                    from?: string;
+                    /** @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a record's modified date. Accepted formats `YYYY-MM-DD` or `YYYY-MM-DDThh:mm:ssZ` */
+                    until?: string;
+                    /** @description Optional for `ListRecords` and `ListIdentifiers` requests, based on a collection id. */
+                    set?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description An OAI-PMH response document */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/xml": Record<string, never>;
+                };
+            };
+        };
+    };
 }


### PR DESCRIPTION
## Summary 
Adds MODS v3.7 as a second metadata format on the OAI-PMH endpoint, implementing the Digital Collections → MODS crosswalk. The discovery team that want richer metadata than `oai_dc` (names with authority URIs and roles, typed subjects, rights URIs, thumbnail and item URLs, etc.) can now request `metadataPrefix=mods`. Existing `oai_dc` harvesting is unchanged.

The crosswalk is `DigitalCollectionstoMODSJuly2026_forOAIPMH.xlsx`, which you can find here: https://github.com/nulib/repodev_planning_and_docs/issues/5765 verbatim

- New `mods-transformer.ts` builds the MODS record per the crosswalk
- `GetRecord` / `ListRecords` dispatch on `metadataPrefix`; unknown prefixes return the spec-defined `cannotDisseminateFormat` error
- `ListMetadataFormats` now advertises both `oai_dc` and `mods`
- MODS resumptionTokens are emitted as `mods:<scrollId>` so token-only follow-up requests keep producing MODS; bare tokens still mean `oai_dc`, so in-flight Primo harvests are unaffected
- Note: creators get a static `roleTerm` of "Creator" (the index has no role on creator entries); `recordInfo` static values follow the crosswalk

`ListMetadataFormats` example:
<img width="1260" height="465" alt="oai-pmh-mods1" src="https://github.com/user-attachments/assets/9a203d2f-903a-47b8-b62b-b343ca2dcf38" />

`metadataPrefix=mods` example:
<img width="2491" height="1032" alt="oai-pmh-mods2" src="https://github.com/user-attachments/assets/39a8135c-ff21-48a5-96bd-2fec4df0bf8b" />

New `cannotDisseminateFormat` error example:
<img width="1183" height="299" alt="oai-pmh-mods3" src="https://github.com/user-attachments/assets/82fecc53-8e0a-4d3d-9314-3933fa94c90c" />


## Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

## Steps to Test
1. `make deps` and `make serve`, then against your dev endpoint (`https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002`):
2. `GET /oai?verb=ListMetadataFormats` — should list both `oai_dc` and `mods`
3. `GET /oai?verb=GetRecord&identifier=<work id>&metadataPrefix=mods` — returns a `mods:mods` record; spot-check titles, names (valueURI + roleTerm), subjects, rights, and the thumbnail/item URLs against the work
4. Same request with `metadataPrefix=oai_dc` — unchanged Dublin Core output
5. `GET /oai?verb=ListRecords&metadataPrefix=mods` — MODS records with a `mods:`-prefixed resumptionToken; feed the token back via `GET /oai?verb=ListRecords&resumptionToken=<token>` and confirm the records are still MODS
6. `GET /oai?verb=GetRecord&identifier=<id>&metadataPrefix=marc21` — returns a `cannotDisseminateFormat` error
7. `cd api && bun test test/integration/oai.test.ts`
