### PR TITLE
OAI-PMH endpoints allow authenticated works

### DIFF
--- a/api/src/handlers/oai/mods-transformer.ts
+++ b/api/src/handlers/oai/mods-transformer.ts
@@ -302,6 +302,16 @@ function locations(work: Work): XmlElement[] {
   return result;
 }
 
+// Current date/time as YYYYMMDDHHmmss.0, matching the legacy XSL output of
+// format-dateTime(current-dateTime(),'[Y0001][M01][D01][H01][m01][s01]') + ".0".
+//
+// Deliberately UTC, regardless of the TZ env var or host zone: the value is
+// labelled encoding="iso8601" with no zone designator, and OAI-PMH datestamps
+// elsewhere in the response are UTC too. Date#toISOString() is always UTC.
+function recordChangeDateUtc(now: Date = new Date()): string {
+  return now.toISOString().replace(/\D/g, "").slice(0, 14) + ".0";
+}
+
 function recordInfo(work: Work): XmlElement {
   return {
     "mods:recordOrigin": {
@@ -314,6 +324,10 @@ function recordInfo(work: Work): XmlElement {
     "mods:recordCreationDate": {
       _attributes: { encoding: "marc" },
       _text: work.create_date,
+    },
+    "mods:recordChangeDate": {
+      _attributes: { encoding: "iso8601" },
+      _text: recordChangeDateUtc(),
     },
     "mods:recordIdentifier": {
       _attributes: { source: "IEN" },

--- a/api/src/handlers/oai/search.ts
+++ b/api/src/handlers/oai/search.ts
@@ -19,7 +19,7 @@ export async function earliestRecord(): Promise<string | undefined> {
     _source: "create_date",
     query: {
       bool: {
-        must: [{ term: { api_model: "Work" } }, ...oaiVisibilityFilter],
+        filter: [{ term: { api_model: "Work" } }, ...oaiVisibilityFilter],
       },
     },
     sort: [{ create_date: "asc" }],
@@ -47,11 +47,11 @@ export async function oaiSearch(
   };
   const query: Record<string, unknown> = {
     bool: {
-      must: [{ term: { api_model: "Work" } }, ...oaiVisibilityFilter, range],
+      filter: [{ term: { api_model: "Work" } }, ...oaiVisibilityFilter, range],
     },
   };
   if (set)
-    (query.bool as { must: unknown[] }).must.push({
+    (query.bool as { filter: unknown[] }).filter.push({
       term: { "collection.id": set },
     });
 
@@ -79,7 +79,7 @@ export async function oaiSets(): Promise<{ status: number; body: string }> {
     _source: ["id", "title"],
     query: {
       bool: {
-        must: [{ term: { api_model: "Collection" } }, ...oaiVisibilityFilter],
+        filter: [{ term: { api_model: "Collection" } }, ...oaiVisibilityFilter],
       },
     },
     sort: [{ title: "asc" }],

--- a/api/src/handlers/oai/search.ts
+++ b/api/src/handlers/oai/search.ts
@@ -4,17 +4,22 @@ import {
   modelsToTargets,
 } from "../../api/request/models.ts";
 
+// OAI-PMH only exposes metadata, so (like the unauthenticated DC API) it
+// includes works and collections that are visible to the institution
+// ("Institution" / netID) as well as fully "Public" ones.
+export const OAI_VISIBILITY = ["Institution", "Public"];
+export const oaiVisibilityFilter = [
+  { term: { published: true } },
+  { terms: { visibility: OAI_VISIBILITY } },
+];
+
 export async function earliestRecord(): Promise<string | undefined> {
   const body = {
     size: 1,
     _source: "create_date",
     query: {
       bool: {
-        must: [
-          { term: { api_model: "Work" } },
-          { term: { published: true } },
-          { term: { visibility: "Public" } },
-        ],
+        must: [{ term: { api_model: "Work" } }, ...oaiVisibilityFilter],
       },
     },
     sort: [{ create_date: "asc" }],
@@ -42,12 +47,7 @@ export async function oaiSearch(
   };
   const query: Record<string, unknown> = {
     bool: {
-      must: [
-        { term: { api_model: "Work" } },
-        { term: { published: true } },
-        { term: { visibility: "Public" } },
-        range,
-      ],
+      must: [{ term: { api_model: "Work" } }, ...oaiVisibilityFilter, range],
     },
   };
   if (set)
@@ -79,11 +79,7 @@ export async function oaiSets(): Promise<{ status: number; body: string }> {
     _source: ["id", "title"],
     query: {
       bool: {
-        must: [
-          { term: { api_model: "Collection" } },
-          { term: { published: true } },
-          { term: { visibility: "Public" } },
-        ],
+        must: [{ term: { api_model: "Collection" } }, ...oaiVisibilityFilter],
       },
     },
     sort: [{ title: "asc" }],

--- a/api/src/handlers/oai/verbs.ts
+++ b/api/src/handlers/oai/verbs.ts
@@ -1,5 +1,10 @@
 import { invalidOaiRequest, output } from "../oai/xml-transformer.ts";
-import { earliestRecord, oaiSearch, oaiSets } from "../oai/search.ts";
+import {
+  OAI_VISIBILITY,
+  earliestRecord,
+  oaiSearch,
+  oaiSets,
+} from "../oai/search.ts";
 import { deleteScroll, getWork, scroll } from "../../api/opensearch.ts";
 import { formatOaiDate } from "./date-utils.ts";
 import {
@@ -185,9 +190,11 @@ export const getRecord = async (
     return unsupportedMetadataPrefix(metadataPrefix);
 
   const esResponse = await getWork(id);
-  if (esResponse.status === 200) {
-    const work = (JSON.parse(esResponse.body) as OpenSearchGetResponse<Work>)
-      ._source!;
+  const work =
+    esResponse.status === 200
+      ? (JSON.parse(esResponse.body) as OpenSearchGetResponse<Work>)._source
+      : undefined;
+  if (work && work.published && OAI_VISIBILITY.includes(work.visibility)) {
     const record = transform(work, metadataPrefix);
     const document = {
       "OAI-PMH": {

--- a/api/test/integration/oai.test.ts
+++ b/api/test/integration/oai.test.ts
@@ -831,6 +831,168 @@ describe("Oai routes", () => {
     });
   });
 
+  describe("visibility", () => {
+    // OAI-PMH only exposes metadata, so it should include works visible to
+    // authenticated (netID / "Institution") users as well as "Public" ones,
+    // matching what the unauthenticated DC API returns.
+    const expectedFilter = [
+      { term: { published: true } },
+      { terms: { visibility: ["Institution", "Public"] } },
+    ];
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function captureSearch(index: string, fixture: string): { body?: any } {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const captured: { body?: any } = {};
+      server.use(
+        http.post(
+          `https://${TEST_OPENSEARCH_HOST}/${index}/_search`,
+          async ({ request }) => {
+            captured.body = await request.json();
+            return HttpResponse.json(JSON.parse(testFixture(fixture)));
+          },
+        ),
+      );
+      return captured;
+    }
+
+    it("includes Institution and Public works in ListRecords", async () => {
+      const captured = captureSearch("dc-v2-work", "mocks/scroll.json");
+      const req = buildRequest("GET", "/oai", {
+        queryParams: { verb: "ListRecords", metadataPrefix: "oai_dc" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+      expect(captured.body.query.bool.must).toEqual(
+        expect.arrayContaining(expectedFilter),
+      );
+      expect(captured.body.query.bool.must).not.toContainEqual({
+        term: { visibility: "Public" },
+      });
+    });
+
+    it("includes Institution and Public works in ListIdentifiers", async () => {
+      const captured = captureSearch("dc-v2-work", "mocks/scroll.json");
+      const req = buildRequest("GET", "/oai", {
+        queryParams: { verb: "ListIdentifiers", metadataPrefix: "oai_dc" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+      expect(captured.body.query.bool.must).toEqual(
+        expect.arrayContaining(expectedFilter),
+      );
+    });
+
+    it("includes Institution and Public works when filtering by set", async () => {
+      const captured = captureSearch(
+        "dc-v2-work",
+        "mocks/oai-list-identifiers-sets.json",
+      );
+      const req = buildRequest("GET", "/oai", {
+        queryParams: {
+          verb: "ListIdentifiers",
+          metadataPrefix: "oai_dc",
+          set: "c4f30015-88b5-4291-b3a6-8ac9b7c7069c",
+        },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+      expect(captured.body.query.bool.must).toEqual(
+        expect.arrayContaining([
+          ...expectedFilter,
+          { term: { "collection.id": "c4f30015-88b5-4291-b3a6-8ac9b7c7069c" } },
+        ]),
+      );
+    });
+
+    it("includes Institution and Public collections in ListSets", async () => {
+      const captured = captureSearch("dc-v2-collection", "mocks/oai-sets.json");
+      const req = buildRequest("GET", "/oai", {
+        queryParams: { verb: "ListSets" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+      expect(captured.body.query.bool.must).toEqual(
+        expect.arrayContaining(expectedFilter),
+      );
+    });
+
+    it("considers Institution and Public works for the Identify earliestDatestamp", async () => {
+      const captured = captureSearch(
+        "dc-v2-work",
+        "mocks/search-earliest-record.json",
+      );
+      const req = buildRequest("GET", "/oai", {
+        queryParams: { verb: "Identify" },
+      });
+      const result = await sendRequest(req);
+      expect(result.status).toEqual(200);
+      expect(captured.body.query.bool.must).toEqual(
+        expect.arrayContaining(expectedFilter),
+      );
+    });
+
+    function getRecordWith(overrides: Record<string, unknown>) {
+      const fixture = JSON.parse(testFixture("mocks/work-1234.json"));
+      fixture._source = { ...fixture._source, ...overrides };
+      server.use(
+        http.get(`https://${TEST_OPENSEARCH_HOST}/dc-v2-work/_doc/1234`, () =>
+          HttpResponse.json(fixture),
+        ),
+      );
+      return sendRequest(
+        buildRequest("GET", "/oai", {
+          queryParams: {
+            verb: "GetRecord",
+            identifier: "1234",
+            metadataPrefix: "oai_dc",
+          },
+        }),
+      );
+    }
+
+    it("returns Institution works from GetRecord", async () => {
+      const result = await getRecordWith({ visibility: "Institution" });
+      expect(result.status).toEqual(200);
+      const resultBody = parseXml(await result.text());
+      expect(resultBody["OAI-PMH"].GetRecord.record).toBeDefined();
+    });
+
+    it("returns idDoesNotExist for Private works in GetRecord", async () => {
+      const result = await getRecordWith({ visibility: "Private" });
+      expect(result.status).toEqual(404);
+      const resultBody = parseXml(await result.text());
+      expect(resultBody["OAI-PMH"].error._attributes.code).toEqual(
+        "idDoesNotExist",
+      );
+    });
+
+    it("returns idDoesNotExist for unpublished works in GetRecord", async () => {
+      const result = await getRecordWith({ published: false });
+      expect(result.status).toEqual(404);
+      const resultBody = parseXml(await result.text());
+      expect(resultBody["OAI-PMH"].error._attributes.code).toEqual(
+        "idDoesNotExist",
+      );
+    });
+
+    it("never exposes Private or unpublished works", async () => {
+      const captured = captureSearch("dc-v2-work", "mocks/scroll.json");
+      const req = buildRequest("GET", "/oai", {
+        queryParams: { verb: "ListRecords", metadataPrefix: "oai_dc" },
+      });
+      await sendRequest(req);
+      const { must } = captured.body.query.bool;
+      const visibility = must.find(
+        (clause: Record<string, unknown>) =>
+          "terms" in clause &&
+          "visibility" in (clause.terms as Record<string, unknown>),
+      );
+      expect(visibility.terms.visibility).not.toContain("Private");
+      expect(must).toContainEqual({ term: { published: true } });
+    });
+  });
+
   describe("GET /oai", () => {
     it("requires a verb", async () => {
       const req = buildRequest("GET", "/oai", {

--- a/api/test/integration/oai.test.ts
+++ b/api/test/integration/oai.test.ts
@@ -349,6 +349,19 @@ describe("Oai routes", () => {
       );
       expect(recordInfo["mods:recordIdentifier"]._text).toEqual("1234");
       expect(recordInfo["mods:recordContentSource"]._text).toEqual("IEN");
+      expect(recordInfo["mods:recordChangeDate"]._attributes.encoding).toEqual(
+        "iso8601",
+      );
+      expect(recordInfo["mods:recordChangeDate"]._text).toMatch(/^\d{14}\.0$/);
+      expect(Object.keys(recordInfo)).toEqual([
+        "mods:recordOrigin",
+        "mods:recordContentSource",
+        "mods:recordCreationDate",
+        "mods:recordChangeDate",
+        "mods:recordIdentifier",
+        "mods:languageOfCataloging",
+        "mods:recordInfoNote",
+      ]);
 
       // relatedItems: collection host, series, related URLs, source system
       const relatedItems = mods["mods:relatedItem"];

--- a/api/test/integration/oai.test.ts
+++ b/api/test/integration/oai.test.ts
@@ -876,10 +876,10 @@ describe("Oai routes", () => {
       });
       const result = await sendRequest(req);
       expect(result.status).toEqual(200);
-      expect(captured.body.query.bool.must).toEqual(
+      expect(captured.body.query.bool.filter).toEqual(
         expect.arrayContaining(expectedFilter),
       );
-      expect(captured.body.query.bool.must).not.toContainEqual({
+      expect(captured.body.query.bool.filter).not.toContainEqual({
         term: { visibility: "Public" },
       });
     });
@@ -891,7 +891,7 @@ describe("Oai routes", () => {
       });
       const result = await sendRequest(req);
       expect(result.status).toEqual(200);
-      expect(captured.body.query.bool.must).toEqual(
+      expect(captured.body.query.bool.filter).toEqual(
         expect.arrayContaining(expectedFilter),
       );
     });
@@ -910,7 +910,7 @@ describe("Oai routes", () => {
       });
       const result = await sendRequest(req);
       expect(result.status).toEqual(200);
-      expect(captured.body.query.bool.must).toEqual(
+      expect(captured.body.query.bool.filter).toEqual(
         expect.arrayContaining([
           ...expectedFilter,
           { term: { "collection.id": "c4f30015-88b5-4291-b3a6-8ac9b7c7069c" } },
@@ -925,7 +925,7 @@ describe("Oai routes", () => {
       });
       const result = await sendRequest(req);
       expect(result.status).toEqual(200);
-      expect(captured.body.query.bool.must).toEqual(
+      expect(captured.body.query.bool.filter).toEqual(
         expect.arrayContaining(expectedFilter),
       );
     });
@@ -940,7 +940,7 @@ describe("Oai routes", () => {
       });
       const result = await sendRequest(req);
       expect(result.status).toEqual(200);
-      expect(captured.body.query.bool.must).toEqual(
+      expect(captured.body.query.bool.filter).toEqual(
         expect.arrayContaining(expectedFilter),
       );
     });
@@ -995,14 +995,14 @@ describe("Oai routes", () => {
         queryParams: { verb: "ListRecords", metadataPrefix: "oai_dc" },
       });
       await sendRequest(req);
-      const { must } = captured.body.query.bool;
-      const visibility = must.find(
+      const { filter } = captured.body.query.bool;
+      const visibility = filter.find(
         (clause: Record<string, unknown>) =>
           "terms" in clause &&
           "visibility" in (clause.terms as Record<string, unknown>),
       );
       expect(visibility.terms.visibility).not.toContain("Private");
-      expect(must).toContainEqual({ term: { published: true } });
+      expect(filter).toContainEqual({ term: { published: true } });
     });
   });
 


### PR DESCRIPTION
## Summary

Expands the OAI-PMH endpoint to include works with Institution visibility alongside Public ones. Also adds the `mods:recordChangeDate` element (encoding="iso8601", formatted YYYYMMDDHHmmss.0 in UTC, matching the XSL output) to `recordInfo` in MODS responses, immediately after `recordCreationDate`.

Restricted work in Meadow:
<img width="996" height="319" alt="SCR-20260821-owgj" src="https://github.com/user-attachments/assets/008e7204-46fc-45f0-81f7-0a8ff3fdefeb" />

Shows up in OAI-PMH response:
<img width="1772" height="450" alt="SCR-20260821-ovvi" src="https://github.com/user-attachments/assets/2b986bfe-a528-4206-bd39-eec8a861b828" />

`mods:recordCreationDate` example with proper **iso8601** encoding:
<img width="1138" height="215" alt="SCR-20260821-ouyv" src="https://github.com/user-attachments/assets/8d5f4ab4-5718-454c-8cf9-d794aeaaea98" />


## Version bump required by the PR

See [Semantic Versioning 2.0.0](https://semver.org/) for help discerning which is required.

- [x] Patch
- [ ] Minor
- [ ] Major

## Steps to Test

Add works with varying visibility to your Meadow dev env

1. `make deps` and `make serve`, then against your dev endpoint (`https://USER_PREFIX.dev.rdc.library.northwestern.edu:3002`):
2. `GET /oai?verb=ListRecords&metadataPrefix=mods` — now allows both `Institution` and `Public` visibilities. Check for `mods:recordChangeDate` values, too.
3. `GET /oai?verb=GetRecord&identifier=<work id>&metadataPrefix=mods` — now allows both `Institution` and `Public` visibilities.
5. `cd api && bun test test/integration/oai.test.ts`

Also please let developers know if there are any special instructions to test this in the development environment. 
